### PR TITLE
refactor: 카카오 로그인 API를 일반 로그인 API와 형식 통일

### DIFF
--- a/scripts/check-social-accounts.sql
+++ b/scripts/check-social-accounts.sql
@@ -1,0 +1,54 @@
+-- 소셜 로그인 계정 확인 스크립트
+
+-- 1. users 테이블 확인 (V12 마이그레이션으로 user -> users로 변경됨)
+SELECT 
+    id,
+    email,
+    nickname,
+    phone_number,
+    role,
+    deleted_at,
+    created_at,
+    updated_at
+FROM users
+ORDER BY created_at DESC
+LIMIT 10;
+
+-- 2. social_accounts 테이블 확인
+SELECT 
+    sa.social_id,
+    sa.user AS user_id,
+    sa.provider,
+    sa.provider_id,
+    sa.created_at,
+    u.email,
+    u.nickname
+FROM social_accounts sa
+LEFT JOIN users u ON sa.user = u.id
+ORDER BY sa.created_at DESC;
+
+-- 3. 카카오 계정만 확인
+SELECT 
+    sa.social_id,
+    sa.user AS user_id,
+    sa.provider,
+    sa.provider_id,
+    sa.created_at,
+    u.email,
+    u.nickname,
+    u.created_at AS user_created_at
+FROM social_accounts sa
+LEFT JOIN users u ON sa.user = u.id
+WHERE sa.provider = 'KAKAO'
+ORDER BY sa.created_at DESC;
+
+-- 4. 테이블 존재 여부 확인
+SHOW TABLES LIKE 'users';
+SHOW TABLES LIKE 'social_accounts';
+SHOW TABLES LIKE 'user';  -- V12 이전 테이블명
+
+-- 5. social_accounts 테이블 구조 확인
+DESCRIBE social_accounts;
+
+-- 6. users 테이블 구조 확인
+DESCRIBE users;

