### PR TITLE
refactor: 채팅 API 응답 규격 및 이미지 메시지 동작 개선

### DIFF
--- a/src/main/java/com/fmi/domain/chatmessage/converter/ChatMessageConverter.java
+++ b/src/main/java/com/fmi/domain/chatmessage/converter/ChatMessageConverter.java
@@ -30,7 +30,6 @@ public class ChatMessageConverter {
                 .messageType(chatMessage.getMessageType())
                 .roomId(chatMessage.getChatRoom().getId())
                 .senderId(chatMessage.getUser().getId())
-                .content(chatMessage.getContent())
                 .imageUrls(chatMessage.getImages().stream()
                         .map(MessageImage::getImageUrl)
                         .collect(Collectors.toList()))

--- a/src/main/java/com/fmi/domain/chatmessage/data/ChatMessage.java
+++ b/src/main/java/com/fmi/domain/chatmessage/data/ChatMessage.java
@@ -57,12 +57,4 @@ public class ChatMessage {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    public String getPreviewContent() {
-        if (this.content != null && !this.content.isBlank()) {
-            return this.content;
-        } else if (this.getMessageType() == MessageType.IMAGE) {
-            return "사진을 보냈습니다.";
-        }
-        return "미리보기가 없는 메시지입니다.";
-    }
 }

--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
@@ -14,10 +14,10 @@ import com.fmi.domain.chatroom.repository.ChatRoomParticipantRepository;
 import com.fmi.domain.chatroom.repository.ChatRoomRepository;
 import com.fmi.domain.chatroom.service.ChatRoomPresenceService;
 import com.fmi.domain.notification.data.enums.NotificationType;
+import com.fmi.domain.userblock.service.BlockService;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import com.fmi.global.service.S3Service;
-import com.fmi.domain.userblock.service.BlockService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 
 import static com.fmi.domain.chatmessage.converter.ChatMessageConverter.messageImageResponseDTO;
 import static com.fmi.domain.chatmessage.converter.ChatMessageConverter.messageResponseDTO;
-import static com.fmi.domain.chatmessage.web.dto.ChatMessageRequestDTO.SendImageRequestDTO;
 import static com.fmi.domain.chatmessage.web.dto.ChatMessageRequestDTO.SendMessageRequestDTO;
 import static com.fmi.domain.chatmessage.web.dto.ChatMessageResponseDTO.*;
 
@@ -86,10 +85,9 @@ public class ChatMessageService {
         return responseDTO;
     }
 
-    public MessageImageResponseDTO sendImageMessage(Long roomId, SendImageRequestDTO requestDTO, Long userId) {
+    public MessageImageResponseDTO sendImageMessage(Long roomId, List<MultipartFile> images, Long userId) {
 
-        List<MultipartFile> imageFiles = requestDTO.getImages();
-        if (imageFiles == null || imageFiles.isEmpty()) {
+        if (images == null || images.isEmpty()) {
             throw new GeneralException(ErrorStatus._IMAGE_NOT_PROVIDED);
         }
 
@@ -109,12 +107,11 @@ public class ChatMessageService {
         ChatMessage chatMessage = ChatMessage.builder()
                 .chatRoom(room)
                 .user(sender)
-                .content(requestDTO.getContent())
                 .messageType(MessageType.IMAGE)
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        List<String> imageUrls = s3Service.upload(imageFiles);
+        List<String> imageUrls = s3Service.upload(images);
         imageUrls.forEach(url -> {
             MessageImage newImage = MessageImage.builder().imageUrl(url).build();
             chatMessage.addImage(newImage);

--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
@@ -175,13 +175,8 @@ public class ChatMessageService {
 
     @Transactional(readOnly = true)
     public MessageSliceResponseDTO messageSlice(Long roomId, Long senderId, Long cursorId) {
-
-        if (!chatRoomParticipantRepository.existsByUser_IdAndChatRoom_Id(senderId, roomId)) {
-            throw new GeneralException(ErrorStatus._MESSAGE_NOT_ALLOWED);
-        }
-
         ChatRoomParticipant me = chatRoomParticipantRepository.findByChatRoom_IdAndUser_Id(roomId, senderId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._MESSAGE_NOT_ALLOWED));
 
         Long cutoff = me.getVisibleFromMessageId();
 

--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
@@ -157,13 +157,14 @@ public class ChatMessageService {
                 } else {
                     // 방 밖에 있음 -> 카운트 +1. DB unreadCount + 1
                     pt.onNewMessageArrived();
-                    chatNotificationService.saveOrUpdateChatNotification(pt.getUser(), roomId, newMessage.getPreviewContent(), NotificationType.CHAT);
+                    chatNotificationService.saveOrUpdateChatNotification(pt.getUser(), roomId, newMessage.getContent(), NotificationType.CHAT);
                 }
             }
             // 갱신된 정보로 DTO 생성
             ListUpdateDTO listUpdateDTO = ListUpdateDTO.builder()
                     .roomId(roomId)
-                    .lastMessage(newMessage.getPreviewContent())
+                    .messageType(newMessage.getMessageType())
+                    .lastMessage(newMessage.getContent())
                     .lastMessageSentAt(newMessage.getCreatedAt())
                     .unreadCount(pt.getUnreadCount())
                     .build();

--- a/src/main/java/com/fmi/domain/chatmessage/web/controller/ChatMessageController.java
+++ b/src/main/java/com/fmi/domain/chatmessage/web/controller/ChatMessageController.java
@@ -5,11 +5,11 @@ import com.fmi.domain.chatmessage.service.ChatMessageService;
 import com.fmi.domain.chatmessage.web.dto.ChatMessageResponseDTO;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.global.apiPayload.code.status.SuccessStatus;
+import com.fmi.service.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import com.fmi.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -19,10 +19,11 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
+import java.util.List;
 
-import static com.fmi.domain.chatmessage.web.dto.ChatMessageRequestDTO.SendImageRequestDTO;
 import static com.fmi.domain.chatmessage.web.dto.ChatMessageRequestDTO.SendMessageRequestDTO;
 
 @RestController
@@ -43,12 +44,12 @@ public class ChatMessageController {
 
     @PostMapping(value = "/{roomId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Void> uploadImage(@PathVariable Long roomId,
-                                         @AuthenticationPrincipal UserDetails userDetails, @ModelAttribute SendImageRequestDTO requestDTO) {
+                                         @AuthenticationPrincipal UserDetails userDetails, @RequestPart("images") List<MultipartFile> images) {
 
         String email = userDetails.getUsername();
         User user = userService.findUser(email);
 
-        chatMessageService.sendImageMessage(roomId, requestDTO, user.getId());
+        chatMessageService.sendImageMessage(roomId, images, user.getId());
         return ApiResponse.of(SuccessStatus._OK);
     }
 

--- a/src/main/java/com/fmi/domain/chatmessage/web/dto/ChatMessageResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatmessage/web/dto/ChatMessageResponseDTO.java
@@ -32,7 +32,6 @@ public class ChatMessageResponseDTO {
         private Long messageId;
         private Long roomId;
         private Long senderId;
-        private String content;
         private MessageType messageType;
         private List<String> imageUrls;
         private LocalDateTime createdAt;

--- a/src/main/java/com/fmi/domain/chatmessage/web/dto/ChatMessageResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatmessage/web/dto/ChatMessageResponseDTO.java
@@ -66,6 +66,7 @@ public class ChatMessageResponseDTO {
     @Getter
     public static class ListUpdateDTO {
         private Long roomId;
+        private MessageType messageType;
         private String lastMessage;
         private LocalDateTime lastMessageSentAt;
         private Long unreadCount; // DB에 저장된 값

--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -70,20 +70,20 @@ public class ChatRoomConverter {
                 .build();
 
         ChatMessage lastMessage = participant.getLastMessage();
-        String preview = null;
+        String content = null;
+        MessageType messageType = null;
+
         if (lastMessage != null) {
-            if (lastMessage.getContent() != null && !lastMessage.getContent().isBlank()) {
-                preview = lastMessage.getContent();
-            } else if (isImageMessage(lastMessage)) {
-                preview = "사진을 보냈습니다.";
-            }
+            content = lastMessage.getContent();
+            messageType=lastMessage.getMessageType();
         }
 
         return ChatRoomSummaryDTO.builder()
                 .roomId(participant.getChatRoom().getId())
                 .contactUser(contactUserDTO)
                 .postInfo(postInfoDTO)
-                .lastMessage(preview)
+                .messageType(messageType)
+                .lastMessage(content)
                 .lastMessageSentAt(participant.getLastMessageSentAt())
                 .unreadCount(participant.getUnreadCount())
                 .build();

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatReminderService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatReminderService.java
@@ -44,8 +44,7 @@ public class ChatReminderService {
             try {
                 User receiver = pt.getUser();
                 Long roomId = pt.getChatRoom().getId();
-
-                String content = pt.getLastMessage().getPreviewContent();
+                String content = pt.getLastMessage().getContent();
 
                 chatNotificationService.saveOrUpdateChatNotification(
                         receiver,

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
@@ -122,7 +122,7 @@ public class ChatRoomService {
 
     public void leaveChatRoom(Long roomId, Long userId) {
         ChatRoomParticipant chatRoomParticipant = chatRoomParticipantRepository.findByUser_IdAndChatRoom_Id(userId, roomId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._PARTICIPANT_NOT_FOUND));
 
         if (chatRoomParticipant.getParticipantState() == ParticipantState.LEFT) {
             return;

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
@@ -120,7 +120,7 @@ public class ChatRoomService {
         return new MyChatListDTO(summaryDTOs, nextCursor);
     }
 
-    public void leftChatRoom(Long roomId, Long userId) {
+    public void leaveChatRoom(Long roomId, Long userId) {
         ChatRoomParticipant chatRoomParticipant = chatRoomParticipantRepository.findByUser_IdAndChatRoom_Id(userId, roomId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
 

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
@@ -36,14 +38,14 @@ public class ChatRoomController {
 
     @Operation(summary = "채팅방 생성/조회", description = "특정 게시글에 대해 1:1 채팅방을 생성하거나 기존 채팅방을 조회합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM_CREATED: 채팅방이 새로 생성됨"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "CHATROOM_CREATED: 채팅방이 새로 생성됨"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM_FOUND: 기존 채팅방이 조회됨"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CHATROOM_NOT_ALLOWED: 자신의 게시글에 채팅 시도"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "POST_NOT_FOUND: 존재하지 않는 게시글"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USER_NOT_FOUND: 존재하지 않는 사용자")
     })
     @PostMapping("/posts/{postId}/chats")
-    public ApiResponse<ChatRoomResultDTO> createChatRoom(@PathVariable("postId") Long postId, @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<ApiResponse<ChatRoomResultDTO>> createChatRoom(@PathVariable("postId") Long postId, @AuthenticationPrincipal UserDetails userDetails) {
         String email = userDetails.getUsername();
         User user = userService.findUser(email);
         Pair<ChatRoomResultDTO, Boolean> result = chatRoomService.createChatRoom(postId, user.getId());
@@ -53,12 +55,15 @@ public class ChatRoomController {
 
         if (isNew) {
             // 새로 생성된 경우
-            return ApiResponse.of(SuccessStatus._CHATROOM_CREATED, responseDTO);
+            return ResponseEntity
+                    .status(HttpStatus.CREATED)
+                    .body(ApiResponse.of(SuccessStatus._CHATROOM_CREATED, responseDTO));
         } else {
             // 기존에 존재했던 경우
-            return ApiResponse.of(SuccessStatus._CHATROOM_FOUND, responseDTO);
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(ApiResponse.of(SuccessStatus._CHATROOM_FOUND, responseDTO));
         }
-
     }
 
     @Operation(summary = "내 채팅 목록 조회", description = "내가 참여하고 있는 채팅방 목록을 커서 기반 페이지네이션으로 조회합니다.")

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -93,10 +93,10 @@ public class ChatRoomController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM_LIST_FETCHED: 채팅 목록 조회 성공")
     })
     @PatchMapping("/chats/{roomId}/leave")
-    public ApiResponse<Void> leftChatRoom(@PathVariable("roomId") Long roomId, @AuthenticationPrincipal UserDetails userDetails) {
+    public ApiResponse<Void> leaveChatRoom(@PathVariable("roomId") Long roomId, @AuthenticationPrincipal UserDetails userDetails) {
         String email = userDetails.getUsername();
         User user = userService.findUser(email);
-        chatRoomService.leftChatRoom(roomId, user.getId());
+        chatRoomService.leaveChatRoom(roomId, user.getId());
         return ApiResponse.of(SuccessStatus._CHATROOM_LEFT);
     }
 

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -5,7 +5,6 @@ import com.fmi.domain.Enum.Type;
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.chatroom.service.ChatRoomPresenceService;
 import com.fmi.domain.chatroom.service.ChatRoomService;
-import com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.global.apiPayload.code.status.SuccessStatus;
 import com.fmi.service.UserQueryService;
@@ -25,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 
 import static com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.ChatRoomResultDTO;
+import static com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.MyChatListDTO;
 
 @RestController
 @RequiredArgsConstructor
@@ -74,7 +74,7 @@ public class ChatRoomController {
 
     })
     @GetMapping("/users/me/chats")
-    public ApiResponse<ChatRoomResponseDTO.MyChatListDTO> getMyPostChatRooms(
+    public ApiResponse<MyChatListDTO> getMyPostChatRooms(
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(name = "type", required = false) Type type,
@@ -84,7 +84,7 @@ public class ChatRoomController {
     ) {
         User user = userService.findUser(userDetails.getUsername());
 
-        ChatRoomResponseDTO.MyChatListDTO responseDTO = chatRoomService.getMyPostChatRooms(user, cursor, size, type, address, sort);
+        MyChatListDTO responseDTO = chatRoomService.getMyPostChatRooms(user, cursor, size, type, address, sort);
         return ApiResponse.of(SuccessStatus._CHATROOM_LIST_FETCHED, responseDTO);
     }
 

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -94,10 +94,7 @@ public class ChatRoomController {
     }
 
     @Operation(summary = "채팅방 나가기", description = "채팅방을 나가면 그 시점부터 나간 사용자에게 대화 내역이 보이지 않고, 내 채팅 목록에도 사라집니다. 다시 채팅이 시작되면 그 나간 이후 시점부터 내역이 보입니다. (나가지 않은 사용자에겐 적용x)")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM_LIST_FETCHED: 채팅 목록 조회 성공")
-    })
-    @PatchMapping("/chats/{roomId}/leave")
+    @PostMapping("/chats/{roomId}/leave")
     public ApiResponse<Void> leaveChatRoom(@PathVariable("roomId") Long roomId, @AuthenticationPrincipal UserDetails userDetails) {
         String email = userDetails.getUsername();
         User user = userService.findUser(email);

--- a/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
@@ -1,8 +1,8 @@
 package com.fmi.domain.chatroom.web.dto;
 
 import com.fmi.domain.Enum.Type;
+import com.fmi.domain.chatmessage.data.enums.MessageType;
 import lombok.*;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -58,6 +58,7 @@ public class ChatRoomResponseDTO {
         private Long roomId;
         private ContactUserDTO contactUser;
         private PostInfoDTO postInfo;
+        private MessageType messageType;
         private String lastMessage;
         private LocalDateTime lastMessageSentAt;
         private Long unreadCount;

--- a/src/main/java/com/fmi/domain/notification/data/Notification.java
+++ b/src/main/java/com/fmi/domain/notification/data/Notification.java
@@ -32,7 +32,7 @@ public class Notification {
     @Column(name = "title", nullable = false, length = 200)
     private String title;
 
-    @Column(name = "message", nullable = false, length = 500)
+    @Column(name = "message", length = 500)
     private String message;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
@@ -57,11 +57,12 @@ public enum ErrorStatus implements BaseErrorCode {
     // 채팅방 관련 응답
     _CHATROOM_NOT_ALLOWED(HttpStatus.FORBIDDEN, "CHATROOM403-NOT_ALLOWED", "자신의 글에는 채팅할 수 없습니다."),
     _CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM404-NOT_FOUND", "존재하지 않는 채팅방입니다."),
+    _PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM404-PARTICIPANT_NOT_FOUND", "참여 중인 채팅방이 아닙니다."),
 
-    //채팅 관련 응답
+    // 채팅 관련 응답
     _IMAGE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "IMAGE400-NOT_PROVIDED", "전송할 이미지가 없습니다."),
     _MESSAGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MESSAGE-NOT_ALLOWED", "채팅 내역을 조회할 권한이 없습니다."),
-    
+
     // 공지사항 관련 응답
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE404-NOT_FOUND", "존재하지 않는 공지사항입니다."),
     


### PR DESCRIPTION
### 채팅 전송 관련 작업 
- 이미지 채팅일 경우 채팅 목록 응답/채팅 목록 업데이트 웹소켓에서 메시지 내용(content)를 null로 전달
- 채팅 목록 응답/채팅 목록 업데이트 웹소켓에서 메시지 타입(messageType(TEXT/IMAGE)필드를 추가
- 채팅 이미지 전송 웹소켓에서 content 필드 제외 
### 채팅 나가기 관련 작업
- 채팅방 나가기에서 에러 응답을 수정
- 채팅방 나가기에서 컨트롤러/서비스 함수 이름 수정
- 채팅방 나가기에서 HTTP 메서드 post로 변경 
### 기타 작업 
- 이전 채팅 내역 조회에서 중복 검증 부분을 삭제
- 채팅방 생성 API HTTP 상태 코드를 201 Created로 변경
- Notification 엔티티에서 message 컬럼 null 허용 