### PR TITLE
refactor: 문의 API를 1:1 개인 문의만 사용하도록 제한 및 불필요한 필드 제거

### DIFF
--- a/src/main/java/com/fmi/domain/admin/dto/AdminInquiryResponse.java
+++ b/src/main/java/com/fmi/domain/admin/dto/AdminInquiryResponse.java
@@ -21,7 +21,6 @@ public class AdminInquiryResponse {
     private InquiryType inquiryType;
     private InquiryCategory category;
     private InquiryStatus status;
-    private Boolean hasReply;
     private LocalDateTime createdAt;
 
     private Long userId;

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -66,7 +66,6 @@ public class AdminService {
                 .inquiryType(inquiry.getInquiryType())
                 .category(inquiry.getCategory())
                 .status(inquiry.getAnswerStatus())
-                .hasReply(inquiryReplyRepository.existsByInquiry(inquiry))
                 .createdAt(inquiry.getCreatedAt())
                 .userId(inquiry.getUser() != null ? inquiry.getUser().getId() : null)
                 .userNickname(inquiry.getUser() != null ? inquiry.getUser().getNickname() : null)

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -184,6 +184,27 @@ public class AdminController {
         return ApiResponse.onSuccess(replyId);
     }
 
+    @PutMapping("/inquiries/{inquiryId}/status")
+    @Operation(summary = "문의 처리 상태 변경(관리자)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "문의 처리 상태 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "INQUIRY404-NOT_FOUND: 존재하지 않는 문의입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"INQUIRY404-NOT_FOUND\", \"message\": \"존재하지 않는 문의입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ApiResponse<String> updateInquiryStatus(@PathVariable Long inquiryId,
+                                                   @RequestBody com.fmi.domain.inquiry.web.dto.request.InquiryStatusUpdateRequestDTO request) {
+        inquiryService.updateStatus(inquiryId, request.getStatus());
+        return ApiResponse.onSuccess("OK");
+    }
+
     @PutMapping("/reports/{reportId}/status")
     @Operation(summary = "신고 처리 상태 변경(관리자)")
     @ApiResponses({

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -200,7 +200,7 @@ public class AdminController {
             )
     })
     public ApiResponse<String> updateInquiryStatus(@PathVariable Long inquiryId,
-                                                   @RequestBody com.fmi.domain.inquiry.web.dto.request.InquiryStatusUpdateRequestDTO request) {
+                                                   @Valid @RequestBody com.fmi.domain.inquiry.web.dto.request.InquiryStatusUpdateRequestDTO request) {
         inquiryService.updateStatus(inquiryId, request.getStatus());
         return ApiResponse.onSuccess("OK");
     }
@@ -221,7 +221,7 @@ public class AdminController {
             )
     })
     public ApiResponse<String> updateReportStatus(@PathVariable Long reportId,
-                                                  @RequestBody ReportStatusUpdateRequestDTO request) {
+                                                  @Valid @RequestBody ReportStatusUpdateRequestDTO request) {
         reportService.updateStatus(reportId, request.getStatus(), request.getAdminNote());
         return ApiResponse.onSuccess("OK");
     }

