### PR TITLE
fix: 채팅방 목록 조회에서 정렬 파라미터 기본값 수정 및 채팅 로직 수정

### DIFF
--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
@@ -142,9 +142,7 @@ public class ChatMessageService {
 
             // 수신자의 카운트만 증가
             if (!pt.getUser().getId().equals(senderId)) {
-                Long userId = pt.getUser().getId();
                 boolean isPresent = presenceService.isUserPresent(roomId, pt.getUser().getId());
-                String preview = newMessage.getPreviewContent();
                 if (isPresent) {
                     // 방안에 있음 -> 즉시 읽음. DB unreadCount = 0
                     pt.readMessages(newMessage.getId());
@@ -156,23 +154,20 @@ public class ChatMessageService {
                     broker.convertAndSendToUser(sender.getId().toString(), "/queue/read-receipts", receiptDTO);
                 } else {
                     // 방 밖에 있음 -> 카운트 +1. DB unreadCount + 1
-                    pt.onNewMessageArrived(newMessage);
-                    chatNotificationService.saveOrUpdateChatNotification(pt.getUser(), roomId, preview, NotificationType.CHAT);
+                    pt.onNewMessageArrived();
+                    chatNotificationService.saveOrUpdateChatNotification(pt.getUser(), roomId, newMessage.getPreviewContent(), NotificationType.CHAT);
                 }
-
-                // 갱신된 정보로 DTO 생성
-                ListUpdateDTO listUpdateDTO = ListUpdateDTO.builder()
-                        .roomId(roomId)
-                        .lastMessage(preview)
-                        .lastMessageSentAt(newMessage.getCreatedAt())
-                        .unreadCount(pt.getUnreadCount())
-                        .build();
-
-                broker.convertAndSendToUser(userId.toString(), "/queue/list-updates", listUpdateDTO);
             }
+            // 갱신된 정보로 DTO 생성
+            ListUpdateDTO listUpdateDTO = ListUpdateDTO.builder()
+                    .roomId(roomId)
+                    .lastMessage(newMessage.getPreviewContent())
+                    .lastMessageSentAt(newMessage.getCreatedAt())
+                    .unreadCount(pt.getUnreadCount())
+                    .build();
 
+            broker.convertAndSendToUser(pt.getUser().getId().toString(), "/queue/list-updates", listUpdateDTO);
         }
-
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
@@ -140,6 +140,11 @@ public class ChatMessageService {
             // 메시지 갱신 및 ACTIVE 설정
             pt.updateLastMessage(newMessage);
 
+            // 발신자가 보낸 메세지 읽음 처리
+            if (pt.getUser().getId().equals(senderId)) {
+                pt.readMessages(newMessage.getId());
+            }
+
             // 수신자의 카운트만 증가
             if (!pt.getUser().getId().equals(senderId)) {
                 boolean isPresent = presenceService.isUserPresent(roomId, pt.getUser().getId());

--- a/src/main/java/com/fmi/domain/chatroom/data/ChatRoom.java
+++ b/src/main/java/com/fmi/domain/chatroom/data/ChatRoom.java
@@ -23,23 +23,13 @@ public class ChatRoom {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //@ManyToOne(fetch = FetchType.LAZY)
-    //@JoinColumn(name = "user_id", nullable = false)
-    //private User user;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    //@Column(length = 100)
-    //private String lastMessage;
-
     // 채팅방 생성 시간
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
-    // 마지막 메시지가 온 시간
-    //private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default

--- a/src/main/java/com/fmi/domain/chatroom/data/ChatRoomParticipant.java
+++ b/src/main/java/com/fmi/domain/chatroom/data/ChatRoomParticipant.java
@@ -108,16 +108,6 @@ public class ChatRoomParticipant {
     }
 
     /**
-     * 안 읽은 개수 1 증가
-     */
-    public void incrementUnreadCount() {
-        if (this.unreadCount == null) {
-            this.unreadCount = 0L;
-        }
-        this.unreadCount += 1;
-    }
-
-    /**
      * 리마인더 발송 후 호출
      */
     public void markReminded() {

--- a/src/main/java/com/fmi/domain/chatroom/data/ChatRoomParticipant.java
+++ b/src/main/java/com/fmi/domain/chatroom/data/ChatRoomParticipant.java
@@ -86,16 +86,11 @@ public class ChatRoomParticipant {
     /**
      * 새 메시지가 도착했을 때 호출
      */
-    public void onNewMessageArrived(ChatMessage message) {
-        this.participantState = ParticipantState.ACTIVE;
-        this.lastMessage = message;
-        this.lastMessageSentAt = message.getCreatedAt();
-
+    public void onNewMessageArrived() {
         // 처음으로 안 읽은 시간 기록
         if (this.unreadCount == 0L) {
             this.firstUnreadAt = LocalDateTime.now();
         }
-
         this.unreadCount++;
     }
 

--- a/src/main/java/com/fmi/domain/chatroom/data/ChatRoomParticipant.java
+++ b/src/main/java/com/fmi/domain/chatroom/data/ChatRoomParticipant.java
@@ -72,6 +72,10 @@ public class ChatRoomParticipant {
         // 목록에서 보이지 않게 lastMessage도 초기화
         this.lastMessage = null;
         this.lastMessageSentAt = null;
+        this.unreadCount = 0L;
+        if (lastMessageIdOrNull != null) {
+            this.lastReadMessageId = lastMessageIdOrNull;
+        }
     }
 
     /**

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -70,7 +70,7 @@ public class ChatRoomController {
             @Parameter(name = "size", description = "한 페이지에 조회할 개수. (기본값: 10)", required = false),
             @Parameter(name = "type", description = "습득물/분실물(FOUND/LOST) 타입", required = false),
             @Parameter(name = "address", description = "지역(ex.서울시 동작구) 필터", required = false),
-            @Parameter(name = "sort", description = "최신순/오래된순(NEWEST/OLDEST) 정렬. 기본값 : 최신순(NEWEST)", required = false),
+            @Parameter(name = "sort", description = "최신순/오래된순(LATEST/OLDEST) 정렬. 기본값 : 최신순(LATEST)", required = false),
 
     })
     @GetMapping("/users/me/chats")

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -79,7 +79,7 @@ public class ChatRoomController {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(name = "type", required = false) Type type,
             @RequestParam(name = "address", required = false) String address,
-            @RequestParam(name= "sort", required = false, defaultValue = "NEWEST") SortType sort,
+            @RequestParam(name= "sort", required = false, defaultValue = "LATEST") SortType sort,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         User user = userService.findUser(userDetails.getUsername());


### PR DESCRIPTION
- 내 채팅 목록 조회에서 기본값 정렬 이름 수정 및 스웨거 설명도 같이 수정
- 채팅 목록 업데이트를 발신자와수신자 모두에게 전송(WebSocket)
- 새 메시지 도착시 호출하는 메서드 중복되는 부분 삭제
- 채팅 발신자도 자신이 보낸 채팅 읽음 처리 추가
- 안 쓰는 코드 삭제
- 채팅방 나갈 때 안 읽음 개수(unreadCount)를 0으로 설정 및 마지막으로 읽은 메시지 갱신 