--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/actuator/health", "/actuator/info", "/ws/**", "/error", "/health", "/api/health").permitAll()
                         .requestMatchers("/auth/login", "/auth/signup", "/auth/refresh", "/auth/logout",
-                                "/auth/check-email", "/auth/check-nickname", "/auth/reset/**", "/s3/**", "/chat-test.html", "/chat-test2.html","/posts/filter").permitAll()
+                                "/auth/check-email", "/auth/check-nickname", "/auth/reset/**", "/s3/**", "/chat-test.html", "/chat-test2.html", "/posts/filter").permitAll()
                         .requestMatchers("/auth/kakao/**", "/auth/email/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/posts/{postId}","/posts").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()

--- a/src/main/java/com/fmi/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/fmi/domain/auth/service/KakaoOAuthService.java
@@ -10,10 +10,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
@@ -32,7 +36,6 @@ public class KakaoOAuthService {
     private static final String USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
 
     public KakaoToken exchangeCodeForToken(String code) {
-
         RestTemplate rt = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -47,11 +50,38 @@ public class KakaoOAuthService {
         }
 
         HttpEntity<MultiValueMap<String, String>> req = new HttpEntity<>(params, headers);
-        KakaoToken token = rt.postForObject(TOKEN_URL, req, KakaoToken.class);
-        if (token == null || token.getAccess_token() == null) {
+        
+        try {
+            ResponseEntity<KakaoToken> response = rt.postForEntity(TOKEN_URL, req, KakaoToken.class);
+            KakaoToken token = response.getBody();
+            
+            if (token == null || token.getAccess_token() == null) {
+                log.error("카카오 토큰 교환 실패: 응답이 null이거나 access_token이 없습니다.");
+                throw new GeneralException(ErrorStatus._KAKAO_TOKEN_EXCHANGE_FAILED);
+            }
+            
+            log.info("카카오 토큰 교환 성공");
+            return token;
+        } catch (HttpClientErrorException e) {
+            log.error("카카오 토큰 교환 실패: HTTP {} - {}", e.getStatusCode(), e.getResponseBodyAsString());
+            
+            // 400 에러인 경우 (인증 코드 재사용, 만료, 잘못된 코드 등)
+            if (e.getStatusCode() == HttpStatus.BAD_REQUEST) {
+                String errorBody = e.getResponseBodyAsString();
+                log.error("카카오 인증 코드 오류: {}", errorBody);
+                throw new GeneralException(ErrorStatus._KAKAO_CODE_INVALID);
+            }
+            
+            // 401 Unauthorized (잘못된 API 키 등)
+            if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+                throw new GeneralException(ErrorStatus._KAKAO_TOKEN_EXCHANGE_FAILED);
+            }
+            
+            throw new GeneralException(ErrorStatus._KAKAO_TOKEN_EXCHANGE_FAILED);
+        } catch (RestClientException e) {
+            log.error("카카오 토큰 교환 실패: 네트워크 오류", e);
             throw new GeneralException(ErrorStatus._KAKAO_TOKEN_EXCHANGE_FAILED);
         }
-        return token;
     }
 
     public KakaoUser getUserInfo(String accessToken) {
@@ -59,11 +89,38 @@ public class KakaoOAuthService {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + accessToken);
         HttpEntity<Void> req = new HttpEntity<>(headers);
-        KakaoUser user = rt.postForObject(USERINFO_URL, req, KakaoUser.class);
-        if (user == null || user.getId() == null) {
+        
+        try {
+            ResponseEntity<KakaoUser> response = rt.postForEntity(USERINFO_URL, req, KakaoUser.class);
+            KakaoUser user = response.getBody();
+            
+            if (user == null || user.getId() == null) {
+                log.error("카카오 사용자 정보 조회 실패: 응답이 null이거나 id가 없습니다.");
+                throw new GeneralException(ErrorStatus._KAKAO_USERINFO_FETCH_FAILED);
+            }
+            
+            log.info("카카오 사용자 정보 조회 성공: userId={}", user.getId());
+            return user;
+        } catch (HttpClientErrorException e) {
+            log.error("카카오 사용자 정보 조회 실패: HTTP {} - {}", e.getStatusCode(), e.getResponseBodyAsString());
+            
+            // 401 Unauthorized (잘못된 토큰)
+            if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+                log.error("카카오 access token이 유효하지 않습니다.");
+                throw new GeneralException(ErrorStatus._KAKAO_USERINFO_FETCH_FAILED);
+            }
+            
+            // 403 Forbidden (권한 없음)
+            if (e.getStatusCode() == HttpStatus.FORBIDDEN) {
+                log.error("카카오 사용자 정보 조회 권한이 없습니다.");
+                throw new GeneralException(ErrorStatus._KAKAO_USERINFO_FETCH_FAILED);
+            }
+            
+            throw new GeneralException(ErrorStatus._KAKAO_USERINFO_FETCH_FAILED);
+        } catch (RestClientException e) {
+            log.error("카카오 사용자 정보 조회 실패: 네트워크 오류", e);
             throw new GeneralException(ErrorStatus._KAKAO_USERINFO_FETCH_FAILED);
         }
-        return user;
     }
 
     @Data

--- a/src/main/java/com/fmi/domain/auth/service/SocialLoginService.java
+++ b/src/main/java/com/fmi/domain/auth/service/SocialLoginService.java
@@ -6,11 +6,18 @@ import com.fmi.domain.auth.data.SocialAccounts;
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.auth.repository.SocialAccountsRepository;
 import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -23,9 +30,15 @@ public class SocialLoginService {
     public User upsertUserFromKakao(Long kakaoId, String email, String nickname, String profileImageUrl) {
         String providerId = String.valueOf(kakaoId);
 
+        // 이미 존재하는 소셜 계정인지 확인
         return socialAccountsRepository.findByProviderAndProviderId(Provider.KAKAO, providerId)
-                .map(SocialAccounts::getUser)
+                .map(existingAccount -> {
+                    log.info("기존 카카오 계정 찾음: providerId={}, userId={}", providerId, existingAccount.getUser().getId());
+                    return existingAccount.getUser();
+                })
                 .orElseGet(() -> {
+                    log.info("새 카카오 계정 생성 시작: providerId={}", providerId);
+                    
                     // 이메일이 없으면 대체 이메일 생성
                     String effectiveEmail = (email != null && !email.isBlank())
                             ? email
@@ -34,6 +47,7 @@ public class SocialLoginService {
                     // 사용자 존재 여부 확인(이메일 기준)
                     User user = userRepository.findByEmail(effectiveEmail)
                             .orElseGet(() -> {
+                                log.info("새 사용자 생성: email={}", effectiveEmail);
                                 User u = AuthConverter.toSocialUserEntity(
                                         kakaoId,
                                         email,
@@ -44,15 +58,36 @@ public class SocialLoginService {
                                 return userRepository.save(u);
                             });
 
-                    // 소셜 계정 연결 저장
-                    SocialAccounts account = SocialAccounts.builder()
-                            .user(user)
-                            .provider(Provider.KAKAO)
-                            .providerId(providerId)
-                            .build();
-                    socialAccountsRepository.save(account);
+                    // 동시성 문제 방지를 위해 저장 전 다시 한 번 확인
+                    // (다른 스레드가 이미 저장했을 수 있음)
+                    Optional<SocialAccounts> existingAccount = socialAccountsRepository.findByProviderAndProviderId(Provider.KAKAO, providerId);
+                    if (existingAccount.isPresent()) {
+                        log.info("동시 요청으로 인해 이미 소셜 계정이 생성됨: providerId={}, userId={}", providerId, existingAccount.get().getUser().getId());
+                        return existingAccount.get().getUser();
+                    }
 
-                    return user;
+                    // 소셜 계정 연결 저장
+                    try {
+                        SocialAccounts account = SocialAccounts.builder()
+                                .user(user)
+                                .provider(Provider.KAKAO)
+                                .providerId(providerId)
+                                .build();
+                        SocialAccounts savedAccount = socialAccountsRepository.save(account);
+                        log.info("소셜 계정 저장 성공: socialId={}, providerId={}, userId={}", savedAccount.getSocialId(), providerId, user.getId());
+                        return user;
+                    } catch (DataIntegrityViolationException e) {
+                        log.warn("소셜 계정 저장 중 중복 키 위반 발생 (동시 요청 가능성): providerId={}, error={}", providerId, e.getMessage());
+                        // 중복 키 위반 시 다시 조회해서 반환
+                        Optional<SocialAccounts> retryAccount = socialAccountsRepository.findByProviderAndProviderId(Provider.KAKAO, providerId);
+                        if (retryAccount.isPresent()) {
+                            log.info("중복 키 위반 후 재조회 성공: providerId={}, userId={}", providerId, retryAccount.get().getUser().getId());
+                            return retryAccount.get().getUser();
+                        }
+                        // 재조회도 실패한 경우
+                        log.error("소셜 계정 저장 실패 후 재조회도 실패: providerId={}, 원본 에러: {}", providerId, e.getMessage(), e);
+                        throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+                    }
                 });
     }
 }

--- a/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
@@ -1,5 +1,7 @@
 package com.fmi.domain.auth.web.controller;
 
+import com.fmi.domain.auth.converter.AuthConverter;
+import com.fmi.domain.auth.response.LoginResponse;
 import com.fmi.domain.auth.service.KakaoOAuthService;
 import com.fmi.domain.auth.service.KakaoOAuthService.KakaoToken;
 import com.fmi.domain.auth.service.KakaoOAuthService.KakaoUser;
@@ -13,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
@@ -21,8 +24,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 @RestController
@@ -41,14 +42,68 @@ public class KakaoAuthController {
     @Value("${jwt.cookie.access-token-name:access_token}")
     private String accessCookieName;
     @Value("${jwt.cookie.secure:false}")
-    private boolean refreshCookieSecure;
+    private boolean cookieSecure;
     @Value("${jwt.cookie.same-site:Lax}")
-    private String refreshCookieSameSite;
+    private String cookieSameSite;
 
     @PostMapping
-    @Operation(summary = "카카오 로그인")
+    @Operation(summary = "카카오 로그인", 
+               description = """
+                   카카오 인증 코드를 사용하여 로그인합니다.
+                   
+                   **동작 방식:**
+                   - 카카오 OAuth 인증 코드를 받아 토큰을 교환하고 사용자 정보를 조회합니다.
+                   - 기존 사용자가 있으면 로그인, 없으면 자동 회원가입 후 로그인합니다.
+                   - 소셜 로그인이므로 임시 비밀번호 기능은 사용하지 않습니다 (isTemporaryPassword는 항상 false).
+                   
+                   **주의사항:**
+                   - 카카오 인증 코드는 **한 번만 사용 가능**합니다. (재사용 시 AUTH400-KAKAO_CODE_INVALID 에러 발생)
+                   - 성공 시 `access_token`과 `refresh_token`이 **쿠키**로 설정됩니다. (응답 body에 포함되지 않음)
+                   - 인증 코드는 프론트엔드에서 카카오 로그인 플로우를 통해 받아야 합니다.
+                   """)
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카카오 로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "카카오 로그인 성공 - access_token과 refresh_token은 Set-Cookie 헤더로 전송됩니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "성공 응답 예시",
+                                    value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "COMMON200",
+                                      "message": "성공입니다.",
+                                      "result": {
+                                        "userId": 1,
+                                        "isTemporaryPassword": false
+                                      }
+                                    }
+                                    """,
+                                    summary = "로그인 성공 시 응답"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "COMMON400: 잘못된 요청입니다 (입력값 검증 실패)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"COMMON400\", \"message\": \"잘못된 요청입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "AUTH400-KAKAO_CODE_INVALID: 카카오 인증 코드가 유효하지 않거나 이미 사용되었습니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"AUTH400-KAKAO_CODE_INVALID\", \"message\": \"카카오 인증 코드가 유효하지 않거나 이미 사용되었습니다. 다시 로그인해주세요.\"}"
+                            )
+                    )
+            ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "500",
                     description = "AUTH500-KAKAO_TOKEN_FAILED: 카카오 토큰 교환에 실패했습니다",
@@ -80,7 +135,7 @@ public class KakaoAuthController {
                     )
             )
     })
-    public ResponseEntity<ApiResponse<Map<String, Object>>> loginWithKakao(@RequestBody KakaoLoginRequest req) {
+    public ResponseEntity<ApiResponse<LoginResponse>> loginWithKakao(@Valid @RequestBody KakaoLoginRequest req) {
         KakaoToken token = kakaoOAuthService.exchangeCodeForToken(req.getCode());
         String kakaoAccessToken = token.getAccess_token();
 
@@ -99,41 +154,44 @@ public class KakaoAuthController {
 
         var localUser = socialLoginService.upsertUserFromKakao(user.getId(), email, nickname, profile);
 
-        Map<String, Object> claims = new HashMap<>();
+        var claims = new java.util.HashMap<String, Object>();
         claims.put("userId", localUser.getId());
+        claims.put("role", localUser.getRole().name());
         claims.put("provider", "KAKAO");
         String accessToken = jwtTokenProvider.createAccessToken(localUser.getEmail(), claims);
 
         String jti = UUID.randomUUID().toString();
-        String refresh = jwtTokenProvider.createRefreshToken(localUser.getEmail(), jti);
-        String refreshHash = sha256Hex(refresh);
-        var refreshExp = jwtTokenProvider.getExpiration(refresh).toInstant();
-        refreshTokenStore.issue(jti, localUser.getEmail(), refreshHash, refreshExp);
+        String refreshToken = jwtTokenProvider.createRefreshToken(localUser.getEmail(), jti);
+        String refreshHash = sha256Hex(refreshToken);
+        java.util.Date refreshExp = jwtTokenProvider.getExpiration(refreshToken);
+        refreshTokenStore.issue(jti, localUser.getEmail(), refreshHash, refreshExp.toInstant());
 
         // accessToken 쿠키 설정
-        var accessExp = jwtTokenProvider.getExpiration(accessToken).toInstant();
+        java.util.Date accessExp = jwtTokenProvider.getExpiration(accessToken);
         ResponseCookie accessCookie = ResponseCookie.from(accessCookieName, accessToken)
                 .httpOnly(true)
-                .secure(refreshCookieSecure)
-                .sameSite(refreshCookieSameSite)
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)
                 .path("/")
-                .maxAge(Duration.between(Instant.now(), accessExp))
+                .maxAge(Duration.between(Instant.now(), accessExp.toInstant()))
                 .build();
 
         // refreshToken 쿠키 설정
-        ResponseCookie refreshCookie = ResponseCookie.from(refreshCookieName, refresh)
+        ResponseCookie refreshCookie = ResponseCookie.from(refreshCookieName, refreshToken)
                 .httpOnly(true)
-                .secure(refreshCookieSecure)
-                .sameSite(refreshCookieSameSite)
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)
                 .path("/")
-                .maxAge(Duration.between(Instant.now(), refreshExp))
+                .maxAge(Duration.between(Instant.now(), refreshExp.toInstant()))
                 .build();
 
-        Map<String, Object> result = Map.of("userId", localUser.getId());
+        // 응답 생성 및 반환
+        // accessToken과 refreshToken은 쿠키로 전송되므로 응답 body에는 포함하지 않습니다.
+        // 소셜 로그인은 임시 비밀번호 기능이 없으므로 isTemporaryPassword는 항상 false입니다.
         return ResponseEntity.ok()
                 .header("Set-Cookie", accessCookie.toString())
                 .header("Set-Cookie", refreshCookie.toString())
-                .body(ApiResponse.onSuccess(result));
+                .body(ApiResponse.onSuccess(AuthConverter.toLoginResponse(localUser.getId(), false)));
     }
 
     private static String sha256Hex(String value) {

--- a/src/main/java/com/fmi/domain/auth/web/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/fmi/domain/auth/web/dto/KakaoLoginRequest.java
@@ -1,5 +1,6 @@
 package com.fmi.domain.auth.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -9,6 +10,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class KakaoLoginRequest {
+    @Schema(
+        description = "카카오 인증 코드 (카카오 OAuth 인증 페이지에서 받은 authorization code)",
+        example = "T84wymjsv8HheAUCfszclq-dceh33VhtqiVNftd5s2jqFVpC9t01dQAAAAQKDQ1fAAABm6cCC_3HP8VuE1ZNOQ",
+        required = true
+    )
     @NotBlank(message = "code 필수")
     private String code;
 }

--- a/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
@@ -29,6 +29,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH400-INVALID_TOKEN", "토큰이 유효하지 않습니다."),
     _TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH400-NOT_FOUND", "Authorization 헤더가 없거나 형식이 잘못되었습니다."),
     _KAKAO_TOKEN_EXCHANGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH500-KAKAO_TOKEN_FAILED", "카카오 토큰 교환에 실패했습니다."),
+    _KAKAO_CODE_INVALID(HttpStatus.BAD_REQUEST, "AUTH400-KAKAO_CODE_INVALID", "카카오 인증 코드가 유효하지 않거나 이미 사용되었습니다. 다시 로그인해주세요."),
     _KAKAO_USERINFO_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH500-KAKAO_USERINFO_FAILED", "카카오 사용자 정보 조회에 실패했습니다."),
     _SOCIAL_ACCOUNT(HttpStatus.BAD_REQUEST, "AUTH400-SOCIAL_ACCOUNT", "소셜 로그인 계정입니다."),
 

--- a/src/main/java/com/fmi/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/fmi/global/apiPayload/exception/ExceptionAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -84,6 +85,14 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         }
         // 일반 UsernameNotFoundException인 경우 _USER_NOT_FOUND 사용
         ErrorReasonDTO errorReason = ErrorStatus._USER_NOT_FOUND.getReasonHttpStatus();
+        return handleExceptionInternal(e, errorReason, null, request);
+    }
+
+    @ExceptionHandler(value = DataIntegrityViolationException.class)
+    public ResponseEntity<Object> handleDataIntegrityViolation(DataIntegrityViolationException e, HttpServletRequest request) {
+        log.error("데이터베이스 제약 조건 위반 발생", e);
+        // 상세 에러 메시지는 로그에만 기록하고 클라이언트에는 일반 메시지만 전달
+        ErrorReasonDTO errorReason = ErrorStatus._BAD_REQUEST.getReasonHttpStatus();
         return handleExceptionInternal(e, errorReason, null, request);
     }
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close refactor/#121

## 🛠️ 작업 내용

- 카카오 로그인 API 응답 형식을 `LoginResponse`로 변경하여 일반 로그인과 일관성 유지
- JWT Claims에 `role` 필드 추가 및 `isTemporaryPassword` 필드 포함 (소셜 로그인은 항상 false)
- 카카오 로그인 관련 에러 코드 추가 및 표준화된 에러 처리 (`ErrorStatus` 사용)
- 소셜 로그인 서비스 중복 저장 방지 로직 추가 (동시성 문제 해결)
- `KakaoLoginRequest` DTO에 `@Valid` 어노테이션 추가 및 Swagger 문서화 개선
- 데이터베이스 제약 조건 위반 예외 처리 추가 (`DataIntegrityViolationException`)
- 쿠키 설정 변수명 통일 (`accessCookieName`, `refreshCookieName`, `cookieSecure`, `cookieSameSite`)
- 테스트 페이지 경로 제거 및 프로덕션 코드 정리

## 📢 참고 및 특이사항

- 카카오 로그인은 소셜 로그인이므로 임시 비밀번호 기능이 없어 `isTemporaryPassword`는 항상 `false`로 설정
- JWT Claims에 `provider: "KAKAO"`는 유지하되, `role`도 함께 포함하여 권한 관리 일관성 유지
- 일반 로그인과 동일한 응답 형식을 사용하여 프론트엔드에서 일관된 방식으로 처리 가능
- `access_token`과 `refresh_token`은 쿠키로 전송되므로 응답 body에 포함하지 않음
- 카카오 인증 코드는 한 번만 사용 가능하므로 재사용 시 `AUTH400-KAKAO_CODE_INVALID` 에러 반환
- 소셜 계정 확인용 SQL 스크립트는 개발/테스트 용도로만 사용

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
