### PR TITLE
docs: Swagger API 명세 구조화 및 응답 스펙 구체화

### DIFF
--- a/src/main/java/com/fmi/controller/HealthController.java
+++ b/src/main/java/com/fmi/controller/HealthController.java
@@ -1,11 +1,13 @@
 package com.fmi.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
 @RestController
+@Tag(name = "Health", description = "헬스체크용 API")
 public class HealthController {
 
     @GetMapping("/health")

--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
@@ -101,7 +101,7 @@ public class ChatMessageService {
         User recipient = room.getOtherParticipant(sender.getId());
 
         if (blockService.isBlocked(sender.getId(), recipient.getId())) {
-            throw new GeneralException(ErrorStatus._MESSAGE_NOT_ALLOWED);
+            throw new GeneralException(ErrorStatus._FORBIDDEN);
         }
 
         ChatMessage chatMessage = ChatMessage.builder()
@@ -243,7 +243,7 @@ public class ChatMessageService {
         }
 
         ChatRoomParticipant chatRoomParticipant = chatRoomParticipantRepository.findByChatRoom_IdAndUser_Id(roomId, userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._PARTICIPANT_NOT_FOUND));
 
         chatRoomParticipant.readMessages(lastMessageId);
 

--- a/src/main/java/com/fmi/domain/chatmessage/web/controller/ChatMessageController.java
+++ b/src/main/java/com/fmi/domain/chatmessage/web/controller/ChatMessageController.java
@@ -47,15 +47,10 @@ public class ChatMessageController {
     @PostMapping(value = "/{roomId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "채팅 이미지 전송", description = "채팅방에 이미지를 전송합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "이미지 전송 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "IMAGE400-NOT_PROVIDED: 전송할 이미지가 없습니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "FILE400-EXT_MISSING: 확장자가 존재하지 않습니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "MESSAGE-NOT_ALLOWED: 채팅 내역을 조회할 권한이 없습니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHATROOM404-NOT_FOUND: 존재하지 않는 채팅방입니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "415", description = "FILE415-EXT_UNSUPPORTED: 허용되지 않는 확장자입니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "FILE500-UPLOAD_IO: 업로드 중 오류가 발생했습니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "MESSAGE-SENT: 이미지 전송에 성공하였습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "FILE-EXT_MISSING: 확장자가 존재하지 않습니다"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "415", description = "FILE-EXT_UNSUPPORTED: 허용되지 않는 확장자입니다"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "FILE-UPLOAD_IO: 업로드 중 오류가 발생했습니다"),
     })
     public ApiResponse<Void> uploadImage(@PathVariable Long roomId,
                                          @AuthenticationPrincipal UserDetails userDetails, @RequestPart("images") List<MultipartFile> images) {
@@ -64,17 +59,13 @@ public class ChatMessageController {
         User user = userService.findUser(email);
 
         chatMessageService.sendImageMessage(roomId, images, user.getId());
-        return ApiResponse.of(SuccessStatus._OK);
+        return ApiResponse.of(SuccessStatus._MESSAGE_IMAGE_SENT);
     }
 
     @Operation(summary = "이전 채팅 내역 조회", description = "현재 채팅방의 이전 대화 내역을 커서 기반 페이지네이션으로 조회합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "MESSAGE_LIST_FETCHED: 이전 채팅 내역 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "LIST400-INVALID_CURSOR: 유효하지 않은 커서입니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "MESSAGE-NOT_ALLOWED: 채팅 내역을 조회할 권한이 없습니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHATROOM404-NOT_FOUND: 존재하지 않는 채팅방입니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "MESSAGE_LIST_FETCHED: 이전 채팅 내역 조회를 성공했습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "MESSAGE-NOT_ALLOWED: 채팅 내역을 조회할 권한이 없습니다")
     })
     @Parameters({
             @Parameter(name = "roomId", description = "조회할 채팅방의 ID", required = true),
@@ -93,11 +84,9 @@ public class ChatMessageController {
                     "1. 해당 유저의 unreadCount를 0으로 갱신하고 lastReadMessageId를 최신으로 업데이트합니다. \n" +
                     "2. (WebSocket) 상대방에게는 '/queue/read-receipts'로 실시간 읽음 확인 이벤트를 전송합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "MESSAGE200-READ, 메세지 읽음을 성공했습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "MESSAGE-NOT_ALLOWED: 채팅 내역을 조회할 권한이 없습니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHATROOM404-NOT_FOUND: 존재하지 않는 채팅방입니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "MESSAGE-READ: 메세지 읽음을 성공했습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CHATROOM-PARTICIPANT_NOT_FOUND: 참여 중인 채팅방이 아닙니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHATROOM-NOT_FOUND: 존재하지 않는 채팅방입니다."),
     })
     @Parameters({
             @Parameter(name = "roomId", description = "읽을 채팅방의 ID", required = true)

--- a/src/main/java/com/fmi/domain/chatmessage/web/controller/ChatMessageController.java
+++ b/src/main/java/com/fmi/domain/chatmessage/web/controller/ChatMessageController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -30,6 +31,7 @@ import static com.fmi.domain.chatmessage.web.dto.ChatMessageRequestDTO.SendMessa
 @RequiredArgsConstructor
 @RequestMapping("/chats")
 @Slf4j
+@Tag(name = "ChatMessage", description = "채팅 메시지 관련 API")
 public class ChatMessageController {
 
     private final ChatMessageService chatMessageService;

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,7 @@ import static com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.MyChatListDTO;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "ChatRoom", description = "채팅방 관련 API")
 public class ChatRoomController {
 
     private final UserQueryService userService;

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -40,11 +40,10 @@ public class ChatRoomController {
 
     @Operation(summary = "채팅방 생성/조회", description = "특정 게시글에 대해 1:1 채팅방을 생성하거나 기존 채팅방을 조회합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "CHATROOM_CREATED: 채팅방이 새로 생성됨"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM_FOUND: 기존 채팅방이 조회됨"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CHATROOM_NOT_ALLOWED: 자신의 게시글에 채팅 시도"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "POST_NOT_FOUND: 존재하지 않는 게시글"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USER_NOT_FOUND: 존재하지 않는 사용자")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "CHATROOM_CREATED: 채팅방이 생성되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM_FOUND: 기존 채팅방을 조회합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CHATROOM_NOT_ALLOWED: 자신의 글에는 채팅할 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "POST_NOT_FOUND: 존재하지 않는 게시글입니다."),
     })
     @PostMapping("/posts/{postId}/chats")
     public ResponseEntity<ApiResponse<ChatRoomResultDTO>> createChatRoom(@PathVariable("postId") Long postId, @AuthenticationPrincipal UserDetails userDetails) {
@@ -70,10 +69,7 @@ public class ChatRoomController {
 
     @Operation(summary = "내 채팅 목록 조회", description = "내가 참여하고 있는 채팅방 목록을 커서 기반 페이지네이션으로 조회합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM_LIST_FETCHED: 채팅 목록 조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "LIST400-INVALID_CURSOR: 유효하지 않은 커서입니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM_LIST_FETCHED: 나의 채팅 목록 조회에 성공했습니다."),
     })
     @Parameters({
             @Parameter(name = "cursor", description = "이전 페이지 응답의 nextCursor 값. 첫 페이지 조회 시 생략.", required = false),
@@ -100,10 +96,8 @@ public class ChatRoomController {
 
     @Operation(summary = "채팅방 나가기", description = "채팅방을 나가면 그 시점부터 나간 사용자에게 대화 내역이 보이지 않고, 내 채팅 목록에도 사라집니다. 다시 채팅이 시작되면 그 나간 이후 시점부터 내역이 보입니다. (나가지 않은 사용자에겐 적용x)")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "채팅방 나가기 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHATROOM404-NOT_FOUND: 존재하지 않는 채팅방입니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM-LEFT: 채팅방 나가기를 성공했습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHATROOM-PARTICIPANT_NOT_FOUND: 참여 중인 채팅방이 아닙니다.")
     })
     @PostMapping("/chats/{roomId}/leave")
     public ApiResponse<Void> leaveChatRoom(@PathVariable("roomId") Long roomId, @AuthenticationPrincipal UserDetails userDetails) {

--- a/src/main/java/com/fmi/domain/comment/web/controller/CommentController.java
+++ b/src/main/java/com/fmi/domain/comment/web/controller/CommentController.java
@@ -7,6 +7,7 @@ import com.fmi.domain.comment.web.dto.CreateCommentDto;
 import com.fmi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("comment")
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Comment", description = "댓글 관련 API")
 public class CommentController {
 
     private final CommentService commentService;

--- a/src/main/java/com/fmi/domain/commentlike/web/controller/CommentLikeController.java
+++ b/src/main/java/com/fmi/domain/commentlike/web/controller/CommentLikeController.java
@@ -4,6 +4,7 @@ import com.fmi.domain.commentlike.service.CommentLikeService;
 import com.fmi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Comment", description = "댓글 관련 API")
 public class CommentLikeController {
 
     private final CommentLikeService commentLikeService;

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -10,6 +10,7 @@ import com.fmi.domain.post.web.dto.UpdatePostDto;
 import com.fmi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +27,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/post")
+@Tag(name = "Post", description = "게시글 관련 API")
 public class PostController {
 
     private final PostService postService;

--- a/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
+++ b/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
@@ -6,6 +6,7 @@ import com.fmi.domain.postfavorite.service.PostFavoriteService;
 import com.fmi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +17,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "Post", description = "게시글 관련 API")
 public class PostFavoriteController {
 
     private final PostFavoriteService postFavoriteService;
@@ -54,7 +56,7 @@ public class PostFavoriteController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @Operation(summary = "즐겨찾기 목록 조회")
+    @Operation(summary = "즐겨찾기 목록 조회", tags = {"User"})
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "즐겨찾기 목록 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),

--- a/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
@@ -62,7 +62,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 채팅 관련 응답
     _IMAGE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "IMAGE400-NOT_PROVIDED", "전송할 이미지가 없습니다."),
-    _MESSAGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MESSAGE-NOT_ALLOWED", "채팅 내역을 조회할 권한이 없습니다."),
+    _MESSAGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MESSAGE403-NOT_ALLOWED", "채팅 내역을 조회할 권한이 없습니다."),
 
     // 공지사항 관련 응답
     _NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE404-NOT_FOUND", "존재하지 않는 공지사항입니다."),

--- a/src/main/java/com/fmi/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/SuccessStatus.java
@@ -20,12 +20,10 @@ public enum SuccessStatus implements BaseCode {
     _CHATROOM_LIST_FETCHED(HttpStatus.OK, "CHATROOM200-LIST", "나의 채팅 목록 조회에 성공했습니다."),
     _CHATROOM_LEFT(HttpStatus.OK, "CHATROOM200-LEFT", "채팅방 나가기를 성공했습니다."),
 
-    // 이미지 관련 응답
-    _IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "IMAGE200-UPLOAD", "이미지 업로드에 성공하였습니다."),
-
     // 메세지 관련 응답
     _MESSAGE_LIST_FETCHED(HttpStatus.OK, "MESSAGE200-LIST", "이전 채팅 내역 조회를 성공했습니다."),
-    _MESSAGE_READ(HttpStatus.OK, "MESSAGE200-READ", "메세지 읽음을 성공했습니다.");
+    _MESSAGE_READ(HttpStatus.OK, "MESSAGE200-READ", "메세지 읽음을 성공했습니다."),
+    _MESSAGE_IMAGE_SENT(HttpStatus.OK, "MESSAGE200-SENT", "이미지 전송에 성공하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/fmi/global/web/controller/S3Controller.java
+++ b/src/main/java/com/fmi/global/web/controller/S3Controller.java
@@ -5,6 +5,7 @@ import com.fmi.global.service.S3Service;
 import com.fmi.global.web.dto.ImageDeleteRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/s3")
+@Tag(name = "S3", description = "S3 테스트용 API")
 public class S3Controller {
 
     private final S3Service s3Service;


### PR DESCRIPTION
## 🧩 관련 이슈

- close #98

## 🛠️ 작업 내용

- 각 도메인들에서 누락된 스웨거 태그 추가하여 구조 통일 
- ChatRoom, ChatMessage에 응답 스펙 구체화 

## 📢 참고 및 특이사항

- 스웨거에서 게시글 즐겨찾기는 게시글에, 댓글 좋아요는 댓글로 같은 그룹으로 배치했습니다. 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
