### PR TITLE
[FEAT] 맨션 + 대댓글 기능 구현 및 알림 설정

### DIFF
--- a/src/main/java/com/fmi/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/fmi/domain/auth/repository/UserRepository.java
@@ -45,6 +45,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 만료된 임시 비밀번호가 있는 사용자 조회 (정리 스케줄러용)
     @Query("SELECT u FROM User u WHERE u.temporaryPasswordExpiresAt IS NOT NULL AND u.temporaryPasswordExpiresAt < :now")
     List<User> findUsersWithExpiredTemporaryPassword(@Param("now") LocalDateTime now);
+
+    Optional<User> findByNickname(String nickname);
 }
 
 

--- a/src/main/java/com/fmi/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/com/fmi/domain/comment/converter/CommentConverter.java
@@ -33,12 +33,4 @@ public class CommentConverter {
         );
     }
 
-    public NotificationDto toCommentNotification(Comment comment) {
-        return NotificationDto.builder()
-                .message("새 댓글이 달렸습니다!")
-                .postId(comment.getPost().getId())
-                .commenterName(comment.getUser().getNickname())
-                .createdAt(LocalDateTime.now())
-                .build();
-    }
 }

--- a/src/main/java/com/fmi/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/com/fmi/domain/comment/converter/CommentConverter.java
@@ -13,10 +13,11 @@ import java.time.LocalDateTime;
 @Component
 public class CommentConverter {
 
-    public Comment toCommentEntity(CreateCommentDto dto, User user, Post post) {
+    public Comment toCommentEntity(CreateCommentDto dto, User user, Post post, Comment parent) {
         return Comment.builder()
                 .user(user)
                 .post(post)
+                .parent(parent)
                 .content(dto.getContent())
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())

--- a/src/main/java/com/fmi/domain/comment/data/Comment.java
+++ b/src/main/java/com/fmi/domain/comment/data/Comment.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -27,14 +29,21 @@ public class Comment {
     @Column(name = "content", nullable = false)
     private String content;
 
-    @Column(name = "p_content")
-    private String p_content;//대댓글 ?
+//    @Column(name = "p_content")
+//    private String p_content;//대댓글 ?
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Comment> replies = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")

--- a/src/main/java/com/fmi/domain/comment/data/Comment.java
+++ b/src/main/java/com/fmi/domain/comment/data/Comment.java
@@ -29,9 +29,6 @@ public class Comment {
     @Column(name = "content", nullable = false)
     private String content;
 
-//    @Column(name = "p_content")
-//    private String p_content;//대댓글 ?
-
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 

--- a/src/main/java/com/fmi/domain/comment/data/Comment.java
+++ b/src/main/java/com/fmi/domain/comment/data/Comment.java
@@ -45,4 +45,5 @@ public class Comment {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
 }

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -18,7 +18,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 
@@ -61,8 +64,45 @@ public class CommentService {
             notifyPostOwner(post, user, dto);
         }
 
+        handleMentions(savedComment, dto);
+
         return commentConverter.toCommentResponse(savedComment);
     }
+
+    private void handleMentions(Comment comment, CreateCommentDto dto) {
+        List<String> mentionedNicknames = extractMentions(dto.getContent());
+
+        for (String nickname : mentionedNicknames) {
+            userRepository.findByNickname(nickname).ifPresent(mentionedUser -> {
+                if (!mentionedUser.getId().equals(comment.getUser().getId())) {
+                    notificationService.createNotification(
+                            mentionedUser,
+                            NotificationType.MENTION,
+                            comment.getUser().getNickname() + "님이 멘션했습니다",
+                            dto.getContent(),
+                            "COMMENT",
+                            comment.getId()
+                    );
+                }
+            });
+        }
+    }
+
+    private List<String> extractMentions(String content) {
+        List<String> mentions = new ArrayList<>();
+        if (content == null || content.isBlank()) return mentions;
+
+        // @뒤에 오는 닉네임 추출 (영문, 숫자, 한글, _, . 허용)
+        Pattern pattern = Pattern.compile("@([A-Za-z0-9가-힣_.]+)");
+        Matcher matcher = pattern.matcher(content);
+
+        while (matcher.find()) {
+            mentions.add(matcher.group(1));
+        }
+
+        return mentions;
+    }
+
 
     private void notifyPostOwner(Post post, User commenter, CreateCommentDto dto) {
         if (!post.getUser().getId().equals(commenter.getId())) {
@@ -131,3 +171,4 @@ public class CommentService {
                 .collect(Collectors.toList());
     }
 }
+

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -57,23 +57,26 @@ public class CommentService {
 
         boolean isReply = parentComment != null;
 
-        if (isReply) {
-            notifyReply(parentComment, user, dto, post);
-        } else {
-            notifyPostOwner(post, user, dto);
-        }
+        Set<Long> mentionedUserIds = handleMentions(savedComment, dto);
 
-        handleMentions(savedComment, dto);
+        if (isReply) {
+            notifyReply(parentComment, user, dto, post, mentionedUserIds);
+        } else {
+            notifyPostOwner(post, user, dto, mentionedUserIds);
+        }
 
         return commentConverter.toCommentResponse(savedComment);
     }
 
-    private void handleMentions(Comment comment, CreateCommentDto dto) {
+    private Set<Long> handleMentions(Comment comment, CreateCommentDto dto) {
         List<String> mentionedNicknames = extractMentions(dto.getContent());
+        Set<Long> mentionedUserIds = new HashSet<>();
 
         for (String nickname : mentionedNicknames) {
             userRepository.findByNickname(nickname).ifPresent(mentionedUser -> {
+//                log.info("멘션 대상 찾음: {}", mentionedUser.getNickname());
                 if (!mentionedUser.getId().equals(comment.getUser().getId())) {//자신 거르기
+
                     notificationService.createNotification(
                             mentionedUser,
                             NotificationType.MENTION,
@@ -82,9 +85,17 @@ public class CommentService {
                             "COMMENT",
                             comment.getId()
                     );
+
+                    mentionedUserIds.add(mentionedUser.getId());
+
+                    log.info("MENTION 알림 전송: to={}, type={}, commentId={}",
+                            mentionedUser.getNickname(),
+                            NotificationType.MENTION,
+                            comment.getId());
                 }
             });
         }
+        return mentionedUserIds;
     }
 
     private List<String> extractMentions(String content) {
@@ -106,30 +117,42 @@ public class CommentService {
     }
 
 
-    private void notifyPostOwner(Post post, User commenter, CreateCommentDto dto) {
-        if (!post.getUser().getId().equals(commenter.getId())) {
-            notificationService.createNotification(
-                    post.getUser(),
-                    NotificationType.COMMENT,
-                    "새 댓글이 달렸습니다",
-                    dto.getContent(),
-                    "POST",
-                    post.getId()
-            );
+    private void notifyPostOwner(Post post, User commenter, CreateCommentDto dto, Set<Long> mentionedUserIds) {
+
+        Long postOwnerId = post.getUser().getId();
+
+        if (postOwnerId.equals(commenter.getId()) || mentionedUserIds.contains(postOwnerId)) {
+            log.info("이미 맨션알림을 보냈거나 자기가 자기게시글에 단 댓글 알림 생략");
+            return;
         }
+
+        notificationService.createNotification(
+                post.getUser(),
+                NotificationType.COMMENT,
+                "새 댓글이 달렸습니다",
+                dto.getContent(),
+                "POST",
+                post.getId()
+        );
     }
 
-    private void notifyReply(Comment parentComment, User replier, CreateCommentDto dto, Post post) {
-        if (!parentComment.getUser().getId().equals(replier.getId())) {
-            notificationService.createNotification(
-                    parentComment.getUser(),
-                    NotificationType.REPLY,
-                    "댓글에 답글이 달렸습니다",
-                    dto.getContent(),
-                    "POST",
-                    post.getId()
-            );
+    private void notifyReply(Comment parentComment, User replier, CreateCommentDto dto, Post post, Set<Long> mentionedUserIds) {
+
+        Long parentOwnerId = parentComment.getUser().getId();
+
+        if (parentOwnerId.equals(replier.getId()) || mentionedUserIds.contains(parentOwnerId)) {
+            log.info("대댓 유저와 부모댓글 유저가 같거나, 이미 맨션 보냈을 때 생략");
+            return;
         }
+
+        notificationService.createNotification(
+                parentComment.getUser(),
+                NotificationType.REPLY,
+                "댓글에 답글이 달렸습니다",
+                dto.getContent(),
+                "POST",
+                post.getId()
+        );
     }
 
     @Transactional

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -47,7 +47,7 @@ public class CommentService {
             parentComment = commentRepository.findById(dto.getParentId())
                     .orElseThrow(() -> new IllegalArgumentException("부모 댓글이 존재하지 않습니다"));
         }
-0
+
         Comment comment = commentConverter.toCommentEntity(dto, user, post, parentComment);
         Comment savedComment = commentRepository.save(comment);
 

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -45,6 +45,7 @@ public class CommentService {
         Comment savedComment = commentRepository.save(comment);
 
         if(!post.getUser().getId().equals(user.getId())){
+
             // DB 저장 + 커밋 후 웹소켓 전송
             notificationService.createNotification(
                     post.getUser(),

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -7,6 +7,7 @@ import com.fmi.domain.comment.data.Comment;
 import com.fmi.domain.comment.repository.CommentRepository;
 import com.fmi.domain.comment.response.CommentResponse;
 import com.fmi.domain.comment.web.dto.CreateCommentDto;
+import com.fmi.domain.notification.data.enums.NotificationType;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -40,8 +41,14 @@ public class CommentService {
         User user = userRepository.findByEmail(userDetails.getUsername())
                 .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다"));
 
+        Comment parentComment = null;
 
-        Comment comment = commentConverter.toCommentEntity(dto, user, post);
+        if (dto.getParentId() != null) {
+            parentComment = commentRepository.findById(dto.getParentId())
+                    .orElseThrow(() -> new IllegalArgumentException("부모 댓글이 존재하지 않습니다"));
+        }
+0
+        Comment comment = commentConverter.toCommentEntity(dto, user, post, parentComment);
         Comment savedComment = commentRepository.save(comment);
 
         if(!post.getUser().getId().equals(user.getId())){
@@ -49,8 +56,20 @@ public class CommentService {
             // DB 저장 + 커밋 후 웹소켓 전송
             notificationService.createNotification(
                     post.getUser(),
-                    com.fmi.domain.notification.data.enums.NotificationType.COMMENT,
+                    NotificationType.COMMENT,
                     "새 댓글이 달렸습니다",
+                    dto.getContent(),
+                    "POST",
+                    post.getId()
+            );
+        }
+
+        if (parentComment != null && !parentComment.getUser().getId().equals(user.getId())) {
+
+            notificationService.createNotification(
+                    parentComment.getUser(),
+                    NotificationType.REPLY,
+                    "댓글에 답글이 달렸습니다",
                     dto.getContent(),
                     "POST",
                     post.getId()

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -51,7 +51,7 @@ public class CommentService {
         Comment comment = commentConverter.toCommentEntity(dto, user, post, parentComment);
         Comment savedComment = commentRepository.save(comment);
 
-        if(!post.getUser().getId().equals(user.getId())){
+        if(parentComment == null && !post.getUser().getId().equals(user.getId())){
 
             // DB 저장 + 커밋 후 웹소켓 전송
             notificationService.createNotification(
@@ -75,6 +75,7 @@ public class CommentService {
                     post.getId()
             );
         }
+
 
 
         return commentConverter.toCommentResponse(savedComment);

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -8,6 +8,7 @@ import com.fmi.domain.comment.repository.CommentRepository;
 import com.fmi.domain.comment.response.CommentResponse;
 import com.fmi.domain.comment.web.dto.CreateCommentDto;
 import com.fmi.domain.notification.data.enums.NotificationType;
+import com.fmi.domain.notification.service.NotificationService;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class CommentService {
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
     private final CommentConverter commentConverter;
-    private final com.fmi.domain.notification.service.NotificationService notificationService;
+    private final NotificationService notificationService;
 
     @Transactional
     public CommentResponse createComment(CreateCommentDto dto, UserDetails userDetails, Long postId) {

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -35,6 +35,7 @@ public class CommentService {
     @Transactional
     public CommentResponse createComment(CreateCommentDto dto, UserDetails userDetails, Long postId) {
 
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다"));
 
@@ -51,9 +52,19 @@ public class CommentService {
         Comment comment = commentConverter.toCommentEntity(dto, user, post, parentComment);
         Comment savedComment = commentRepository.save(comment);
 
-        if(parentComment == null && !post.getUser().getId().equals(user.getId())){
+        boolean isReply = parentComment != null;
 
-            // DB 저장 + 커밋 후 웹소켓 전송
+        if (isReply) {
+            notifyReply(parentComment, user, dto, post);
+        } else {
+            notifyPostOwner(post, user, dto);
+        }
+
+        return commentConverter.toCommentResponse(savedComment);
+    }
+
+    private void notifyPostOwner(Post post, User commenter, CreateCommentDto dto) {
+        if (!post.getUser().getId().equals(commenter.getId())) {
             notificationService.createNotification(
                     post.getUser(),
                     NotificationType.COMMENT,
@@ -63,9 +74,10 @@ public class CommentService {
                     post.getId()
             );
         }
+    }
 
-        if (parentComment != null && !parentComment.getUser().getId().equals(user.getId())) {
-
+    private void notifyReply(Comment parentComment, User replier, CreateCommentDto dto, Post post) {
+        if (!parentComment.getUser().getId().equals(replier.getId())) {
             notificationService.createNotification(
                     parentComment.getUser(),
                     NotificationType.REPLY,
@@ -75,10 +87,6 @@ public class CommentService {
                     post.getId()
             );
         }
-
-
-
-        return commentConverter.toCommentResponse(savedComment);
     }
 
     @Transactional

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -18,8 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -74,7 +73,7 @@ public class CommentService {
 
         for (String nickname : mentionedNicknames) {
             userRepository.findByNickname(nickname).ifPresent(mentionedUser -> {
-                if (!mentionedUser.getId().equals(comment.getUser().getId())) {
+                if (!mentionedUser.getId().equals(comment.getUser().getId())) {//자신 거르기
                     notificationService.createNotification(
                             mentionedUser,
                             NotificationType.MENTION,
@@ -89,18 +88,21 @@ public class CommentService {
     }
 
     private List<String> extractMentions(String content) {
-        List<String> mentions = new ArrayList<>();
-        if (content == null || content.isBlank()) return mentions;
 
-        // @뒤에 오는 닉네임 추출 (영문, 숫자, 한글, _, . 허용)
-        Pattern pattern = Pattern.compile("@([A-Za-z0-9가-힣_.]+)");
+        if (content == null || content.isBlank() || !content.contains("@")) {
+            return Collections.emptyList();
+        }
+
+        Set<String> mentions = new HashSet<>();
+
+        Pattern pattern = Pattern.compile("(?<=\\s|^)@([A-Za-z0-9가-힣_.]+)(?=\\s|$)");
         Matcher matcher = pattern.matcher(content);
 
         while (matcher.find()) {
             mentions.add(matcher.group(1));
         }
 
-        return mentions;
+        return new ArrayList<>(mentions);
     }
 
 

--- a/src/main/java/com/fmi/domain/comment/web/dto/CreateCommentDto.java
+++ b/src/main/java/com/fmi/domain/comment/web/dto/CreateCommentDto.java
@@ -8,4 +8,5 @@ import lombok.*;
 @AllArgsConstructor
 public class CreateCommentDto {
     private String content;
+    private Long parentId;
 }

--- a/src/main/java/com/fmi/domain/notification/data/enums/NotificationType.java
+++ b/src/main/java/com/fmi/domain/notification/data/enums/NotificationType.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum NotificationType {
     COMMENT("댓글"),
+    REPLY("대댓글"),
     CHAT("채팅"),
     INQUIRY_REPLY("문의 답변"),
     REPORT_RESULT("신고 처리 결과"),
@@ -12,6 +13,7 @@ public enum NotificationType {
     KEYWORD("키워드"),
     NOTICE("공지사항"),
     SYSTEM("시스템");
+
 
     private final String description;
 

--- a/src/main/java/com/fmi/domain/notification/data/enums/NotificationType.java
+++ b/src/main/java/com/fmi/domain/notification/data/enums/NotificationType.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum NotificationType {
     COMMENT("댓글"),
     REPLY("대댓글"),
+    MENTION("맨션"),
     CHAT("채팅"),
     INQUIRY_REPLY("문의 답변"),
     REPORT_RESULT("신고 처리 결과"),

--- a/src/main/java/com/fmi/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fmi/domain/notification/service/NotificationService.java
@@ -301,5 +301,7 @@ public class NotificationService {
                 return true;
         }
     }
+
+    
 }
 

--- a/src/main/java/com/fmi/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fmi/domain/notification/service/NotificationService.java
@@ -13,6 +13,7 @@ import com.fmi.domain.notification.web.dto.response.NotificationSettingsDTO;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ import com.fmi.domain.user.repository.UserKeywordRepository;
 import com.fmi.domain.user.data.UserKeyword;
 import com.fmi.domain.post.data.Post;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -221,6 +223,8 @@ public class NotificationService {
                     .build();
             
             notificationRepository.save(notification);
+
+            log.info(" 알림 저장 완료: {}", notification.getNotificationId());
 
             // 트랜잭션 커밋 이후 웹소켓 전송 (실패 시에도 DB 저장은 보장)
             if (TransactionSynchronizationManager.isSynchronizationActive()) {


### PR DESCRIPTION
맨션 + 대댓글 알림 설정 

- 대댓 depth 1단
- 맨션 > 대댓 > 새댓글 (우선순위 알림) 
- 게시글 작성자에게는 대댓글 알림 전송x (맨션은 적용)
- 알림 중복 방지
- 댓글 생성 구조 리펙토링
- 기존 Comment 엔티티에 p_content는 삭제하면 됨