### PR TITLE
refactor: 내 채팅 목록 조회, 채팅방 생성/조회 응답 수정

### DIFF
--- a/src/main/java/com/fmi/domain/auth/data/User.java
+++ b/src/main/java/com/fmi/domain/auth/data/User.java
@@ -53,7 +53,7 @@ public class User {
     @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "profile_img", nullable = false)
+    @Column(name = "profile_img")
     private String profile_img;
 
     @CreatedDate

--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -52,9 +52,23 @@ public class ChatRoomConverter {
                 .profileImageUrl(contactUser.getProfile_img())
                 .build();
 
+        Post post = chatRoom.getPost();
+
+        String thumbnailUrl = post.getImages().isEmpty() ? null : post.getImages().get(0).getImgUrl();
+
+        PostInfoDTO postInfoDTO = PostInfoDTO.builder()
+                .postId(post.getId())
+                .postType(post.getPostType())
+                .title(post.getTitle())
+                .address(post.getAddress())
+                .thumbnailUrl(thumbnailUrl)
+                .build();
+
+
         return ChatRoomSummaryDTO.builder()
                 .roomId(chatRoom.getId())
                 .contactUser(contactUserDTO)
+                .postInfo(postInfoDTO)
                 .lastMessage(chatRoom.getLastMessage())
                 .lastMessageSentAt(chatRoom.getUpdatedAt())
                 .build();

--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -12,10 +12,12 @@ import static com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.*;
 public class ChatRoomConverter {
     public static ChatRoomResultDTO toChatRoomResultDTO(ChatRoom chatRoom, User user, Post post) {
 
+        String thumbnailUrl = post.getImages().isEmpty() ? null : post.getImages().get(0).getImgUrl();
+
         var opponentUser = opponentUserDTO.builder()
                 .opponentUserId(user.getId())
                 .nickname(user.getNickname())
-                .profileImageUrl(user.getProfile_img())
+                .profileImageUrl(user.getProfile_img() == null ? null : user.getProfile_img())
                 .emailVerified(user.isEmail_verified())
                 .build();
 
@@ -23,6 +25,8 @@ public class ChatRoomConverter {
                 .postId(post.getId())
                 .postType(post.getPostType())
                 .title(post.getTitle())
+                .address(post.getAddress())
+                .thumbnailUrl(thumbnailUrl)
                 .build();
 
         return ChatRoomResultDTO.builder()

--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomRepository.java
@@ -21,10 +21,13 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
                                                   @Param("userId1") Long userId1,
                                                   @Param("userId2") Long userId2);
 
-    @Query("SELECT cr FROM ChatRoom cr JOIN cr.participants p WHERE p.user.id = :userId " +
-            "AND (cr.updatedAt < :cursorUpdatedAt OR (cr.updatedAt = :cursorUpdatedAt AND cr.id < :cursorId)) " +
-            "AND cr.lastMessage IS NOT NULL " +
-            "ORDER BY cr.updatedAt DESC, cr.id DESC")
+    @Query("SELECT cr FROM ChatRoom cr " +
+            " JOIN FETCH cr.post p "+
+            " JOIN cr.participants pt " +
+            " WHERE pt.user.id = :userId " +
+            " AND (cr.updatedAt < :cursorUpdatedAt OR (cr.updatedAt = :cursorUpdatedAt AND cr.id < :cursorId)) " +
+            " AND cr.lastMessage IS NOT NULL " +
+            " ORDER BY cr.updatedAt DESC, cr.id DESC")
     Slice<ChatRoom> findMyChatRoomsWithCursor(
             @Param("userId") Long userId,
             @Param("cursorUpdatedAt") LocalDateTime cursorUpdatedAt,
@@ -32,9 +35,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             Pageable pageable
     );
 
-    @Query("SELECT cr FROM ChatRoom cr JOIN cr.participants p WHERE p.user.id = :userId " +
-            "AND cr.lastMessage IS NOT NULL " +
-            "ORDER BY cr.updatedAt DESC, cr.id DESC")
+    @Query("SELECT cr FROM ChatRoom cr " +
+            " JOIN FETCH cr.post p " +
+            " JOIN cr.participants pt" +
+            " WHERE pt.user.id = :userId " +
+            " AND cr.lastMessage IS NOT NULL " +
+            " ORDER BY cr.updatedAt DESC, cr.id DESC")
     Slice<ChatRoom> findMyChatRoomsFirstPage(
             @Param("userId") Long userId,
             Pageable pageable);

--- a/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
@@ -40,6 +40,8 @@ public class ChatRoomResponseDTO {
         private Long postId;
         private Type postType;
         private String title;
+        private String address;
+        private String thumbnailUrl;
     }
 
     @Builder

--- a/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
@@ -60,6 +60,7 @@ public class ChatRoomResponseDTO {
     public static class ChatRoomSummaryDTO {
         private Long roomId;
         private ContactUserDTO contactUser;
+        private PostInfoDTO postInfo;
         private String lastMessage;
         private LocalDateTime lastMessageSentAt;
     }


### PR DESCRIPTION
피그마를 참고하여 내 채팅 목록 조회, 채팅방 생성/조회 응답을 수정했습니다.

- User 엔티티에서 profileImage null 허용으로 수정
- 채팅방 생성/조회 응답시 주소, thumbnail 값 추가
- 내 채팅 목록 조회시 post관련하여 응답 추가 