--- a/src/main/java/com/fmi/domain/inquiry/converter/InquiryConverter.java
+++ b/src/main/java/com/fmi/domain/inquiry/converter/InquiryConverter.java
@@ -10,40 +10,26 @@ import org.springframework.stereotype.Component;
 @Component
 public class InquiryConverter {
     
-    public InquiryListDTO toListDTO(Inquiry inquiry, boolean hasReply) {
-        String authorNickname = inquiry.getUser() != null 
-                ? inquiry.getUser().getNickname() 
-                : "익명";
-        
+    public InquiryListDTO toListDTO(Inquiry inquiry) {
         return InquiryListDTO.builder()
                 .inquiryId(inquiry.getId())
                 .title(inquiry.getTitle())
-                .inquiryType(inquiry.getInquiryType())
                 .category(inquiry.getCategory())
                 .status(inquiry.getAnswerStatus())
-                .authorNickname(authorNickname)
-                .hasReply(hasReply)
                 .createdAt(inquiry.getCreatedAt())
                 .build();
     }
     
     public InquiryDetailDTO toDetailDTO(Inquiry inquiry, InquiryReply reply) {
-        String authorNickname = inquiry.getUser() != null 
-                ? inquiry.getUser().getNickname() 
-                : "익명";
-        
         InquiryReplyDTO replyDTO = reply != null ? toReplyDTO(reply) : null;
         
         return InquiryDetailDTO.builder()
                 .inquiryId(inquiry.getId())
                 .title(inquiry.getTitle())
                 .content(inquiry.getContent())
-                .inquiryType(inquiry.getInquiryType())
                 .category(inquiry.getCategory())
                 .status(inquiry.getAnswerStatus())
-                .authorNickname(authorNickname)
                 .createdAt(inquiry.getCreatedAt())
-                .updatedAt(inquiry.getUpdatedAt())
                 .reply(replyDTO)
                 .build();
     }

--- a/src/main/java/com/fmi/domain/inquiry/data/Inquiry.java
+++ b/src/main/java/com/fmi/domain/inquiry/data/Inquiry.java
@@ -71,5 +71,9 @@ public class Inquiry {
     public void markAsPending() {
         this.answerStatus = InquiryStatus.PENDING;
     }
+    
+    public void markAsReceived() {
+        this.answerStatus = InquiryStatus.RECEIVED;
+    }
 }
 

--- a/src/main/java/com/fmi/domain/inquiry/data/enums/InquiryType.java
+++ b/src/main/java/com/fmi/domain/inquiry/data/enums/InquiryType.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 
 @Getter
 public enum InquiryType {
-    PUBLIC("전체 공개 문의"),
     PRIVATE("1:1 개인 문의");
 
     private final String description;

--- a/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
@@ -8,8 +8,6 @@ import com.fmi.domain.inquiry.data.enums.InquiryStatus;
 import com.fmi.domain.inquiry.data.enums.InquiryType;
 import com.fmi.domain.inquiry.repository.InquiryReplyRepository;
 import com.fmi.domain.inquiry.repository.InquiryRepository;
-import com.fmi.domain.inquiry.web.dto.request.InquiryPrivateRequestDTO;
-import com.fmi.domain.inquiry.web.dto.request.InquiryPublicRequestDTO;
 import com.fmi.domain.inquiry.web.dto.request.InquiryCreateRequestDTO;
 import com.fmi.domain.inquiry.web.dto.response.InquiryDetailDTO;
 import com.fmi.domain.inquiry.web.dto.response.InquiryListDTO;
@@ -38,70 +36,20 @@ public class InquiryService {
     private final EmailService emailService;
     
     /**
-     * 공개 문의 작성
-     */
-    @Transactional
-    public Long createPublicInquiry(InquiryPublicRequestDTO request, User user) {
-        Inquiry inquiry = Inquiry.builder()
-                .user(user)  // 비회원인 경우 null
-                .title(request.getTitle())
-                .content(request.getContent())
-                .category(request.getCategory())
-                .inquiryType(InquiryType.PUBLIC)
-                .email(request.getEmail())  // 비회원용 이메일
-                .build();
-        
-        Inquiry saved = inquiryRepository.save(inquiry);
-        return saved.getId();
-    }
-    
-    /**
-     * 1:1 개인 문의 작성
-     */
-    @Transactional
-    public Long createPrivateInquiry(InquiryPrivateRequestDTO request, User user) {
-        Inquiry inquiry = Inquiry.builder()
-                .user(user)
-                .title(request.getTitle())
-                .content(request.getContent())
-                .category(request.getCategory())
-                .inquiryType(InquiryType.PRIVATE)
-                .build();
-        
-        Inquiry saved = inquiryRepository.save(inquiry);
-        return saved.getId();
-    }
-
-    /**
-     * 단일 엔드포인트: 문의 생성 (PUBLIC/PRIVATE)
+     * 1:1 개인 문의 생성
      */
     @Transactional
     public Long createInquiry(InquiryCreateRequestDTO request, User user) {
-        InquiryType type = request.getInquiryType();
-        if (type == null) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST);
-        }
         Inquiry.InquiryBuilder builder = Inquiry.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
                 .category(request.getCategory())
-                .inquiryType(type);
+                .inquiryType(InquiryType.PRIVATE)  // 항상 1:1 개인 문의로 설정
+                .user(user);
 
-        if (type == InquiryType.PUBLIC) {
-            // 공개 문의: 회원만 가능 + email 필수
-            if (user == null) {
-                throw new GeneralException(ErrorStatus._INQUIRY_ACCESS_DENIED);
-            }
-            if (request.getEmail() == null || request.getEmail().isBlank()) {
-                throw new GeneralException(ErrorStatus._BAD_REQUEST);
-            }
-            builder.user(user).email(request.getEmail());
-        } else {
-            // 1:1 문의: 비회원도 가능 (email은 정책에 따라 선택)
-            builder.user(user);
-            if (user == null && request.getEmail() != null && !request.getEmail().isBlank()) {
-                builder.email(request.getEmail());
-            }
+        // 비회원 문의인 경우 이메일 설정
+        if (user == null && request.getEmail() != null && !request.getEmail().isBlank()) {
+            builder.email(request.getEmail());
         }
 
         Inquiry saved = inquiryRepository.save(builder.build());
@@ -147,6 +95,9 @@ public class InquiryService {
                 .build();
 
         InquiryReply saved = inquiryReplyRepository.save(reply);
+        
+        // 답변 추가 시 문의 상태를 ANSWERED로 변경
+        inquiry.markAsAnswered();
 
         // 회원 문의인 경우에만 알림 및 이메일 발송
         if (inquiry.getUser() != null) {
@@ -202,33 +153,12 @@ public class InquiryService {
     }
     
     /**
-     * 공개 문의 목록 조회
-     */
-    public Page<InquiryListDTO> getPublicInquiryList(InquiryCategory category, InquiryStatus status, Pageable pageable) {
-        Page<Inquiry> inquiries;
-        
-        if (status != null) {
-            inquiries = inquiryRepository.findByInquiryTypeAndAnswerStatus(InquiryType.PUBLIC, status, pageable);
-        } else {
-            inquiries = inquiryRepository.findByInquiryType(InquiryType.PUBLIC, pageable);
-        }
-        
-        return inquiries.map(inquiry -> {
-            boolean hasReply = inquiryReplyRepository.existsByInquiry(inquiry);
-            return inquiryConverter.toListDTO(inquiry, hasReply);
-        });
-    }
-    
-    /**
      * 내 문의 내역 조회
      */
     public Page<InquiryListDTO> getMyInquiries(User user, Pageable pageable) {
         Page<Inquiry> inquiries = inquiryRepository.findByUser(user, pageable);
         
-        return inquiries.map(inquiry -> {
-            boolean hasReply = inquiryReplyRepository.existsByInquiry(inquiry);
-            return inquiryConverter.toListDTO(inquiry, hasReply);
-        });
+        return inquiries.map(inquiry -> inquiryConverter.toListDTO(inquiry));
     }
     
     /**
@@ -238,17 +168,102 @@ public class InquiryService {
         Inquiry inquiry = inquiryRepository.findById(inquiryId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._INQUIRY_NOT_FOUND));
         
-        // 권한 확인: 공개 문의는 누구나, 비공개 문의는 본인만
-        if (inquiry.getInquiryType() == InquiryType.PRIVATE) {
-            if (user == null || !inquiry.getUser().getId().equals(user.getId())) {
-                throw new GeneralException(ErrorStatus._INQUIRY_ACCESS_DENIED);
-            }
+        // 권한 확인: 1:1 개인 문의는 본인만 조회 가능
+        if (user == null || inquiry.getUser() == null || !inquiry.getUser().getId().equals(user.getId())) {
+            throw new GeneralException(ErrorStatus._INQUIRY_ACCESS_DENIED);
         }
         
         // 답변 조회
         InquiryReply reply = inquiryReplyRepository.findByInquiry(inquiry).orElse(null);
         
         return inquiryConverter.toDetailDTO(inquiry, reply);
+    }
+    
+    /**
+     * 문의 상태 변경(관리자)
+     */
+    @Transactional
+    public void updateStatus(Long inquiryId, InquiryStatus status) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INQUIRY_NOT_FOUND));
+
+        switch (status) {
+            case RECEIVED:
+                inquiry.markAsReceived();
+                break;
+            case PENDING:
+                inquiry.markAsPending();
+                break;
+            case ANSWERED:
+                inquiry.markAsAnswered();
+                break;
+            default:
+                throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+
+        // 문의자에게 상태 변경 알림 및 이메일 발송
+        String statusMessage = getStatusMessage(status);
+        
+        // 회원 문의인 경우 알림 및 이메일 발송
+        if (inquiry.getUser() != null) {
+            notificationService.createNotification(
+                    inquiry.getUser(),
+                    NotificationType.INQUIRY_REPLY,
+                    "문의 상태가 변경되었습니다",
+                    statusMessage,
+                    ReferenceType.INQUIRY,
+                    inquiry.getId()
+            );
+            
+            // 문의 상태 변경 이메일 발송
+            try {
+                String statusDate = java.time.format.DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")
+                        .format(java.time.LocalDateTime.now());
+                
+                emailService.sendHtmlEmail(
+                    inquiry.getUser().getEmail(),
+                    "문의 상태가 변경되었습니다",
+                    "inquiry-status-change-email.html",
+                    java.util.Map.of(
+                        "TITLE", inquiry.getTitle(),
+                        "STATUS", statusMessage,
+                        "DATE", statusDate
+                    )
+                );
+            } catch (Exception e) {
+                // 이메일 발송 실패해도 알림은 성공 처리
+            }
+        } else if (inquiry.getEmail() != null) {
+            // 비회원 문의인 경우 이메일로만 발송
+            try {
+                String statusDate = java.time.format.DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")
+                        .format(java.time.LocalDateTime.now());
+                
+                emailService.sendHtmlEmail(
+                    inquiry.getEmail(),
+                    "문의 상태가 변경되었습니다",
+                    "inquiry-status-change-email.html",
+                    java.util.Map.of(
+                        "TITLE", inquiry.getTitle(),
+                        "STATUS", statusMessage,
+                        "DATE", statusDate
+                    )
+                );
+            } catch (Exception e) {
+                // 이메일 발송 실패는 무시
+            }
+        }
+    }
+    
+    /**
+     * 상태에 따른 메시지 반환
+     */
+    private String getStatusMessage(InquiryStatus status) {
+        return switch (status) {
+            case RECEIVED -> "접수";
+            case PENDING -> "보류";
+            case ANSWERED -> "답변완료";
+        };
     }
 }
 

--- a/src/main/java/com/fmi/domain/inquiry/web/controller/InquiryController.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/controller/InquiryController.java
@@ -32,11 +32,11 @@ public class InquiryController {
     private final InquiryService inquiryService;
     
     /**
-     * 공개 문의 작성
+     * 1:1 개인 문의 작성
      * POST /api/inquiries
      */
     @PostMapping
-    @Operation(summary = "문의 작성", description = "inquiryType=PUBLIC|PRIVATE 로 구분합니다. PUBLIC: 회원만 가능 + email 필수 / PRIVATE: 비회원 가능(필요 시 email 포함)")
+    @Operation(summary = "1:1 개인 문의 작성", description = "비회원도 가능하며, 비회원인 경우 email을 포함할 수 있습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "문의 작성 성공")
     })
@@ -47,35 +47,13 @@ public class InquiryController {
         return ApiResponse.onSuccess(inquiryId);
     }
     
-    // 기존 /inquiries/public, /inquiries/private 엔드포인트는 제거되었습니다. 단일 POST /inquiries 를 사용하세요.
-    
-    /**
-     * 공개 문의 목록 조회
-     * GET /api/inquiries/public?category=GENERAL&status=PENDING&page=0&size=10
-     */
-    @GetMapping("/public")
-    @Operation(summary = "공개 문의 목록 조회")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "공개 문의 목록 조회 성공")
-    })
-    public ApiResponse<Page<InquiryListDTO>> getPublicInquiryList(
-            @RequestParam(required = false) InquiryCategory category,
-            @RequestParam(required = false) InquiryStatus status,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<InquiryListDTO> inquiries = inquiryService.getPublicInquiryList(category, status, pageable);
-        return ApiResponse.onSuccess(inquiries);
-    }
-    
     /**
      * 내 문의 내역 조회
      * GET /api/inquiries/me?page=0&size=10
      */
     @GetMapping("/me")
     @PreAuthorize("isAuthenticated()")
