### PR TITLE
refactor: 내 정보 조회 API에서 이메일 인증 여부 필드 제거

### DIFF
--- a/src/main/java/com/fmi/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/fmi/domain/user/converter/UserConverter.java
@@ -17,14 +17,13 @@ public class UserConverter {
 
     /**
      * User Entity → UserProfileResponse 변환
-     * 닉네임, 이메일(인증여부), 프로필 이미지만 반환
+     * 닉네임, 이메일, 프로필 이미지만 반환
      */
     public static UserProfileResponse toUserProfileResponse(User user) {
         return UserProfileResponse.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
                 .email(user.getEmail())
-                .emailVerified(user.isEmail_verified())
                 .profileImg(user.getProfile_img())
                 .build();
     }

--- a/src/main/java/com/fmi/domain/user/response/UserProfileResponse.java
+++ b/src/main/java/com/fmi/domain/user/response/UserProfileResponse.java
@@ -11,7 +11,6 @@ public class UserProfileResponse {
     private Long userId;              // 사용자 ID
     private String nickname;          // 닉네임 (수정 가능)
     private String email;             // 이메일 (조회만)
-    private boolean emailVerified;    // 이메일 인증 여부 (조회만)
     private String profileImg;        // 프로필 이미지 URL (수정 가능)
 }
 

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -75,7 +75,7 @@ public class UserController {
     }
 
     @GetMapping("/me")
-    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 기본 프로필 정보를 조회합니다. (닉네임, 이메일, 이메일 인증 여부, 프로필 이미지)")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 기본 프로필 정보를 조회합니다. (닉네임, 이메일, 프로필 이미지)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 정보 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(


### PR DESCRIPTION
## 🧩 관련 이슈

- close refactor/#145

## 🛠️ 작업 내용

- 내 정보 조회 API에서 이메일 인증 여부 필드 제거

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
