### PR TITLE
feat: 메시지 없는 채팅방도 내 채팅 목록에 노출

### DIFF
--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
@@ -43,7 +43,8 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
                 .selectFrom(pt)
                 .join(pt.chatRoom, cr).fetchJoin()
                 .join(cr.post, p).fetchJoin()
-                .join(pt.lastMessage, lm).fetchJoin()
+                //todo: 추후에 이걸로 다시 변경 .join(pt.lastMessage, lm).fetchJoin()
+                .leftJoin(pt.lastMessage, lm).fetchJoin()
                 .join(cr.participants, otherPt)
                 .join(otherPt.user, otherUser).fetchJoin()
                 .where(
@@ -51,7 +52,7 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
                         pt.user.id.eq(userId),
                         otherPt.user.id.ne(userId),
                         pt.participantState.eq(ParticipantState.ACTIVE),
-                        pt.lastMessage.isNotNull(),
+                        //todo: 추후에 주석 해제 pt.lastMessage.isNotNull(),
 
                         typeEq(type),
                         addressEq(address)


### PR DESCRIPTION
- 메시지 유무와 관계없이 참여 중인 모든 방이 조회되도록 했습니다. 
- 추후에는 다시 메시지가 있어야 조회되도록 수정될 예정입니다. 