### PR TITLE
feat: 임시 저장 + 전체조회 + 단일 조회

### DIFF
--- a/src/main/java/com/fmi/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/fmi/domain/post/converter/PostConverter.java
@@ -3,8 +3,10 @@ package com.fmi.domain.post.converter;
 import com.fmi.domain.User;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostImage;
+import com.fmi.domain.post.response.PostListResponse;
 import com.fmi.domain.post.response.PostResponse;
 import com.fmi.domain.post.web.dto.CreatePostDto;
+import com.fmi.domain.post.web.dto.TemporaryPostDto;
 import com.fmi.domain.post.web.dto.UpdatePostDto;
 import org.springframework.stereotype.Component;
 
@@ -25,13 +27,31 @@ public class PostConverter {
                 .itemStatus(request.getItemStatus())
                 .postType(request.getPostType())
                 .content(request.getContent())
-                .pContent(request.getContent())
                 .viewCnt(0)
                 .date(request.getDate())
                 .radius(request.getRadius())
+                .temporarySave(request.isTemporarySave())
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
-                .temporarySave(request.isTemporarySave())
+                .build();
+    }
+
+    public Post toTemporaryPostEntity(TemporaryPostDto request, User user) {
+        return Post.builder()
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .temporarySave(true)
+                .address(request.getAddress())
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .itemStatus(request.getItemStatus())
+                .postType(request.getPostType())
+                .radius(request.getRadius())
+                .viewCnt(0)
+                .date(request.getDate())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
                 .build();
     }
 
@@ -59,10 +79,22 @@ public class PostConverter {
         if (dto.getRadius() != 0) post.setRadius(dto.getRadius());
         if (dto.getContent() != null) post.setContent(dto.getContent());
 
-        post.setTemporarySave(dto.isTemporarySave());
         post.setUpdatedAt(LocalDateTime.now());
     }
 
