### PR TITLE
docs: Swagger 태그 순서 변경 

### DIFF
--- a/src/main/java/com/fmi/config/SwaggerConfig.java
+++ b/src/main/java/com/fmi/config/SwaggerConfig.java
@@ -41,21 +41,19 @@ public class SwaggerConfig {
     @Bean
     public OpenApiCustomizer sortTagsAlphabetically() {
         return openApi -> {
-            if (openApi.getTags() != null) {
-                openApi.getTags().sort(Comparator
-                        .comparingInt((Tag t) -> {
-                            String name = t.getName();
-                            if ("Health".equals(name)) {
-                                return 2;
-                            }
-                            if ("S3".equals(name)) {
-                                return 1;
-                            }
-                            return 0;
-                        })
-                        .thenComparing(Tag::getName)
-                );
-            }
+            List<Tag> tags = openApi.getTags();
+            if (tags == null || tags.isEmpty()) return;
+
+            tags.sort(Comparator
+                    .comparingInt((Tag t) -> {
+                        String name = t.getName();
+                        if ("Auth".equals(name)) return -1;
+                        if ("S3".equals(name)) return 1;
+                        if ("Health".equals(name)) return 2;
+                        return 0;
+                    })
+                    .thenComparing(Tag::getName, String.CASE_INSENSITIVE_ORDER)
+            );
         };
     }
 }

--- a/src/main/java/com/fmi/config/SwaggerConfig.java
+++ b/src/main/java/com/fmi/config/SwaggerConfig.java
@@ -6,9 +6,11 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.tags.Tag;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Configuration
@@ -34,5 +36,26 @@ public class SwaggerConfig {
                         new Tag().name("Report").description("신고 API"),
                         new Tag().name("Notification").description("알림 API")
                 ));
+    }
+
+    @Bean
+    public OpenApiCustomizer sortTagsAlphabetically() {
+        return openApi -> {
+            if (openApi.getTags() != null) {
+                openApi.getTags().sort(Comparator
+                        .comparingInt((Tag t) -> {
+                            String name = t.getName();
+                            if ("Health".equals(name)) {
+                                return 2;
+                            }
+                            if ("S3".equals(name)) {
+                                return 1;
+                            }
+                            return 0;
+                        })
+                        .thenComparing(Tag::getName)
+                );
+            }
+        };
     }
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #116 

## 🛠️ 작업 내용

- Swagger에서 S3, Health 태그를 맨 아래로 이동
- Auth 태그는 맨 위로 이동 
- 나머지는 알파벳순 정렬

## 📢 참고 및 특이사항


## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
