### PR TITLE
fix: 조회수 증가 / 게시글 상세 조회 통합

### DIFF
--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/actuator/health", "/actuator/info", "/ws/**", "/error", "/health", "/api/health").permitAll()
                         .requestMatchers("/auth/login", "/auth/signup", "/auth/refresh", "/auth/logout",
-                                "/auth/check-email", "/auth/check-nickname", "/auth/reset/**", "/s3/**", "/chat-test.html", "/chat-test2.html").permitAll()
+                                "/auth/check-email", "/auth/check-nickname", "/auth/reset/**", "/s3/**", "/chat-test.html", "/chat-test2.html","/posts/filter").permitAll()
                         .requestMatchers("/auth/kakao/**", "/auth/email/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/post/{postId}","/post/").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()

--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/login", "/auth/signup", "/auth/refresh", "/auth/logout",
                                 "/auth/check-email", "/auth/check-nickname", "/auth/reset/**", "/s3/**", "/chat-test.html", "/chat-test2.html","/posts/filter").permitAll()
                         .requestMatchers("/auth/kakao/**", "/auth/email/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/post/{postId}","/post/").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/post/{postId}","/post").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                         // 공지사항, 공개 문의 - 공개 API (경로 개편)
                         .requestMatchers("/notice/**", "/inquiry/public/**").permitAll()

--- a/src/main/java/com/fmi/domain/comment/web/controller/CommentController.java
+++ b/src/main/java/com/fmi/domain/comment/web/controller/CommentController.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("comment")
+@RequestMapping("comments")
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Comment", description = "댓글 관련 API")

--- a/src/main/java/com/fmi/domain/commentlike/web/controller/CommentLikeController.java
+++ b/src/main/java/com/fmi/domain/commentlike/web/controller/CommentLikeController.java
@@ -27,7 +27,7 @@ public class CommentLikeController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "COMMENT404-NOT_FOUND: 존재하지 않는 댓글입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
     })
-    @PostMapping("/{commentId}/like")
+    @PostMapping("comments/{commentId}/like")
     public ResponseEntity<ApiResponse<Boolean>> toggleLike(
             @PathVariable Long commentId,
             @AuthenticationPrincipal UserDetails userDetails

--- a/src/main/java/com/fmi/domain/commentlike/web/controller/CommentLikeController.java
+++ b/src/main/java/com/fmi/domain/commentlike/web/controller/CommentLikeController.java
@@ -27,7 +27,7 @@ public class CommentLikeController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "COMMENT404-NOT_FOUND: 존재하지 않는 댓글입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
     })
-    @PostMapping("comments/{commentId}/like")
+    @PostMapping("comments/{commentId}/likes")
     public ResponseEntity<ApiResponse<Boolean>> toggleLike(
             @PathVariable Long commentId,
             @AuthenticationPrincipal UserDetails userDetails

--- a/src/main/java/com/fmi/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/fmi/domain/post/converter/PostConverter.java
@@ -147,7 +147,7 @@ public class PostConverter {
                 .build();
     }
 
-    public PostResponse toPostDetailResponse(Post post, boolean isFavorite) {
+    public PostResponse toPostDetailResponse(Post post, boolean isFavorite, Long viewcount) {
 
         List<String> imageUrls = post.getImages() != null ?
                 post.getImages().stream()
@@ -169,6 +169,7 @@ public class PostConverter {
                 .category(post.getCategory())
                 .favoriteCount(post.getFavoriteCount())
                 .favoriteStatus(isFavorite)
+                .viewcount(viewcount)
                 .build();
     }
 
@@ -203,7 +204,6 @@ public class PostConverter {
                 .postId(postId)
                 .viewCount(viewcnt)
                 .build();
-
     }
 
     public FilterResponse toFilterResponse(Slice<Post> slice) {

--- a/src/main/java/com/fmi/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/fmi/domain/post/converter/PostConverter.java
@@ -147,7 +147,7 @@ public class PostConverter {
                 .build();
     }
 
-    public PostResponse toPostDetailResponse(Post post, boolean isFavorite, Long viewcount) {
+    public PostResponse toPostDetailResponse(Post post, boolean isFavorite, Long viewCount) {
 
         List<String> imageUrls = post.getImages() != null ?
                 post.getImages().stream()
@@ -169,7 +169,7 @@ public class PostConverter {
                 .category(post.getCategory())
                 .favoriteCount(post.getFavoriteCount())
                 .favoriteStatus(isFavorite)
-                .viewcount(viewcount)
+                .viewCount(viewCount)
                 .build();
     }
 

--- a/src/main/java/com/fmi/domain/post/response/PostResponse.java
+++ b/src/main/java/com/fmi/domain/post/response/PostResponse.java
@@ -29,5 +29,5 @@ public class PostResponse {
 
     private boolean favoriteStatus;
 
-    private Long viewcount;
+    private Long viewCount;
 }

--- a/src/main/java/com/fmi/domain/post/response/PostResponse.java
+++ b/src/main/java/com/fmi/domain/post/response/PostResponse.java
@@ -29,4 +29,5 @@ public class PostResponse {
 
     private boolean favoriteStatus;
 
+    private Long viewcount;
 }

--- a/src/main/java/com/fmi/domain/post/service/PostService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostService.java
@@ -207,9 +207,38 @@ public class PostService {
 
             isFavorite = favorite != null && favorite.isFavorite();
         }
+        Long viewCount = increaseViewCount(postId, userDetails);
 
+        return postConverter.toPostDetailResponse(post, isFavorite, viewCount);
+    }
 
-        return postConverter.toPostDetailResponse(post, isFavorite);
+    private Long increaseViewCount(Long postId, UserDetails userDetails) {
+
+        if (userDetails == null) {
+            return null;
+        }
+
+        String email = userDetails.getUsername();
+        String viewSetKey = "post:view:set:" + postId;
+        String viewCountKey = "post:view:count:" + postId;
+
+        Long added = stringRedisTemplate.opsForSet().add(viewSetKey, email);
+
+        boolean newViewer = added != null && added > 0;
+
+        if (newViewer) {
+            stringRedisTemplate.opsForValue().increment(viewCountKey);
+        }
+
+        Long ttl = stringRedisTemplate.getExpire(viewSetKey);
+
+        if (ttl == null || ttl < 0) {
+            stringRedisTemplate.expire(viewSetKey, Duration.ofHours(1));
+        }
+
+        return Optional.ofNullable(stringRedisTemplate.opsForValue().get(viewCountKey))
+                .map(Long::parseLong)
+                .orElse(null);
     }
 
     @Transactional
@@ -298,30 +327,6 @@ public class PostService {
         return postConverter.toShareResponse(post);
     }
 
-    public ViewResponse getPostView(Long postId, UserDetails userDetails) {
-
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._POST_NOT_FOUND));
-
-        String email=userDetails.getUsername();
-
-        String viewSetKey = "post:view:set:" + postId;      // 어떤 유저가 조회했는지
-        String viewCountKey = "post:view:count:" + postId;  // 게시글 조회수 누적
-
-        Long added = stringRedisTemplate.opsForSet().add(viewSetKey, email);
-        boolean newViewer = added != null && added > 0;
-        if (newViewer) {
-            stringRedisTemplate.opsForValue().increment(viewCountKey);
-        }
-        stringRedisTemplate.expire(viewSetKey, Duration.ofHours(1));
-
-        Long currentViewCount = Optional.ofNullable(stringRedisTemplate.opsForValue().get(viewCountKey))
-                .map(Long::parseLong)
-                .orElse(post.getViewCnt());
-
-        return postConverter.toViewResponse(postId,currentViewCount);
-
-    }
 
     @Transactional(readOnly = true)
     public FilterResponse getPostsByFilter(PostFilterDto dto, Pageable pageable, Long cursorId) {

--- a/src/main/java/com/fmi/domain/post/service/PostService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostService.java
@@ -219,26 +219,22 @@ public class PostService {
         }
 
         String email = userDetails.getUsername();
-        String viewSetKey = "post:view:set:" + postId;
+        String userCheckKey = "post:view:lock:" + postId + ":" + email;
         String viewCountKey = "post:view:count:" + postId;
+        String changedIdsKey = "post:changed:ids";
 
-        Long added = stringRedisTemplate.opsForSet().add(viewSetKey, email);
+        Boolean isFirstView = stringRedisTemplate.opsForValue()
+                .setIfAbsent(userCheckKey, "y", Duration.ofMinutes(5));
 
-        boolean newViewer = added != null && added > 0;
+        if (Boolean.TRUE.equals(isFirstView)) {
+            Long updatedCount = stringRedisTemplate.opsForValue().increment(viewCountKey);
+            stringRedisTemplate.opsForSet().add(changedIdsKey, postId.toString());
 
-        if (newViewer) {
-            stringRedisTemplate.opsForValue().increment(viewCountKey);
+            return updatedCount;
         }
 
-        Long ttl = stringRedisTemplate.getExpire(viewSetKey);
-
-        if (ttl == null || ttl < 0) {
-            stringRedisTemplate.expire(viewSetKey, Duration.ofHours(1));
-        }
-
-        return Optional.ofNullable(stringRedisTemplate.opsForValue().get(viewCountKey))
-                .map(Long::parseLong)
-                .orElse(null);
+        String currentCount = stringRedisTemplate.opsForValue().get(viewCountKey);
+        return currentCount != null ? Long.parseLong(currentCount) : 0L;
     }
 
     @Transactional

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -26,13 +26,13 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/post")
+@RequestMapping("/posts")
 @Tag(name = "Post", description = "게시글 관련 API")
 public class PostController {
 
     private final PostService postService;
 
-    @PostMapping(value = "/")
+    @PostMapping
     @Operation(summary = "게시글 생성")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 생성 성공"),
@@ -53,7 +53,7 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @GetMapping("/")
+    @GetMapping
     @Operation(summary = "전체 게시글 조회")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
@@ -79,6 +79,8 @@ public class PostController {
     public ResponseEntity<ApiResponse<PostResponse>> getPost(
             @PathVariable Long postId,
             @AuthenticationPrincipal UserDetails userDetails){
+
+
 
         PostResponse post = postService.getPost(postId,userDetails);
         return ResponseEntity.ok(ApiResponse.onSuccess(post));

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -78,8 +78,8 @@ public class PostController {
     })
     public ResponseEntity<ApiResponse<PostResponse>> getPost(
             @PathVariable Long postId,
-            @AuthenticationPrincipal UserDetails userDetails
-    ){
+            @AuthenticationPrincipal UserDetails userDetails){
+
         PostResponse post = postService.getPost(postId,userDetails);
         return ResponseEntity.ok(ApiResponse.onSuccess(post));
     }
@@ -188,22 +188,6 @@ public class PostController {
         PostShareResponse shareResponse = postService.getSharePost(postId);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(shareResponse));
-    }
-
-    @GetMapping("/views/{postId}")
-    @Operation(summary = "게시글 조회수 증가",description = "한 유저당 시간 당 1 조회수로 제한")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회수 증가 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "POST404-NOT_FOUND: 존재하지 않는 게시글입니다"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
-    })
-    public ResponseEntity<ApiResponse<ViewResponse>> getPostView(
-            @PathVariable Long postId,
-            @AuthenticationPrincipal UserDetails userDetails
-    ) {
-        ViewResponse response = postService.getPostView(postId, userDetails);
-
-        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @PostMapping("/filter")

--- a/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
+++ b/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
@@ -17,7 +17,8 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@Tag(name = "Post", description = "게시글 관련 API")
+@RequestMapping("/favorites")
+@Tag(name = "Favorites", description = "즐겨찾기 API")
 public class PostFavoriteController {
 
     private final PostFavoriteService postFavoriteService;
@@ -29,7 +30,7 @@ public class PostFavoriteController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "POST404-NOT_FOUND: 존재하지 않는 게시글입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
     })
-    @PostMapping("/{postId}/favorite")
+    @PostMapping("/{postId}")
     public ResponseEntity<ApiResponse<PostFavoriteResponse>> createFavorite(@PathVariable Long postId,
                                                                             @AuthenticationPrincipal UserDetails userDetails) {
 
@@ -46,7 +47,7 @@ public class PostFavoriteController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "POST404-NOT_FOUND: 존재하지 않는 게시글입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
     })
-    @DeleteMapping("/{postId}/favorite")
+    @DeleteMapping("/{postId}")
     public ResponseEntity<ApiResponse<PostFavoriteResponse>> deleteFavorite(@PathVariable Long postId,
                                                                             @AuthenticationPrincipal UserDetails userDetails) {
 
@@ -62,7 +63,7 @@ public class PostFavoriteController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
     })
-    @GetMapping("/post/favoriteList")
+    @GetMapping("/list")
     public ResponseEntity<ApiResponse<List<PostListResponse>>> getFavoritePost(@AuthenticationPrincipal UserDetails userDetails){
 
         List<PostListResponse> response = postFavoriteService.getFavoritePost(userDetails);

--- a/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
+++ b/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
@@ -17,20 +17,18 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/favorites")
-@Tag(name = "Favorites", description = "즐겨찾기 API")
 public class PostFavoriteController {
 
     private final PostFavoriteService postFavoriteService;
 
-    @Operation(summary = "즐겨찾기 추가",description = "즐겨찾기를 추가합니다.")
+    @Operation(summary = "즐겨찾기 추가",description = "즐겨찾기를 추가합니다.",tags = {"Post"})
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "즐겨찾기 추가 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "POST404-NOT_FOUND: 존재하지 않는 게시글입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
     })
-    @PostMapping("/{postId}")
+    @PostMapping("/posts/{postId}/favorites")
     public ResponseEntity<ApiResponse<PostFavoriteResponse>> createFavorite(@PathVariable Long postId,
                                                                             @AuthenticationPrincipal UserDetails userDetails) {
 
@@ -40,14 +38,14 @@ public class PostFavoriteController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @Operation(summary = "즐겨찾기 삭제",description = "즐겨찾기를 삭제합니다.")
+    @Operation(summary = "즐겨찾기 삭제",description = "즐겨찾기를 삭제합니다.",tags = {"Post"})
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "즐겨찾기 삭제 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "POST404-NOT_FOUND: 존재하지 않는 게시글입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
     })
-    @DeleteMapping("/{postId}")
+    @DeleteMapping("/posts/{postId}/favorites")
     public ResponseEntity<ApiResponse<PostFavoriteResponse>> deleteFavorite(@PathVariable Long postId,
                                                                             @AuthenticationPrincipal UserDetails userDetails) {
 
@@ -63,7 +61,7 @@ public class PostFavoriteController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
     })
-    @GetMapping("/list")
+    @GetMapping("/users/me/favorites")
     public ResponseEntity<ApiResponse<List<PostListResponse>>> getFavoritePost(@AuthenticationPrincipal UserDetails userDetails){
 
         List<PostListResponse> response = postFavoriteService.getFavoritePost(userDetails);


### PR DESCRIPTION
## 🧩 관련 이슈

- close #95 

## 🛠️ 작업 내용

- redis ttl 5분으로 수정
- 스웨거 엔드포인트 수정
- 필터api 로그인 없이도 접근가능

## 📢 참고 및 특이사항

- 현재 레디스로 직접 실시간 조회수를 표현하고있음 -> 추후 디비에 레디스 값을 스케쥴러로 적재해야할듯

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