+    public void temporaryPostFromDto(Post post, TemporaryPostDto dto) {
+        if (dto.getPostType() != null) post.setPostType(dto.getPostType());
+        if (dto.getTitle() != null) post.setTitle(dto.getTitle());
+        if (dto.getItemStatus() != null) post.setItemStatus(dto.getItemStatus());
+        if (dto.getDate() != null) post.setDate(dto.getDate());
+        if (dto.getAddress() != null) post.setAddress(dto.getAddress());
+        if (dto.getLatitude() != 0) post.setLatitude(dto.getLatitude());
+        if (dto.getLongitude() != 0) post.setLongitude(dto.getLongitude());
+        if (dto.getRadius() != 0) post.setRadius(dto.getRadius());
+        if (dto.getContent() != null) post.setContent(dto.getContent());
+
+        post.setUpdatedAt(LocalDateTime.now());
+    }
 
     public PostResponse toPostResponse(Post post) {
         List<String> imageUrls = post.getImages() != null ?
@@ -84,4 +116,26 @@ public class PostConverter {
                 .postType(post.getPostType())
                 .build();
     }
+
+    public PostListResponse toPostListResponse(Post post) {
+
+        String thumbnailUrl = post.getImages().isEmpty() ? null : post.getImages().get(0).getImgUrl();
+
+        String summary = post.getContent() != null
+                ? (post.getContent().length() > 20 ? post.getContent().substring(0, 20) + "..." : post.getContent())
+                : null;
+
+        return PostListResponse.builder()
+                .postId(post.getId())
+                .title(post.getTitle())
+                .summary(summary)
+                .thumbnailUrl(thumbnailUrl)
+                .address(post.getAddress())
+                .itemStatus(post.getItemStatus())
+                .postType(post.getPostType())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/fmi/domain/post/data/Post.java
+++ b/src/main/java/com/fmi/domain/post/data/Post.java
@@ -1,5 +1,6 @@
 package com.fmi.domain.post.data;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fmi.domain.Enum.Status;
 import com.fmi.domain.Enum.Type;
 import com.fmi.domain.User;
@@ -51,11 +52,8 @@ public class Post {
     @Column(name = "content", nullable = false)
     private String content;
 
-    @Column(name = "p_content", nullable = false)
-    private String pContent;
-
-    @Column(name = "temporarySave",nullable = false)
-    private Boolean temporarySave;
+    @Column(name = "temporary_save",nullable = false)
+    private boolean temporarySave;
 
     @Column(name = "date")
     private LocalDate date;
@@ -70,6 +68,7 @@ public class Post {
     private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OrderBy("displayOrder ASC")
     private List<PostImage> images = new ArrayList<>();
 
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -1,11 +1,28 @@
 package com.fmi.domain.post.repository;
 
+import com.fmi.domain.Enum.Type;
+import com.fmi.domain.User;
 import com.fmi.domain.post.data.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post,Long> {
 
+
+    @Query("SELECT p FROM Post p LEFT JOIN FETCH p.images WHERE p.user = :user AND p.temporarySave = true")
+    Optional<Post> findByUserAndTemporarySaveTrue(@Param("user") User user);
+
+//    Page<Post> findByTemporarySaveFalse(Pageable pageable);
+
+    Page<Post> findByTemporarySaveFalseAndPostType(Type postType, Pageable pageable);
+
+    Optional<Post> deleteByUserAndTemporarySaveTrue(User user);
 
 }

--- a/src/main/java/com/fmi/domain/post/response/PostListResponse.java
+++ b/src/main/java/com/fmi/domain/post/response/PostListResponse.java
@@ -1,0 +1,30 @@
+package com.fmi.domain.post.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fmi.domain.Enum.Status;
+import com.fmi.domain.Enum.Type;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostListResponse {
+    private Long postId;
+    private String title;
+    private String summary; // content 앞부분 , 미리보기
+    private String thumbnailUrl; // 대표 이미지 1장
+    private String address;
+    private Status itemStatus;
+    private Type postType;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/fmi/domain/post/service/PostService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostService.java
@@ -1,18 +1,25 @@
 package com.fmi.domain.post.service;
 
+import com.fmi.domain.Enum.Type;
 import com.fmi.domain.User;
 import com.fmi.domain.post.converter.PostConverter;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostImage;
 import com.fmi.domain.post.repository.PostImageRepository;
 import com.fmi.domain.post.repository.PostRepository;
+import com.fmi.domain.post.response.PostListResponse;
 import com.fmi.domain.post.response.PostResponse;
 import com.fmi.domain.post.web.dto.CreatePostDto;
+import com.fmi.domain.post.web.dto.TemporaryPostDto;
 import com.fmi.domain.post.web.dto.UpdatePostDto;
 import com.fmi.global.service.S3Service;
 import com.fmi.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -80,6 +88,12 @@ public class PostService {
                     .toList();
 
             if (!imagesToDelete.isEmpty()) {
+
+                List<String> urlsToDelete = imagesToDelete.stream()
+                        .map(PostImage::getImgUrl)
+                        .toList();
+
+                s3Service.delete(urlsToDelete);
                 postImageRepository.deleteAll(imagesToDelete);
             }
         }
@@ -87,9 +101,8 @@ public class PostService {
         if (images != null && !images.isEmpty()) {
             List<String> s3Urls = s3Service.upload(images);
             List<PostImage> newImages = postConverter.toPostImageEntities(post, s3Urls);
-            if (!newImages.isEmpty()) {
-                postImageRepository.saveAll(newImages);
-            }
+            postImageRepository.saveAll(newImages);
+            post.getImages().addAll(newImages);//추가
         }
 
         return postConverter.toPostResponse(post);
@@ -109,7 +122,117 @@ public class PostService {
             throw new RuntimeException("작성자만 삭제할 수 있습니다.");
         }
 
+        List<String> s3Urls = post.getImages().stream()
+                .map(PostImage::getImgUrl)
+                .toList();
+
+        s3Service.delete(s3Urls);
         postRepository.delete(post);
+
+        return post;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostListResponse> getAllPosts(Type type, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<Post> postPage = postRepository.findByTemporarySaveFalseAndPostType(type, pageable);
+
+        return postPage.stream()
+                .map(postConverter::toPostListResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public PostResponse getPost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+
+        return postConverter.toPostResponse(post);
+    }
+
+    @Transactional
+    public void saveTemporaryPost(TemporaryPostDto request, UserDetails userDetails, List<MultipartFile> images) {
+
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+        Optional<Post> existingTempPost = postRepository.findByUserAndTemporarySaveTrue(user);
+
+        if (existingTempPost.isEmpty()) {
+            Post newTempPost = postConverter.toTemporaryPostEntity(request, user);
+
+            if (images != null && !images.isEmpty()) {
+                List<String> s3Urls = s3Service.upload(images);
+                List<PostImage> postImages = postConverter.toPostImageEntities(newTempPost, s3Urls);
+                postImageRepository.saveAll(postImages);
+            }
+
+            postRepository.save(newTempPost);
+
+        }
+        else {
+            Post tempPost = existingTempPost.get();
+            postConverter.temporaryPostFromDto(tempPost, request);
+            tempPost.setTemporarySave(true);
+
+            if (request.getDeleteImageIds() != null && !request.getDeleteImageIds().isEmpty()) {
+                List<PostImage> oldImages = postImageRepository.findByPost(tempPost);
+
+                List<PostImage> imagesToDelete = oldImages.stream()
+                        .filter(img -> request.getDeleteImageIds().contains(img.getId()))
+                        .toList();
+
+                if (!imagesToDelete.isEmpty()) {
+                    List<String> urlsToDelete = imagesToDelete.stream()
+                            .map(PostImage::getImgUrl)
+                            .toList();
+                    s3Service.delete(urlsToDelete);
+
+                    postImageRepository.deleteAll(imagesToDelete);
+                }
+            }
+
+            if (images != null && !images.isEmpty()) {
+                List<String> s3Urls = s3Service.upload(images);
+                List<PostImage> newImages = postConverter.toPostImageEntities(tempPost, s3Urls);
+                postImageRepository.saveAll(newImages);
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public PostResponse getTemporaryPost(UserDetails userDetails){
+
+        String email = userDetails.getUsername();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("사용자 찾을 수 없습니다."));
+
+        Post post = postRepository.findByUserAndTemporarySaveTrue(user)
+                .orElseThrow(()-> new RuntimeException("사용자의 임시 게시글을 찾을 수 없습니다."));
+
+        return postConverter.toPostResponse(post);
+    }
+
+    @Transactional
+    public Post deleteTemporaryPost(UserDetails userDetails){
+
+        String email = userDetails.getUsername();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("사용자 찾을 수 없습니다."));
+
+        Post post = postRepository.findByUserAndTemporarySaveTrue(user)
+                .orElseThrow(()-> new RuntimeException("임시 게시글이 없습니다."));
+
+        List<String> s3Urls = post.getImages().stream()
+                .map(PostImage::getImgUrl)
+                .toList();
+
+        if (!s3Urls.isEmpty()) {
+            s3Service.delete(s3Urls);
+        }
+
+        postRepository.deleteByUserAndTemporarySaveTrue(user);
 
         return post;
     }

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -1,10 +1,11 @@
 package com.fmi.domain.post.web.controller;
 
-import com.fmi.domain.post.converter.PostConverter;
-import com.fmi.domain.post.data.Post;
+import com.fmi.domain.Enum.Type;
+import com.fmi.domain.post.response.PostListResponse;
 import com.fmi.domain.post.response.PostResponse;
 import com.fmi.domain.post.service.PostService;
 import com.fmi.domain.post.web.dto.CreatePostDto;
+import com.fmi.domain.post.web.dto.TemporaryPostDto;
 import com.fmi.domain.post.web.dto.UpdatePostDto;
 import com.fmi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,12 +39,25 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-//    @GetMapping("/")
-//    @Operation(summary = "게시글 조회")
-//    public ResponseEntity<ApiResponse<List<PostResponse>>> getpost(){
-//        List<PostResponse> posts = postService.getAllPosts();
-//        return ResponseEntity.ok(ApiResponse.onSuccess(posts));
-//    }
+    @GetMapping("/")
+    @Operation(summary = "전체 게시글 조회")
+    public ResponseEntity<ApiResponse<List<PostListResponse>>> getAllPosts(
+            @RequestParam Type type,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        List<PostListResponse> posts = postService.getAllPosts(type, page, size);
+        return ResponseEntity.ok(ApiResponse.onSuccess(posts));
+    }
+
+    @GetMapping("/{postId}")
+    @Operation(summary = "게시글 상세 조회")
+    public ResponseEntity<ApiResponse<PostResponse>> getPost(
+            @PathVariable Long postId
+    ){
+        PostResponse post = postService.getPost(postId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(post));
+    }
 
     @PutMapping("/{postId}")
     @Operation(summary = "게시글 수정")
@@ -69,12 +83,35 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.onSuccess("게시글 삭제 완료"));
     }
 
+    @PostMapping("/draft")
+    @Operation(summary = "게시글 임시 저장")
+    public ResponseEntity<ApiResponse<Void>> saveTemporaryPost(
 
-    @PostMapping("/test-username")
-    @Operation(summary = "userDetail.username 체크")
-    public ResponseEntity<String> checkUsername(@AuthenticationPrincipal UserDetails userDetails) {
-        log.info("현재 로그인한 유저 username: {}", userDetails.getUsername());
-        return ResponseEntity.ok("로그 확인");
+            @RequestPart("request") TemporaryPostDto request,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
+    ) {
+        postService.saveTemporaryPost(request, userDetails, images);
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    @GetMapping("/draft")
+    @Operation(summary = "임시 저장 조회")
+    public ResponseEntity<ApiResponse<PostResponse>> getTemporaryPost(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        PostResponse post = postService.getTemporaryPost(userDetails);
+        return ResponseEntity.ok(ApiResponse.onSuccess(post));
+    }
+
+    @DeleteMapping("/draft")
+    @Operation(summary = "임시 저장 삭제")
+    public ResponseEntity<ApiResponse<String>> deleteTemporaryPost(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        postService.deleteTemporaryPost(userDetails);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess("임시 게시글 삭제 완료"));
     }
 
 }

--- a/src/main/java/com/fmi/domain/post/web/dto/CreatePostDto.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/CreatePostDto.java
@@ -21,7 +21,8 @@ public class CreatePostDto {
     private double latitude;
     private double longitude;
     private String content;
-    private List<String> imageUrls; // S3의 URL
-    private boolean temporarySave;
     private double radius;
+
+    private boolean temporarySave;
+
 }

--- a/src/main/java/com/fmi/domain/post/web/dto/TemporaryPostDto.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/TemporaryPostDto.java
@@ -12,8 +12,7 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-public class UpdatePostDto {
-
+public class TemporaryPostDto {
     private Type postType;
     private String title;
     private Status itemStatus;
@@ -22,8 +21,8 @@ public class UpdatePostDto {
     private double latitude;
     private double longitude;
     private String content;
-    private boolean temporarySave;
     private double radius;
+    private boolean temporary_save;
 
     private List<Long> deleteImageIds;
 }


### PR DESCRIPTION
 게시글 타입별 전체 조회(image 1장 + content 20자 제한) + 페이징

 임시 게시물 저장/수정/삭제/조회
- 임시 저장 생성 (기존 임시 저장 없을 시)
- 임시 저장 update (임시 저장 존재 시)


추후 즐찾, 조회수 구현 시 전체 조회 수정 예정