### PR TITLE
refactor: 알림 설정 변경 API를 모든 알림 타입 변경 가능하도록 확장

### DIFF
--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -1,23 +1,33 @@
 package com.fmi.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.security.CustomUserDetailsService;
 import com.fmi.security.JwtAuthenticationFilter;
 import com.fmi.security.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 @Configuration
@@ -41,11 +51,39 @@ public class SecurityConfig {
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint())
+                )
                 .httpBasic(h -> h.disable());
 
         http.addFilterBefore(new JwtAuthenticationFilter(tokenProvider, userDetailsService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    /**
+     * 인증 실패 시 프로젝트 표준 ApiResponse 형식으로 응답
+     */
+    @Bean
+    public AuthenticationEntryPoint customAuthenticationEntryPoint() {
+        return new AuthenticationEntryPoint() {
+            private final ObjectMapper objectMapper = new ObjectMapper();
+
+            @Override
+            public void commence(HttpServletRequest request, HttpServletResponse response,
+                                 AuthenticationException authException) throws IOException {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
+
+                ApiResponse<Object> apiResponse = ApiResponse.onFailure(
+                        ErrorStatus._UNAUTHORIZED.getReasonHttpStatus().getCode(),
+                        ErrorStatus._UNAUTHORIZED.getReasonHttpStatus().getMessage(),
+                        null
+                );
+
+                objectMapper.writeValue(response.getWriter(), apiResponse);
+            }
+        };
     }
 
     @Bean

--- a/src/main/java/com/fmi/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/fmi/domain/notification/converter/NotificationConverter.java
@@ -22,7 +22,7 @@ public class NotificationConverter {
                 .build();
     }
     
-    public NotificationSettingsDTO toSettingsDTO(NotificationSettings settings) {
+    public NotificationSettingsDTO toSettingsDTO(NotificationSettings settings, com.fmi.domain.auth.data.User user) {
         return NotificationSettingsDTO.builder()
                 .commentEnabled(settings.getCommentEnabled())
                 .chatEnabled(settings.getChatEnabled())
@@ -31,6 +31,7 @@ public class NotificationConverter {
                 .favoriteEnabled(settings.getFavoriteEnabled())
                 .noticeEnabled(settings.getNoticeEnabled())
                 .categoryEnabled(settings.getCategoryEnabled())
+                .marketingConsent(user.isMarketingConsent())
                 .build();
     }
 }

--- a/src/main/java/com/fmi/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fmi/domain/notification/service/NotificationService.java
@@ -153,7 +153,11 @@ public class NotificationService {
         NotificationSettings settings = notificationSettingsRepository.findByUser(user)
                 .orElseGet(() -> createDefaultSettings(user));
         
-        return notificationConverter.toSettingsDTO(settings);
+        // User 엔티티를 최신 상태로 조회 (marketingConsent 포함)
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+        
+        return notificationConverter.toSettingsDTO(settings, freshUser);
     }
     
     /**
@@ -161,9 +165,14 @@ public class NotificationService {
      */
     @Transactional
     public NotificationSettingsDTO updateSettings(User user, NotificationSettingsUpdateDTO request) {
-        NotificationSettings settings = notificationSettingsRepository.findByUser(user)
-                .orElseGet(() -> createDefaultSettings(user));
+        // User 엔티티를 최신 상태로 조회
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         
+        NotificationSettings settings = notificationSettingsRepository.findByUser(freshUser)
+                .orElseGet(() -> createDefaultSettings(freshUser));
+        
+        // NotificationSettings 업데이트
         settings.updateSettings(
                 request.getCommentEnabled(),
                 request.getChatEnabled(),
@@ -175,19 +184,32 @@ public class NotificationService {
         );
         
         NotificationSettings saved = notificationSettingsRepository.save(settings);
-        return notificationConverter.toSettingsDTO(saved);
+        
+        // User.marketingConsent 업데이트 (요청에 값이 있는 경우에만)
+        if (request.getMarketingConsent() != null) {
+            freshUser.setMarketingConsent(request.getMarketingConsent());
+            userRepository.save(freshUser);
+        }
+        
+        return notificationConverter.toSettingsDTO(saved, freshUser);
     }
 
     /**
      * 댓글/채팅/카테고리 설정만 부분 업데이트
+     * @deprecated 모든 알림 타입을 변경할 수 있는 updateSettings() 사용 권장
      */
+    @Deprecated
     @Transactional
     public NotificationSettingsDTO updateBasicSettings(User user, Boolean commentEnabled, Boolean chatEnabled, Boolean categoryEnabled) {
-        NotificationSettings settings = notificationSettingsRepository.findByUser(user)
-                .orElseGet(() -> createDefaultSettings(user));
+        // User 엔티티를 최신 상태로 조회
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+        
+        NotificationSettings settings = notificationSettingsRepository.findByUser(freshUser)
+                .orElseGet(() -> createDefaultSettings(freshUser));
         settings.updateSettings(commentEnabled, chatEnabled, null, null, null, null, categoryEnabled);
         NotificationSettings saved = notificationSettingsRepository.save(settings);
-        return notificationConverter.toSettingsDTO(saved);
+        return notificationConverter.toSettingsDTO(saved, freshUser);
     }
     
     /**

--- a/src/main/java/com/fmi/domain/notification/web/controller/NotificationController.java
+++ b/src/main/java/com/fmi/domain/notification/web/controller/NotificationController.java
@@ -68,11 +68,13 @@ public class NotificationController {
     }
     
     /**
-     * 알림 설정 변경(댓글/채팅/카테고리만 변경 가능)
-     * PUT /notification/settings
+     * 알림 설정 변경 (모든 알림 타입 변경 가능)
+     * PUT /notifications/settings
      */
     @PutMapping("/settings")
-    @Operation(summary = "알림 설정 변경", description = "댓글, 채팅, 카테고리 설정만 변경 가능합니다.")
+    @Operation(summary = "알림 설정 변경", 
+               description = "모든 알림 타입을 개별적으로 설정/해제할 수 있습니다. " +
+                           "지원 필드: 댓글, 채팅, 즐겨찾기, 1:1문의 답변, 신고 처리 결과, 공지사항, 카테고리, 마케팅 이메일 수신 동의")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 설정 변경 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -108,25 +110,9 @@ public class NotificationController {
     })
     public ApiResponse<NotificationSettingsDTO> updateSettings(
             @AuthenticationPrincipal User user,
-            @RequestBody BasicSettingsRequest request) {
-        NotificationSettingsDTO settings = notificationService.updateBasicSettings(user,
-                request.getCommentEnabled(), request.getChatEnabled(), request.getCategoryEnabled());
+            @RequestBody com.fmi.domain.notification.web.dto.request.NotificationSettingsUpdateDTO request) {
+        NotificationSettingsDTO settings = notificationService.updateSettings(user, request);
         return ApiResponse.onSuccess(settings);
-    }
-
-    // 통합으로 대체: PATCH /notification/settings/basic 제거
-
-    public static class BasicSettingsRequest {
-        private Boolean commentEnabled;
-        private Boolean chatEnabled;
-        private Boolean categoryEnabled;
-
-        public Boolean getCommentEnabled() { return commentEnabled; }
-        public void setCommentEnabled(Boolean commentEnabled) { this.commentEnabled = commentEnabled; }
-        public Boolean getChatEnabled() { return chatEnabled; }
-        public void setChatEnabled(Boolean chatEnabled) { this.chatEnabled = chatEnabled; }
-        public Boolean getCategoryEnabled() { return categoryEnabled; }
-        public void setCategoryEnabled(Boolean categoryEnabled) { this.categoryEnabled = categoryEnabled; }
     }
 
     /**

--- a/src/main/java/com/fmi/domain/notification/web/dto/request/NotificationSettingsUpdateDTO.java
+++ b/src/main/java/com/fmi/domain/notification/web/dto/request/NotificationSettingsUpdateDTO.java
@@ -15,5 +15,6 @@ public class NotificationSettingsUpdateDTO {
     private Boolean favoriteEnabled;         // 좋아요 알림
     private Boolean noticeEnabled;           // 공지사항 알림
     private Boolean categoryEnabled;         // 카테고리 알림
+    private Boolean marketingConsent;        // 마케팅 이메일 수신 동의
 }
 

--- a/src/main/java/com/fmi/domain/notification/web/dto/response/NotificationSettingsDTO.java
+++ b/src/main/java/com/fmi/domain/notification/web/dto/response/NotificationSettingsDTO.java
@@ -17,5 +17,6 @@ public class NotificationSettingsDTO {
     private Boolean favoriteEnabled;         // 좋아요 알림
     private Boolean noticeEnabled;           // 공지사항 알림
     private Boolean categoryEnabled;         // 카테고리 알림
+    private Boolean marketingConsent;        // 마케팅 이메일 수신 동의
 }
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close refactor/#125

## 🛠️ 작업 내용

- 알림 설정 변경 API를 모든 알림 타입 변경 가능하도록 확장

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
