### PR TITLE
refactor: 관리자 전용 비밀번호 검증/변경 API 제거 및 일반 회원 API로 통합

### DIFF
--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -28,7 +28,6 @@ import com.fmi.domain.report.web.dto.response.ReportResponseDTO;
 import com.fmi.domain.user.data.UserCategory;
 import com.fmi.domain.user.repository.UserCategoryRepository;
 import com.fmi.domain.user.service.UserService;
-import com.fmi.domain.user.web.dto.PasswordChangeRequest;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -147,21 +146,6 @@ public class AdminService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._REPORT_NOT_FOUND));
         
         return reportConverter.toResponseDTO(report);
-    }
-
-    /**
-     * 현재 비밀번호 검증 (기존 UserService 사용)
-     */
-    public boolean verifyPassword(User admin, String currentPassword) {
-        return userService.verifyPassword(admin.getEmail(), currentPassword);
-    }
-
-    /**
-     * 관리자 비밀번호 변경 (기존 UserService 사용)
-     */
-    @Transactional
-    public void changePassword(User admin, PasswordChangeRequest request) {
-        userService.changePassword(admin.getEmail(), request);
     }
 
     /**

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -27,7 +27,6 @@ import com.fmi.domain.report.converter.ReportConverter;
 import com.fmi.domain.report.web.dto.response.ReportResponseDTO;
 import com.fmi.domain.user.data.UserCategory;
 import com.fmi.domain.user.repository.UserCategoryRepository;
-import com.fmi.domain.user.service.UserService;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +51,6 @@ public class AdminService {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final UserCategoryRepository userCategoryRepository;
-    private final UserService userService;
 
     public Page<AdminInquiryResponse> getInquiryPage(InquiryType type,
                                                      InquiryStatus status,

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -6,7 +6,6 @@ import com.fmi.domain.admin.dto.AdminReportResponse;
 import com.fmi.domain.admin.dto.AdminUserDetailResponse;
 import com.fmi.domain.admin.service.AdminService;
 import com.fmi.domain.admin.web.dto.AdminSignupRequest;
-import com.fmi.domain.user.web.dto.PasswordChangeRequest;
 import com.fmi.domain.auth.converter.AuthConverter;
 import com.fmi.domain.auth.response.SignupResponse;
 import com.fmi.domain.auth.service.AuthService;
@@ -14,7 +13,6 @@ import com.fmi.domain.Enum.WithdrawalReason;
 import com.fmi.domain.inquiry.data.enums.InquiryCategory;
 import com.fmi.domain.inquiry.data.enums.InquiryStatus;
 import com.fmi.domain.inquiry.data.enums.InquiryType;
-import com.fmi.domain.auth.data.User;
 import com.fmi.domain.inquiry.service.InquiryService;
 import com.fmi.domain.inquiry.web.dto.InquiryReplyCreateRequestDTO;
 import com.fmi.domain.inquiry.web.dto.response.InquiryDetailDTO;
@@ -37,9 +35,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -269,72 +265,6 @@ public class AdminController {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "deletedAt"));
         Page<AdminDeletedUserResponse> response = adminService.getDeletedUsers(reason, pageable);
         return ApiResponse.onSuccess(response);
-    }
-
-    @PostMapping("/password/verify")
-    @Operation(summary = "현재 비밀번호 검증", description = "관리자의 현재 비밀번호를 검증합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 검증 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400",
-                    description = "USER400-PASSWORD_INCORRECT: 현재 비밀번호가 일치하지 않습니다",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = "{\"isSuccess\": false, \"code\": \"USER400-PASSWORD_INCORRECT\", \"message\": \"현재 비밀번호가 일치하지 않습니다.\"}"
-                            )
-                    )
-            )
-    })
-    public ApiResponse<Boolean> verifyPassword(
-            @AuthenticationPrincipal User admin,
-            @RequestBody PasswordChangeRequest request
-    ) {
-        boolean isValid = adminService.verifyPassword(admin, request.getCurrentPassword());
-        return ApiResponse.onSuccess(isValid);
-    }
-
-    @PatchMapping("/password")
-    @Operation(summary = "관리자 비밀번호 변경", description = "관리자의 비밀번호를 변경합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400",
-                    description = "USER400-PASSWORD_INCORRECT: 현재 비밀번호가 일치하지 않습니다",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = "{\"isSuccess\": false, \"code\": \"USER400-PASSWORD_INCORRECT\", \"message\": \"현재 비밀번호가 일치하지 않습니다.\"}"
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400",
-                    description = "USER400-PASSWORD_MISMATCH: 새 비밀번호와 확인이 일치하지 않습니다",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = "{\"isSuccess\": false, \"code\": \"USER400-PASSWORD_MISMATCH\", \"message\": \"새 비밀번호와 확인이 일치하지 않습니다.\"}"
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400",
-                    description = "AUTH400-WEAK_PASSWORD: 비밀번호 규칙을 만족하지 않습니다",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    value = "{\"isSuccess\": false, \"code\": \"AUTH400-WEAK_PASSWORD\", \"message\": \"비밀번호 규칙을 만족하지 않습니다. 8~16자, 대/소문자·숫자·특수문자를 포함해야 합니다.\"}"
-                            )
-                    )
-            )
-    })
-    public ApiResponse<String> changePassword(
-            @AuthenticationPrincipal User admin,
-            @Valid @RequestBody PasswordChangeRequest request
-    ) {
-        adminService.changePassword(admin, request);
-        return ApiResponse.onSuccess("OK");
     }
 }
 

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -13,6 +13,7 @@ import com.fmi.domain.user.response.UserOtherPageResponse;
 import com.fmi.domain.user.response.UserProfileResponse;
 import com.fmi.domain.user.web.dto.AccountDeleteRequest;
 import com.fmi.domain.user.web.dto.PasswordChangeRequest;
+import com.fmi.domain.user.web.dto.PasswordVerifyRequest;
 import com.fmi.domain.user.web.dto.ProfileImageUpdateRequest;
 import com.fmi.domain.user.web.dto.UserUpdateRequest;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
@@ -161,16 +162,19 @@ public class UserService {
     }
 
     /**
-     * 비밀번호 변경
-     * 임시 비밀번호로 로그인한 경우에도 사용 가능 (임시 비밀번호를 현재 비밀번호로 확인)
-     * 원래 비밀번호로도 변경 가능
+     * 현재 비밀번호 검증 (프론트엔드에서 별도로 검증할 때 사용)
      */
