### PR TITLE
feat: 이전 채팅 내역 조회/채팅방 나가기

### DIFF
--- a/src/main/java/com/fmi/domain/chatmessage/converter/ChatMessageConverter.java
+++ b/src/main/java/com/fmi/domain/chatmessage/converter/ChatMessageConverter.java
@@ -2,7 +2,10 @@ package com.fmi.domain.chatmessage.converter;
 
 import com.fmi.domain.chatmessage.data.ChatMessage;
 import com.fmi.domain.chatmessage.data.MessageImage;
+import com.fmi.domain.chatmessage.data.enums.MessageType;
+import com.fmi.domain.chatmessage.web.dto.ChatMessageResponseDTO;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.fmi.domain.chatmessage.web.dto.ChatMessageResponseDTO.MessageImageResponseDTO;
@@ -35,4 +38,16 @@ public class ChatMessageConverter {
                 .build();
     }
 
+    public static ChatMessageResponseDTO.MessageDTO fromEntity(ChatMessage message, List<String> imageUrls) {
+
+        return ChatMessageResponseDTO.MessageDTO.builder()
+                .messageId(message.getId())
+                .messageType(message.getMessageType().name())
+                .senderId(message.getUser().getId())
+                .content(message.getContent() == null || message.getContent().isEmpty() ? null : message.getContent())
+                .imageUrls(message.getMessageType() == MessageType.IMAGE ? imageUrls : null)
+                .createdAt(message.getCreatedAt())
+                .build();
+
+    }
 }

--- a/src/main/java/com/fmi/domain/chatmessage/converter/ChatMessageConverter.java
+++ b/src/main/java/com/fmi/domain/chatmessage/converter/ChatMessageConverter.java
@@ -38,7 +38,7 @@ public class ChatMessageConverter {
                 .build();
     }
 
-    public static ChatMessageResponseDTO.MessageDTO fromEntity(ChatMessage message, List<String> imageUrls) {
+    public static ChatMessageResponseDTO.MessageDTO GetMessageResponseDTO(ChatMessage message, List<String> imageUrls) {
 
         return ChatMessageResponseDTO.MessageDTO.builder()
                 .messageId(message.getId())

--- a/src/main/java/com/fmi/domain/chatmessage/repositiory/ChatMessageRepository.java
+++ b/src/main/java/com/fmi/domain/chatmessage/repositiory/ChatMessageRepository.java
@@ -1,9 +1,36 @@
 package com.fmi.domain.chatmessage.repositiory;
 
 import com.fmi.domain.chatmessage.data.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    /**
+     * 첫 페이지 조회 (커서가 없을 때)
+     */
+    @Query("SELECT m FROM ChatMessage m " +
+            "WHERE m.chatRoom.id = :roomId " +
+            "ORDER BY m.id DESC")
+    Slice<ChatMessage> findByChatRoomIdOrderByIdDesc(
+            @Param("roomId") Long roomId,
+            Pageable pageable
+    );
+
+    /**
+     * 커서가 있을 때
+     */
+    @Query("SELECT m FROM ChatMessage m " +
+            "WHERE m.chatRoom.id = :roomId AND m.id < :cursorId " +
+            "ORDER BY m.id DESC")
+    Slice<ChatMessage> findByRoomIdWithCursor(
+            @Param("roomId") Long roomId,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/fmi/domain/chatmessage/repositiory/ChatMessageRepository.java
+++ b/src/main/java/com/fmi/domain/chatmessage/repositiory/ChatMessageRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
@@ -15,10 +17,11 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
      * 첫 페이지 조회 (커서가 없을 때)
      */
     @Query("SELECT m FROM ChatMessage m " +
-            "WHERE m.chatRoom.id = :roomId " +
-            "ORDER BY m.id DESC")
+            " WHERE m.chatRoom.id = :roomId " +
+            " and ( :cutoff is null or m.id> :cutoff )" +
+            " ORDER BY m.id DESC")
     Slice<ChatMessage> findByChatRoomIdOrderByIdDesc(
-            @Param("roomId") Long roomId,
+            @Param("roomId") Long roomId, @Param("cutoff") Long cutoff,
             Pageable pageable
     );
 
@@ -26,11 +29,15 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
      * 커서가 있을 때
      */
     @Query("SELECT m FROM ChatMessage m " +
-            "WHERE m.chatRoom.id = :roomId AND m.id < :cursorId " +
-            "ORDER BY m.id DESC")
+            " WHERE m.chatRoom.id = :roomId AND m.id < :cursorId " +
+            " and ( :cutoff is null or m.id> :cutoff )" +
+            " ORDER BY m.id DESC")
     Slice<ChatMessage> findByRoomIdWithCursor(
             @Param("roomId") Long roomId,
-            @Param("cursorId") Long cursorId,
+            @Param("cursorId") Long cursorId, @Param("cutoff") Long cutoff,
             Pageable pageable
     );
+
+    Optional<ChatMessage> findTopByChatRoom_IdOrderByIdDesc(Long roomId);
+
 }

