### PR TITLE
chore: 카카오 로그인 API에 개발 환경 지원 추가

### DIFF
--- a/src/main/java/com/fmi/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/fmi/domain/auth/service/KakaoOAuthService.java
@@ -31,19 +31,35 @@ public class KakaoOAuthService {
     private String clientSecret; // 선택 항목
     @Value("${KAKAO_REDIRECT_URI:}")
     private String redirectUri;
+    @Value("${KAKAO_REDIRECT_URI_DEV:}")
+    private String redirectUriDev;
 
     private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private static final String USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
 
     public KakaoToken exchangeCodeForToken(String code) {
+        return exchangeCodeForToken(code, null);
+    }
+
+    public KakaoToken exchangeCodeForToken(String code, String environment) {
         RestTemplate rt = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
+        // environment에 따라 환경 변수에서 redirectUri 선택
+        String finalRedirectUri;
+        if (environment != null && environment.equalsIgnoreCase("dev") && redirectUriDev != null && !redirectUriDev.isBlank()) {
+            // environment가 "dev"이면 개발용 사용
+            finalRedirectUri = redirectUriDev;
+        } else {
+            // 기본값(프로덕션) 사용
+            finalRedirectUri = this.redirectUri;
+        }
+
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", restApiKey);
-        params.add("redirect_uri", redirectUri);
+        params.add("redirect_uri", finalRedirectUri);
         params.add("code", code);
         if (clientSecret != null && !clientSecret.isBlank()) {
             params.add("client_secret", clientSecret);

--- a/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
@@ -116,7 +116,8 @@ public class KakaoAuthController {
             )
     })
     public ResponseEntity<ApiResponse<LoginResponse>> loginWithKakao(@Valid @RequestBody KakaoLoginRequest req) {
-        KakaoToken token = kakaoOAuthService.exchangeCodeForToken(req.getCode());
+        // environment에 따라 환경 변수에서 자동 선택
+        KakaoToken token = kakaoOAuthService.exchangeCodeForToken(req.getCode(), req.getEnvironment());
         String kakaoAccessToken = token.getAccess_token();
 
         KakaoUser user = kakaoOAuthService.getUserInfo(kakaoAccessToken);

--- a/src/main/java/com/fmi/domain/auth/web/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/fmi/domain/auth/web/dto/KakaoLoginRequest.java
@@ -17,5 +17,12 @@ public class KakaoLoginRequest {
     )
     @NotBlank(message = "code 필수")
     private String code;
+    
+    @Schema(
+        description = "환경 타입 (선택사항: 'dev' 또는 'prod', 없으면 기본값 'prod' 사용)",
+        example = "dev",
+        allowableValues = {"dev", "prod"}
+    )
+    private String environment;
 }
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close chore/#139

## 🛠️ 작업 내용

- 카카오 로그인 API에 개발 환경 지원 추가

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