-    public void changePassword(String email, PasswordChangeRequest request) {
-        // 현재 비밀번호 검증
+    public void verifyPasswordWithException(String email, PasswordVerifyRequest request) {
         if (!verifyPassword(email, request.getCurrentPassword())) {
             throw new GeneralException(ErrorStatus._CURRENT_PASSWORD_INCORRECT);
         }
+    }
 
+    /**
+     * 비밀번호 변경
+     * 현재 비밀번호는 별도 엔드포인트에서 검증해야 하며, 이 메서드는 새 비밀번호만 받아서 변경합니다.
+     */
+    public void changePassword(String email, PasswordChangeRequest request) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -6,6 +6,7 @@ import com.fmi.domain.user.response.UserProfileResponse;
 import com.fmi.domain.user.service.UserService;
 import com.fmi.domain.user.web.dto.AccountDeleteRequest;
 import com.fmi.domain.user.web.dto.PasswordChangeRequest;
+import com.fmi.domain.user.web.dto.PasswordVerifyRequest;
 import com.fmi.domain.user.web.dto.ProfileImageUpdateRequest;
 import com.fmi.domain.user.web.dto.UserUpdateRequest;
 import com.fmi.global.apiPayload.ApiResponse;
@@ -197,11 +198,11 @@ public class UserController {
         return ApiResponse.onSuccess(response);
     }
 
-    @PatchMapping("/me/password")
-    @Operation(summary = "비밀번호 변경", 
-               description = "현재 비밀번호를 확인하고 새 비밀번호로 변경합니다. 새 비밀번호는 8~16자, 대/소문자·숫자·특수문자를 포함해야 합니다.")
+    @PostMapping("/me/password/verify")
+    @Operation(summary = "현재 비밀번호 검증", 
+               description = "현재 비밀번호가 올바른지 검증합니다. 비밀번호 변경 전에 먼저 호출하여 비밀번호를 확인해야 합니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 검증 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
                     description = "USER400-PASSWORD_INCORRECT: 현재 비밀번호가 일치하지 않습니다",
@@ -212,6 +213,31 @@ public class UserController {
                             )
                     )
             ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "USER404-NOT_FOUND: 존재하지 않는 회원입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"USER404-NOT_FOUND\", \"message\": \"존재하지 않는 회원입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ApiResponse<Void> verifyPassword(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody PasswordVerifyRequest request
+    ) {
+        String email = userDetails.getUsername();
+        userService.verifyPasswordWithException(email, request);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @PatchMapping("/me/password")
+    @Operation(summary = "비밀번호 변경", 
+               description = "새 비밀번호로 변경합니다. 비밀번호 검증은 별도 엔드포인트(/users/me/password/verify)에서 먼저 완료해야 합니다. 새 비밀번호는 8~16자, 대/소문자·숫자·특수문자를 포함해야 합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
                     description = "USER400-PASSWORD_MISMATCH: 새 비밀번호와 확인이 일치하지 않습니다",

--- a/src/main/java/com/fmi/domain/user/web/dto/PasswordChangeRequest.java
+++ b/src/main/java/com/fmi/domain/user/web/dto/PasswordChangeRequest.java
@@ -11,9 +11,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class PasswordChangeRequest {
     
-    @NotBlank(message = "현재 비밀번호를 입력해주세요")
-    private String currentPassword;
-    
     @NotBlank(message = "새 비밀번호를 입력해주세요")
     @Pattern(
         regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[{\\]}\\\\|;:'\",<.>/?])[A-Za-z\\d!@#$%^&*()\\-_=+\\[{\\]}\\\\|;:'\",<.>/?]{8,16}$",

--- a/src/main/java/com/fmi/domain/user/web/dto/PasswordVerifyRequest.java
+++ b/src/main/java/com/fmi/domain/user/web/dto/PasswordVerifyRequest.java
@@ -1,0 +1,15 @@
+package com.fmi.domain.user.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PasswordVerifyRequest {
+    
+    @NotBlank(message = "현재 비밀번호를 입력해주세요")
+    private String currentPassword;
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close refactor/#128

## 🛠️ 작업 내용

- 관리자 전용 비밀번호 검증/변경 API 제거 및 일반 회원 API로 통합

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