-    @Operation(summary = "내 문의 내역 조회", description = "공개/비공개 문의를 모두 조회합니다.")
+    @Operation(summary = "내 문의 내역 조회", description = "본인의 1:1 개인 문의를 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 문의 내역 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -114,7 +92,7 @@ public class InquiryController {
      * GET /api/inquiries/{inquiryId}
      */
     @GetMapping("/{inquiryId}")
-    @Operation(summary = "문의 상세 조회", description = "공개 문의는 누구나, 비공개 문의는 본인만 조회 가능합니다.")
+    @Operation(summary = "문의 상세 조회", description = "본인의 1:1 개인 문의만 조회 가능합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "문의 상세 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/fmi/domain/inquiry/web/dto/request/InquiryCreateRequestDTO.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/dto/request/InquiryCreateRequestDTO.java
@@ -1,9 +1,7 @@
 package com.fmi.domain.inquiry.web.dto.request;
 
 import com.fmi.domain.inquiry.data.enums.InquiryCategory;
-import com.fmi.domain.inquiry.data.enums.InquiryType;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
@@ -13,9 +11,7 @@ public class InquiryCreateRequestDTO {
     @NotBlank
     private String content;
     private InquiryCategory category;
-    @NotNull
-    private InquiryType inquiryType; // PUBLIC or PRIVATE
-    private String email; // PUBLIC일 때만 사용(비회원 문의)
+    private String email; // 비회원 문의 시 이메일 (선택)
 }
 
 

--- a/src/main/java/com/fmi/domain/inquiry/web/dto/request/InquiryStatusUpdateRequestDTO.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/dto/request/InquiryStatusUpdateRequestDTO.java
@@ -1,0 +1,11 @@
+package com.fmi.domain.inquiry.web.dto.request;
+
+import com.fmi.domain.inquiry.data.enums.InquiryStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class InquiryStatusUpdateRequestDTO {
+    @NotNull
+    private InquiryStatus status; // RECEIVED, PENDING, ANSWERED
+}

--- a/src/main/java/com/fmi/domain/inquiry/web/dto/response/InquiryDetailDTO.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/dto/response/InquiryDetailDTO.java
@@ -2,7 +2,6 @@ package com.fmi.domain.inquiry.web.dto.response;
 
 import com.fmi.domain.inquiry.data.enums.InquiryCategory;
 import com.fmi.domain.inquiry.data.enums.InquiryStatus;
-import com.fmi.domain.inquiry.data.enums.InquiryType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,12 +17,9 @@ public class InquiryDetailDTO {
     private Long inquiryId;
     private String title;
     private String content;
-    private InquiryType inquiryType;
     private InquiryCategory category;
     private InquiryStatus status;
-    private String authorNickname;
     private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
     
     // 답변 (있는 경우)
     private InquiryReplyDTO reply;

--- a/src/main/java/com/fmi/domain/inquiry/web/dto/response/InquiryListDTO.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/dto/response/InquiryListDTO.java
@@ -2,7 +2,6 @@ package com.fmi.domain.inquiry.web.dto.response;
 
 import com.fmi.domain.inquiry.data.enums.InquiryCategory;
 import com.fmi.domain.inquiry.data.enums.InquiryStatus;
-import com.fmi.domain.inquiry.data.enums.InquiryType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,11 +16,8 @@ import java.time.LocalDateTime;
 public class InquiryListDTO {
     private Long inquiryId;
     private String title;
-    private InquiryType inquiryType;
     private InquiryCategory category;
     private InquiryStatus status;
-    private String authorNickname;
-    private Boolean hasReply;
     private LocalDateTime createdAt;
 }
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close refactor/#127

## 🛠️ 작업 내용

- 문의 API를 1:1 개인 문의만 사용하도록 제한 및 불필요한 필드 제거

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