--- a/src/main/java/com/fmi/domain/chatmessage/repositiory/MessageImageRepository.java
+++ b/src/main/java/com/fmi/domain/chatmessage/repositiory/MessageImageRepository.java
@@ -1,0 +1,10 @@
+package com.fmi.domain.chatmessage.repositiory;
+
+import com.fmi.domain.chatmessage.data.MessageImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MessageImageRepository extends JpaRepository<MessageImage, Long> {
+    List<MessageImage> findAllByChatMessage_IdIn(List<Long> messageIds);
+}

--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
@@ -1,32 +1,39 @@
 package com.fmi.domain.chatmessage.service;
 
 import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.domain.chatmessage.converter.ChatMessageConverter;
 import com.fmi.domain.chatmessage.data.ChatMessage;
 import com.fmi.domain.chatmessage.data.MessageImage;
 import com.fmi.domain.chatmessage.data.enums.MessageType;
 import com.fmi.domain.chatmessage.repositiory.ChatMessageRepository;
+import com.fmi.domain.chatmessage.repositiory.MessageImageRepository;
 import com.fmi.domain.chatroom.data.ChatRoom;
+import com.fmi.domain.chatroom.repository.ChatRoomParticipantRepository;
 import com.fmi.domain.chatroom.repository.ChatRoomRepository;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import com.fmi.global.service.S3Service;
-import com.fmi.domain.auth.repository.UserRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.fmi.domain.chatmessage.converter.ChatMessageConverter.messageImageResponseDTO;
 import static com.fmi.domain.chatmessage.converter.ChatMessageConverter.messageResponseDTO;
 import static com.fmi.domain.chatmessage.web.dto.ChatMessageRequestDTO.SendImageRequestDTO;
 import static com.fmi.domain.chatmessage.web.dto.ChatMessageRequestDTO.SendMessageRequestDTO;
-import static com.fmi.domain.chatmessage.web.dto.ChatMessageResponseDTO.MessageImageResponseDTO;
-import static com.fmi.domain.chatmessage.web.dto.ChatMessageResponseDTO.MessageResponseDTO;
+import static com.fmi.domain.chatmessage.web.dto.ChatMessageResponseDTO.*;
 
 @Service
 @Transactional
@@ -37,6 +44,8 @@ public class ChatMessageService {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
+    private final ChatRoomParticipantRepository chatRoomParticipantRepository;
+    private final MessageImageRepository messageImageRepository;
     private final S3Service s3Service;
 
     public MessageResponseDTO sendMessage(Long roomId, Long senderId, SendMessageRequestDTO req) {
@@ -110,5 +119,66 @@ public class ChatMessageService {
         broker.convertAndSendToUser(recipient.getEmail(), "/queue/messages", responseDTO);
         broker.convertAndSendToUser(sender.getEmail(), "/queue/messages", responseDTO);
         return responseDTO;
+    }
+
+    @Transactional(readOnly = true)
+    public MessageSliceResponseDTO messageSlice(Long roomId, Long senderId, Long cursorId) {
+
+        if (!chatRoomParticipantRepository.existsByUser_IdAndChatRoom_Id(senderId, roomId)) {
+            throw new GeneralException(ErrorStatus._MESSAGE_NOT_ALLOWED);
+        }
+
+        final int pageSize = 20;
+        PageRequest pageable = PageRequest.of(0, pageSize);
+
+        // 메인 메시지 조회 (이미지 조인 X)
+        Slice<ChatMessage> messagesSlice;
+        if (cursorId== null) {
+            messagesSlice = chatMessageRepository.findByChatRoomIdOrderByIdDesc(roomId, pageable);
+        } else {
+            messagesSlice = chatMessageRepository.findByRoomIdWithCursor(roomId, cursorId, pageable);
+        }
+
+        List<ChatMessage> finalMessages = messagesSlice.getContent();
+
+        // 메시지 ID 목록 추출
+        List<Long> imageMessageIds = finalMessages.stream()
+                .filter(m -> m.getMessageType() == MessageType.IMAGE)
+                .map(ChatMessage::getId)
+                .toList();
+
+        // 이미지 메시지가 있을 경우에만, 이미지 목록을 IN 쿼리로 한방에 조회
+        Map<Long, List<String>> imagesMap = Collections.emptyMap();
+        if (!imageMessageIds.isEmpty()) {
+            List<MessageImage> images = messageImageRepository.findAllByChatMessage_IdIn(imageMessageIds);
+
+            // (메시지 ID)별로 (이미지 URL 리스트)를 그룹핑
+            imagesMap = images.stream()
+                    .collect(Collectors.groupingBy(
+                            image -> image.getChatMessage().getId(), // 부모 메시지 ID로 그룹핑
+                            Collectors.mapping(MessageImage::getImageUrl, Collectors.toList()) // URL을 List로
+                    ));
+        }
+
+        // DTO로 변환
+        Map<Long, List<String>> finalImagesMap = imagesMap;
+        List<MessageDTO> messageDtos = finalMessages.stream()
+                .map(message -> {
+                    // 맵에서 해당 메시지의 이미지 리스트를 찾음 (없으면 빈 리스트)
+                    List<String> imageUrls = finalImagesMap.getOrDefault(message.getId(), Collections.emptyList());
+                    return ChatMessageConverter.fromEntity(message, imageUrls);
+                })
+                .toList();
+
+        Long nextCursorId = null;
+        // 다음 페이지가 있고, 현재 조회된 메시지가 실제로 있을 때
+        if (messagesSlice.hasNext() && !finalMessages.isEmpty()) {
+            nextCursorId = finalMessages.get(finalMessages.size() - 1).getId();
+        }
+
+        return MessageSliceResponseDTO.builder()
+                .messages(messageDtos)
+                .nextCursor(nextCursorId)
+                .build();
     }
 }

--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
@@ -9,6 +9,7 @@ import com.fmi.domain.chatmessage.data.enums.MessageType;
 import com.fmi.domain.chatmessage.repositiory.ChatMessageRepository;
 import com.fmi.domain.chatmessage.repositiory.MessageImageRepository;
 import com.fmi.domain.chatroom.data.ChatRoom;
+import com.fmi.domain.chatroom.data.ChatRoomParticipant;
 import com.fmi.domain.chatroom.repository.ChatRoomParticipantRepository;
 import com.fmi.domain.chatroom.repository.ChatRoomRepository;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
@@ -20,7 +21,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
@@ -67,7 +67,7 @@ public class ChatMessageService {
                 .createdAt(LocalDateTime.now())
                 .build());
 
-        room.updateLastMessage((req.getContent()));
+        updateParticipantsOnNewMessage(room.getId(), chatMessage);
 
         MessageResponseDTO responseDTO = messageResponseDTO(chatMessage);
         broker.convertAndSendToUser(recipient.getEmail(), "/queue/messages", responseDTO);
@@ -107,18 +107,22 @@ public class ChatMessageService {
 
         ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
 
-        if (!StringUtils.hasText(savedMessage.getContent())) {
-            room.updateLastMessage("사진을 보냈습니다.");
-        }
-        else {
-            room.updateLastMessage(requestDTO.getContent());
-        }
+        updateParticipantsOnNewMessage(room.getId(), savedMessage);
 
         // DTO로 변환하여 WebSocket 브로드캐스팅
         MessageImageResponseDTO responseDTO = messageImageResponseDTO(savedMessage);
         broker.convertAndSendToUser(recipient.getEmail(), "/queue/messages", responseDTO);
         broker.convertAndSendToUser(sender.getEmail(), "/queue/messages", responseDTO);
         return responseDTO;
+    }
+
+    private void updateParticipantsOnNewMessage(Long roomId, ChatMessage newMessage) {
+        List<ChatRoomParticipant> allParticipants = chatRoomParticipantRepository.findAllByChatRoom_Id(roomId);
+
+        for (ChatRoomParticipant pt : allParticipants) {
+            // 메시지 갱신 및 ACTIVE 설정
+            pt.updateLastMessage(newMessage);
+        }
     }
 
     @Transactional(readOnly = true)
@@ -128,15 +132,20 @@ public class ChatMessageService {
             throw new GeneralException(ErrorStatus._MESSAGE_NOT_ALLOWED);
         }
 
+        ChatRoomParticipant me = chatRoomParticipantRepository.findByChatRoom_IdAndUser_Id(roomId, senderId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
+
+        Long cutoff = me.getVisibleFromMessageId();
+
         final int pageSize = 20;
         PageRequest pageable = PageRequest.of(0, pageSize);
 
         // 메인 메시지 조회 (이미지 조인 X)
         Slice<ChatMessage> messagesSlice;
         if (cursorId== null) {
-            messagesSlice = chatMessageRepository.findByChatRoomIdOrderByIdDesc(roomId, pageable);
+            messagesSlice = chatMessageRepository.findByChatRoomIdOrderByIdDesc(roomId, cutoff, pageable);
         } else {
-            messagesSlice = chatMessageRepository.findByRoomIdWithCursor(roomId, cursorId, pageable);
+            messagesSlice = chatMessageRepository.findByRoomIdWithCursor(roomId, cursorId, cutoff, pageable);
         }
 
         List<ChatMessage> finalMessages = messagesSlice.getContent();

--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
@@ -166,7 +166,7 @@ public class ChatMessageService {
                 .map(message -> {
                     // 맵에서 해당 메시지의 이미지 리스트를 찾음 (없으면 빈 리스트)
                     List<String> imageUrls = finalImagesMap.getOrDefault(message.getId(), Collections.emptyList());
-                    return ChatMessageConverter.fromEntity(message, imageUrls);
+                    return ChatMessageConverter.GetMessageResponseDTO(message, imageUrls);
                 })
                 .toList();
 

--- a/src/main/java/com/fmi/domain/chatmessage/web/controller/ChatMessageController.java
+++ b/src/main/java/com/fmi/domain/chatmessage/web/controller/ChatMessageController.java
@@ -2,9 +2,14 @@ package com.fmi.domain.chatmessage.web.controller;
 
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.chatmessage.service.ChatMessageService;
+import com.fmi.domain.chatmessage.web.dto.ChatMessageResponseDTO;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.global.apiPayload.code.status.SuccessStatus;
 import com.fmi.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -43,5 +48,21 @@ public class ChatMessageController {
 
         chatMessageService.sendImageMessage(roomId, requestDTO, user.getId());
         return ApiResponse.of(SuccessStatus._OK);
+    }
+
+    @Operation(summary = "이전 채팅 내역 조회", description = "현재 채팅방의 이전 대화 내역을 커서 기반 페이지네이션으로 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "MESSAGE_LIST_FETCHED: 이전 채팅 내역 조회 성공")
+    })
+    @Parameters({
+            @Parameter(name = "roomId", description = "조회할 채팅방의 ID", required = true),
+            @Parameter(name = "cursor", description = "이전 페이지 응답의 nextCursor 값. 첫 페이지 조회 시 생략.", required = false)
+    })
+    @GetMapping("{roomId}/messages")
+    public ApiResponse<ChatMessageResponseDTO.MessageSliceResponseDTO> listMessages(@PathVariable Long roomId, @AuthenticationPrincipal UserDetails userDetails, @RequestParam(required = false) Long cursor) {
+        String email = userDetails.getUsername();
+        User user = userService.findUser(email);
+        ChatMessageResponseDTO.MessageSliceResponseDTO messageSliceResponseDTO = chatMessageService.messageSlice(roomId, user.getId(), cursor);
+        return ApiResponse.of(SuccessStatus._MESSAGE_LIST_FETCHED,messageSliceResponseDTO);
     }
 }

--- a/src/main/java/com/fmi/domain/chatmessage/web/dto/ChatMessageResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatmessage/web/dto/ChatMessageResponseDTO.java
@@ -44,7 +44,7 @@ public class ChatMessageResponseDTO {
     @Getter
     public static class MessageSliceResponseDTO {
         private List<MessageDTO> messages;
-        private boolean hasNext;
+        private Long nextCursor;
     }
 
     @Builder

--- a/src/main/java/com/fmi/domain/chatmessage/web/dto/ChatMessageResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatmessage/web/dto/ChatMessageResponseDTO.java
@@ -38,4 +38,26 @@ public class ChatMessageResponseDTO {
         private LocalDateTime createdAt;
     }
 
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MessageSliceResponseDTO {
+        private List<MessageDTO> messages;
+        private boolean hasNext;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class MessageDTO {
+        private Long messageId;
+        private String messageType;
+        private Long senderId;
+        private String content;
+        private List<String> imageUrls;
+        private LocalDateTime createdAt;
+    }
+
 }

--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -1,7 +1,10 @@
 package com.fmi.domain.chatroom.converter;
 
 import com.fmi.domain.auth.data.User;
+import com.fmi.domain.chatmessage.data.ChatMessage;
+import com.fmi.domain.chatmessage.data.enums.MessageType;
 import com.fmi.domain.chatroom.data.ChatRoom;
+import com.fmi.domain.chatroom.data.ChatRoomParticipant;
 import com.fmi.domain.post.data.Post;
 
 import java.util.List;
@@ -36,15 +39,18 @@ public class ChatRoomConverter {
                 .build();
     }
 
-    public static List<ChatRoomSummaryDTO> toChatRoomSummaryListDTO(List<ChatRoom> chatRooms, Long currentUserId) {
-        return chatRooms.stream()
-                .map(chatRoom -> toChatRoomSummaryDTO(chatRoom, currentUserId))
+    public static List<ChatRoomSummaryDTO> toChatRoomSummaryListDTO(List<ChatRoomParticipant> participants, User currentUser) {
+        return participants.stream()
+                .map(pt -> {
+                    User contactUser = pt.getChatRoom().getOtherParticipant(currentUser.getId());
+
+                    return toChatRoomSummaryDTO(pt, contactUser);
+                })
                 .collect(Collectors.toList());
     }
 
-    public static ChatRoomSummaryDTO toChatRoomSummaryDTO(ChatRoom chatRoom, Long currentUserId) {
 
-        User contactUser = chatRoom.getOtherParticipant(currentUserId);
+    public static ChatRoomSummaryDTO toChatRoomSummaryDTO(ChatRoomParticipant participant, User contactUser) {
 
         ContactUserDTO contactUserDTO = ContactUserDTO.builder()
                 .userId(contactUser.getId())
@@ -52,8 +58,7 @@ public class ChatRoomConverter {
                 .profileImageUrl(contactUser.getProfile_img())
                 .build();
 
-        Post post = chatRoom.getPost();
-
+        Post post = participant.getChatRoom().getPost();
         String thumbnailUrl = post.getImages().isEmpty() ? null : post.getImages().get(0).getImgUrl();
 
         PostInfoDTO postInfoDTO = PostInfoDTO.builder()
@@ -64,14 +69,26 @@ public class ChatRoomConverter {
                 .thumbnailUrl(thumbnailUrl)
                 .build();
 
+        ChatMessage lastMessage = participant.getLastMessage();
+        String preview = null;
+        if (lastMessage != null) {
+            if (lastMessage.getContent() != null && !lastMessage.getContent().isBlank()) {
+                preview = lastMessage.getContent();
+            } else if (isImageMessage(lastMessage)) {
+                preview = "사진을 보냈습니다.";
+            }
+        }
 
         return ChatRoomSummaryDTO.builder()
-                .roomId(chatRoom.getId())
+                .roomId(participant.getChatRoom().getId())
                 .contactUser(contactUserDTO)
                 .postInfo(postInfoDTO)
-                .lastMessage(chatRoom.getLastMessage())
-                .lastMessageSentAt(chatRoom.getUpdatedAt())
+                .lastMessage(preview)
+                .lastMessageSentAt(participant.getLastMessageSentAt())
                 .build();
     }
 
+    private static boolean isImageMessage(ChatMessage message) {
+        return message.getMessageType() == MessageType.IMAGE;
+    }
 }

--- a/src/main/java/com/fmi/domain/chatroom/data/ChatRoom.java
+++ b/src/main/java/com/fmi/domain/chatroom/data/ChatRoom.java
@@ -31,15 +31,15 @@ public class ChatRoom {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @Column(length = 100)
-    private String lastMessage;
+    //@Column(length = 100)
+    //private String lastMessage;
 
     // 채팅방 생성 시간
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     // 마지막 메시지가 온 시간
-    private LocalDateTime updatedAt;
+    //private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -57,11 +57,6 @@ public class ChatRoom {
                 .filter(user -> !user.getId().equals(userId)) // 나 자신이 아닌 사용자를 필터링
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("채팅방에 다른 참여자가 없습니다."));
-    }
-
-    public void updateLastMessage(String content) {
-        this.lastMessage = content;
-        this.updatedAt = LocalDateTime.now();
     }
 
     /**

--- a/src/main/java/com/fmi/domain/chatroom/data/ChatRoomParticipant.java
+++ b/src/main/java/com/fmi/domain/chatroom/data/ChatRoomParticipant.java
@@ -1,11 +1,15 @@
 package com.fmi.domain.chatroom.data;
 
 import com.fmi.domain.auth.data.User;
+import com.fmi.domain.chatmessage.data.ChatMessage;
+import com.fmi.domain.chatroom.data.enums.ParticipantState;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -25,7 +29,43 @@ public class ChatRoomParticipant {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private ParticipantState participantState = ParticipantState.ACTIVE;
+
+    @Column(name = "visible_from_message_id")
+    private Long visibleFromMessageId;
+
+    // 목록 정렬/미리보기용
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "last_message_id")
+    private ChatMessage lastMessage;
+
+    // 목록 정렬용
+    private LocalDateTime lastMessageSentAt;
+
     void setChatRoom(ChatRoom chatRoom) {
         this.chatRoom = chatRoom;
     }
+
+    /**
+     * 채팅방을 나갈 때 호출
+     */
+    public void leftChatRoom(Long lastMessageIdOrNull) {
+        this.participantState = ParticipantState.LEFT;
+        this.visibleFromMessageId = lastMessageIdOrNull;
+        // 목록에서 보이지 않게 lastMessage도 초기화
+        this.lastMessage = null;
+        this.lastMessageSentAt = null;
+    }
+
+    /**
+     * 새 메시지가 전송될 때 호출
+     */
+    public void updateLastMessage(ChatMessage message) {
+        this.participantState = ParticipantState.ACTIVE;
+        this.lastMessage = message;
+        this.lastMessageSentAt = message.getCreatedAt();
+    }
+
 }

--- a/src/main/java/com/fmi/domain/chatroom/data/enums/ParticipantState.java
+++ b/src/main/java/com/fmi/domain/chatroom/data/enums/ParticipantState.java
@@ -1,0 +1,6 @@
+package com.fmi.domain.chatroom.data.enums;
+
+public enum ParticipantState {
+    ACTIVE,
+    LEFT
+}

--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepository.java
@@ -4,4 +4,5 @@ import com.fmi.domain.chatroom.data.ChatRoomParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomParticipant,Long> {
+    boolean existsByUser_IdAndChatRoom_Id(Long userId, Long roomId);
 }

--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepository.java
@@ -1,8 +1,59 @@
 package com.fmi.domain.chatroom.repository;
 
 import com.fmi.domain.chatroom.data.ChatRoomParticipant;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomParticipant,Long> {
     boolean existsByUser_IdAndChatRoom_Id(Long userId, Long roomId);
+    Optional<ChatRoomParticipant> findByUser_IdAndChatRoom_Id(Long userId, Long roomId);
+
+    Optional<ChatRoomParticipant> findByChatRoom_IdAndUser_Id(Long roomId, Long userId);
+
+    List<ChatRoomParticipant> findAllByChatRoom_Id(Long roomId);
+
+    // 내 채팅방 목록 조회 (첫 페이지)
+    @Query("SELECT pt FROM ChatRoomParticipant pt " +
+            " JOIN FETCH pt.chatRoom cr " +
+            " JOIN FETCH cr.post p " +
+            " JOIN FETCH pt.lastMessage lm " + // lastMessage 정보
+            " JOIN cr.participants otherPt " + // 상대방 participant 정보
+            " JOIN otherPt.user otherUser " + // 상대방 user 정보
+            " WHERE pt.user.id = :userId " +
+            "   AND otherPt.user.id != :userId " +
+            "   AND pt.participantState = com.fmi.domain.chatroom.data.enums.ParticipantState.ACTIVE " + //
+            // ACTIVE 상태
+            "   AND pt.lastMessage IS NOT NULL " + // lastMessage가 있음
+            " ORDER BY pt.lastMessageSentAt DESC, pt.id DESC")
+    Slice<ChatRoomParticipant> findMyChatRoomsFirstPage(
+            @Param("userId") Long userId,
+            Pageable pageable);
+
+    // 내 채팅방 목록 조회 (커서 기반)
+    @Query("SELECT pt FROM ChatRoomParticipant pt " +
+            " JOIN FETCH pt.chatRoom cr " +
+            " JOIN FETCH cr.post p " +
+            " JOIN FETCH pt.lastMessage lm " +
+            " JOIN cr.participants otherPt " +
+            " JOIN otherPt.user otherUser " +
+            " WHERE pt.user.id = :userId " +
+            "   AND otherPt.user.id != :userId " +
+            "   AND pt.participantState = com.fmi.domain.chatroom.data.enums.ParticipantState.ACTIVE " +
+            "   AND pt.lastMessage IS NOT NULL " +
+            // 커서 로직 (lastMessageSentAt, pt.id 기준)
+            "   AND (pt.lastMessageSentAt < :cursorTime OR (pt.lastMessageSentAt = :cursorTime AND pt.id < :cursorId)) " +
+            " ORDER BY pt.lastMessageSentAt DESC, pt.id DESC")
+    Slice<ChatRoomParticipant> findMyChatRoomsWithCursor(
+            @Param("userId") Long userId,
+            @Param("cursorTime") LocalDateTime cursorTime,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomRepository.java
@@ -1,18 +1,16 @@
 package com.fmi.domain.chatroom.repository;
 
 import com.fmi.domain.chatroom.data.ChatRoom;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
     //Optional<ChatRoom> findByPostIdAndUserId(Long postId, Long contactUserId);
 
     @Query("SELECT cr FROM ChatRoom cr JOIN cr.participants p1 JOIN cr.participants p2 " +
@@ -21,27 +19,4 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
                                                   @Param("userId1") Long userId1,
                                                   @Param("userId2") Long userId2);
 
-    @Query("SELECT cr FROM ChatRoom cr " +
-            " JOIN FETCH cr.post p "+
-            " JOIN cr.participants pt " +
-            " WHERE pt.user.id = :userId " +
-            " AND (cr.updatedAt < :cursorUpdatedAt OR (cr.updatedAt = :cursorUpdatedAt AND cr.id < :cursorId)) " +
-            " AND cr.lastMessage IS NOT NULL " +
-            " ORDER BY cr.updatedAt DESC, cr.id DESC")
-    Slice<ChatRoom> findMyChatRoomsWithCursor(
-            @Param("userId") Long userId,
-            @Param("cursorUpdatedAt") LocalDateTime cursorUpdatedAt,
-            @Param("cursorId") Long cursorId,
-            Pageable pageable
-    );
-
-    @Query("SELECT cr FROM ChatRoom cr " +
-            " JOIN FETCH cr.post p " +
-            " JOIN cr.participants pt" +
-            " WHERE pt.user.id = :userId " +
-            " AND cr.lastMessage IS NOT NULL " +
-            " ORDER BY cr.updatedAt DESC, cr.id DESC")
-    Slice<ChatRoom> findMyChatRoomsFirstPage(
-            @Param("userId") Long userId,
-            Pageable pageable);
 }

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
@@ -1,15 +1,19 @@
 package com.fmi.domain.chatroom.service;
 
 import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.domain.chatmessage.data.ChatMessage;
+import com.fmi.domain.chatmessage.repositiory.ChatMessageRepository;
 import com.fmi.domain.chatroom.converter.ChatRoomConverter;
 import com.fmi.domain.chatroom.data.ChatRoom;
 import com.fmi.domain.chatroom.data.ChatRoomParticipant;
+import com.fmi.domain.chatroom.data.enums.ParticipantState;
+import com.fmi.domain.chatroom.repository.ChatRoomParticipantRepository;
 import com.fmi.domain.chatroom.repository.ChatRoomRepository;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
-import com.fmi.domain.auth.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -31,6 +35,8 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final ChatRoomParticipantRepository chatRoomParticipantRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     public Pair<ChatRoomResultDTO, Boolean> createChatRoom(Long postId, Long contactUserId) {
 
@@ -84,37 +90,54 @@ public class ChatRoomService {
         }
     }
 
-    public MyChatListDTO getMyPostChatRooms(Long userId, Long cursorId, int size) {
+    public MyChatListDTO getMyPostChatRooms(User user, Long cursorId, int size) {
 
-        Slice<ChatRoom> chatRoomSlice;
+        Slice<ChatRoomParticipant> participantSlice;
+        PageRequest pageable = PageRequest.of(0, size);
 
-        // 커서 ID가 없으면 첫 페이지이므로, 간단한 쿼리 호출
         if (cursorId == null) {
-            chatRoomSlice = chatRoomRepository.findMyChatRoomsFirstPage(
-                    userId, PageRequest.of(0, size));
+            participantSlice = chatRoomParticipantRepository.findMyChatRoomsFirstPage(
+                    user.getId(), pageable);
         } else {
-            // 커서 ID가 있으면, 해당 ID의 updatedAt을 기준으로 다음 페이지를 조회
-            ChatRoom cursorRoom = chatRoomRepository.findById(cursorId)
+            // 커서의 기준이 'ChatRoomParticipant'의 ID가 됨
+            ChatRoomParticipant cursorParticipant = chatRoomParticipantRepository.findById(cursorId)
                     .orElseThrow(() -> new GeneralException(ErrorStatus._INVALID_CURSOR));
 
-            chatRoomSlice = chatRoomRepository.findMyChatRoomsWithCursor(
-                    userId, cursorRoom.getUpdatedAt(), cursorId, PageRequest.of(0, size));
+            participantSlice = chatRoomParticipantRepository.findMyChatRoomsWithCursor(
+                    user.getId(),
+                    cursorParticipant.getLastMessageSentAt(), // 커서 기준 (시간)
+                    cursorParticipant.getId(),                // 커서 기준 (ID)
+                    pageable);
         }
 
-        return buildChatListResponse(chatRoomSlice, userId);
+        return buildChatListResponse(participantSlice, user);
     }
 
-    // DTO 변환 및 다음 커서 계산 메서드
-    private MyChatListDTO buildChatListResponse(Slice<ChatRoom> chatRoomSlice, Long userId) {
-        List<ChatRoom> chatRooms = chatRoomSlice.getContent();
+    private MyChatListDTO buildChatListResponse(Slice<ChatRoomParticipant> participantSlice, User user) {
+        List<ChatRoomParticipant> participants = participantSlice.getContent();
 
-        List<ChatRoomSummaryDTO> summaryDTOs = ChatRoomConverter.toChatRoomSummaryListDTO(chatRooms, userId);
+        List<ChatRoomSummaryDTO> summaryDTOs = ChatRoomConverter.toChatRoomSummaryListDTO(participants, user);
 
         Long nextCursor = null;
-        if (!chatRooms.isEmpty() && chatRoomSlice.hasNext()) {
-            nextCursor = chatRooms.get(chatRooms.size() - 1).getId();
+        if (!participants.isEmpty() && participantSlice.hasNext()) {
+            // 커서는 마지막 'ChatRoomParticipant'의 ID가 됨
+            nextCursor = participants.get(participants.size() - 1).getId();
         }
 
         return new MyChatListDTO(summaryDTOs, nextCursor);
+    }
+
+    public void leftChatRoom(Long roomId, Long userId) {
+        ChatRoomParticipant chatRoomParticipant = chatRoomParticipantRepository.findByUser_IdAndChatRoom_Id(userId, roomId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
+
+        if (chatRoomParticipant.getParticipantState() == ParticipantState.LEFT) {
+            return;
+        }
+
+        Long lastMsgId = chatMessageRepository.findTopByChatRoom_IdOrderByIdDesc(roomId)
+                .map(ChatMessage::getId).orElse(null);
+
+        chatRoomParticipant.leftChatRoom(lastMsgId);
     }
 }

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -72,6 +72,10 @@ public class ChatRoomController {
         return ApiResponse.of(SuccessStatus._CHATROOM_LIST_FETCHED, responseDTO);
     }
 
+    @Operation(summary = "채팅방 나가기", description = "채팅방을 나가면 그 시점부터 나간 사용자에게 대화 내역이 보이지 않고, 내 채팅 목록에도 사라집니다. 다시 채팅이 시작되면 그 나간 이후 시점부터 내역이 보입니다. (나가지 않은 사용자에겐 적용x)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM_LIST_FETCHED: 채팅 목록 조회 성공")
+    })
     @PatchMapping("/chats/{roomId}/leave")
     public ApiResponse<Void> leftChatRoom(@PathVariable("roomId") Long roomId, @AuthenticationPrincipal UserDetails userDetails) {
         String email = userDetails.getUsername();

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -68,8 +68,16 @@ public class ChatRoomController {
     ) {
         User user = userService.findUser(userDetails.getUsername());
 
-        ChatRoomResponseDTO.MyChatListDTO responseDTO = chatRoomService.getMyPostChatRooms(user.getId(), cursor, size);
+        ChatRoomResponseDTO.MyChatListDTO responseDTO = chatRoomService.getMyPostChatRooms(user, cursor, size);
         return ApiResponse.of(SuccessStatus._CHATROOM_LIST_FETCHED, responseDTO);
+    }
+
+    @PatchMapping("/chats/{roomId}/leave")
+    public ApiResponse<Void> leftChatRoom(@PathVariable("roomId") Long roomId, @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername();
+        User user = userService.findUser(email);
+        chatRoomService.leftChatRoom(roomId, user.getId());
+        return ApiResponse.of(SuccessStatus._CHATROOM_LEFT);
     }
 
 }

--- a/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
@@ -47,7 +47,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM404-NOT_FOUND", "존재하지 않는 채팅방입니다."),
 
     //채팅 관련 응답
-    _IMAGE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "IMAGE400-NOT_PROVIDED", "전송할 이미지가 없습니다.");;
+    _IMAGE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "IMAGE400-NOT_PROVIDED", "전송할 이미지가 없습니다."),
+    _MESSAGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MESSAGE-NOT_ALLOWED", "채팅 내역을 조회할 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/fmi/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/SuccessStatus.java
@@ -18,6 +18,7 @@ public enum SuccessStatus implements BaseCode {
     _CHATROOM_CREATED(HttpStatus.CREATED, "CHATROOM201-CREATED", "채팅방이 생성되었습니다."),
     _CHATROOM_FOUND(HttpStatus.OK, "CHATROOM200-FOUND", "기존 채팅방을 조회합니다."),
     _CHATROOM_LIST_FETCHED(HttpStatus.OK, "CHATROOM200-LIST", "나의 채팅 목록 조회에 성공했습니다."),
+    _CHATROOM_LEFT(HttpStatus.OK, "CHATROOM200-LEFT", "채팅방 나가기를 성공했습니다."),
 
     // 이미지 관련 응답
     _IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "IMAGE200-UPLOAD", "이미지 업로드에 성공하였습니다."),

--- a/src/main/java/com/fmi/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/SuccessStatus.java
@@ -20,7 +20,10 @@ public enum SuccessStatus implements BaseCode {
     _CHATROOM_LIST_FETCHED(HttpStatus.OK, "CHATROOM200-LIST", "나의 채팅 목록 조회에 성공했습니다."),
 
     // 이미지 관련 응답
-    _IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "IMAGE200-UPLOAD", "이미지 업로드에 성공하였습니다.");
+    _IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "IMAGE200-UPLOAD", "이미지 업로드에 성공하였습니다."),
+
+    // 메세지 관련 응답
+    _MESSAGE_LIST_FETCHED(HttpStatus.OK, "MESSAGE200-LIST", "이전 채팅 내역 조회를 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
- 이전 채팅 내역 조회하기 기능 추가
- 채팅방 나가기 기능 추가 
- ChatParticipant 엔티티에 lastMessage, lastSentAt, visibleFromMessageId 추가
- 내 채팅 목록 조회시 ChatRoom 엔티티의 lastMessage 삭제 -> ChatParticipant 엔티티의 lastMessage로 변경 
- 이전 채팅 내역 조회에서 채팅방을 나간 후 그 뒤에 메세지 내역은 나간 시점 이후부터 채팅 내역에 포함되도록 수정 
- 채팅을 보낼때 채팅 참여 상태가 LEFT였을시 ACTIVE로 갱신 