### PR TITLE
feat: 공지사항 댓글 기능 추가 및 수정, 삭제 기능 추가(관리자 전용)

### DIFF
--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -18,6 +18,8 @@ import com.fmi.domain.inquiry.web.dto.InquiryReplyCreateRequestDTO;
 import com.fmi.domain.inquiry.web.dto.response.InquiryDetailDTO;
 import com.fmi.domain.notice.service.NoticeService;
 import com.fmi.domain.notice.web.dto.NoticeCreateRequestDTO;
+import com.fmi.domain.notice.web.dto.NoticeUpdateRequestDTO;
+import com.fmi.domain.notice.web.dto.NoticeResponseDTO;
 import com.fmi.domain.report.data.enums.ReportStatus;
 import com.fmi.domain.report.data.enums.ReportTargetType;
 import com.fmi.domain.report.service.ReportService;
@@ -42,6 +44,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -157,6 +160,65 @@ public class AdminController {
     public ApiResponse<Long> createNotice(@RequestBody NoticeCreateRequestDTO request) {
         Long id = noticeService.createNotice(request);
         return ApiResponse.onSuccess(id);
+    }
+
+    @PutMapping("/notices/{noticeId}")
+    @Operation(summary = "공지 수정(관리자)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "공지 수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"noticeId\": 1, \"title\": \"수정 제목\", \"content\": \"수정 내용\", \"category\": \"GENERAL\", \"pinned\": false, \"viewCount\": 10, \"createdAt\": \"2024-01-01T00:00:00\", \"updatedAt\": \"2024-01-02T00:00:00\"}}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "NOTICE404-NOT_FOUND: 존재하지 않는 공지사항입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"NOTICE404-NOT_FOUND\", \"message\": \"존재하지 않는 공지사항입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ApiResponse<NoticeResponseDTO> updateNotice(@PathVariable Long noticeId,
+                                                       @Valid @RequestBody NoticeUpdateRequestDTO request) {
+        NoticeResponseDTO response = noticeService.updateNotice(noticeId, request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @DeleteMapping("/notices/{noticeId}")
+    @Operation(summary = "공지 삭제(관리자)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "공지 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": \"공지사항 삭제 완료\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "NOTICE404-NOT_FOUND: 존재하지 않는 공지사항입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"NOTICE404-NOT_FOUND\", \"message\": \"존재하지 않는 공지사항입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ApiResponse<String> deleteNotice(@PathVariable Long noticeId) {
+        noticeService.deleteNotice(noticeId);
+        return ApiResponse.onSuccess("공지사항 삭제 완료");
     }
 
     @PostMapping("/inquiries/{inquiryId}/reply")

--- a/src/main/java/com/fmi/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/com/fmi/domain/comment/converter/CommentConverter.java
@@ -24,14 +24,25 @@ public class CommentConverter {
     }
 
     public CommentResponse toCommentResponse(Comment comment) {
-        return new CommentResponse(
-                comment.getId(),
-                comment.getContent(),
-                comment.getUser().getNickname(),
-                comment.getCreatedAt(),
-                comment.getLikeCount(),
-                comment.getParent() != null ? comment.getParent().getId() : null
-        );
+        return toCommentResponse(comment, false, false);
+    }
+
+    public CommentResponse toCommentResponse(Comment comment, boolean canEdit, boolean canDelete) {
+        User author = comment.getUser();
+        Long authorId = author != null ? author.getId() : null;
+        String authorName = author != null ? author.getNickname() : null;
+
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .authorId(authorId)
+                .authorName(authorName)
+                .createdAt(comment.getCreatedAt())
+                .likeCount(comment.getLikeCount())
+                .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .canEdit(canEdit)
+                .canDelete(canDelete)
+                .build();
     }
 
 }

--- a/src/main/java/com/fmi/domain/comment/response/CommentResponse.java
+++ b/src/main/java/com/fmi/domain/comment/response/CommentResponse.java
@@ -12,8 +12,11 @@ import java.time.LocalDateTime;
 public class CommentResponse {
     private Long id;
     private String content;
+    private Long authorId;
     private String authorName;
     private LocalDateTime createdAt;
     private int likeCount;
     private Long parentId;
+    private boolean canEdit;
+    private boolean canDelete;
 }

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -86,7 +86,7 @@ public class CommentService {
             notifyPostOwner(post, user, dto, mentionedUserIds);
         }
 
-        return commentConverter.toCommentResponse(savedComment);
+        return toResponse(savedComment, userDetails);
     }
 
     private Set<Long> handleMentions(Comment comment, CreateCommentDto dto) {
@@ -189,7 +189,7 @@ public class CommentService {
         comment.setContent(dto.getContent());
         comment.setUpdatedAt(LocalDateTime.now());
 
-        return commentConverter.toCommentResponse(comment);
+        return toResponse(comment, userDetails);
     }
 
     @Transactional
@@ -212,12 +212,12 @@ public class CommentService {
 
         commentRepository.delete(comment);
 
-        return commentConverter.toCommentResponse(comment);
+        return toResponse(comment, userDetails);
     }
 
 
     @Transactional(readOnly = true)
-    public CommentSliceResponse getComments(Long postId, Long cursor, int size) {
+    public CommentSliceResponse getComments(Long postId, Long cursor, int size, UserDetails userDetails) {
 
         Slice<Comment> comments;
 
@@ -234,10 +234,33 @@ public class CommentService {
 
         List<CommentResponse> result = comments.stream()
                 .limit(size)
-                .map(commentConverter::toCommentResponse)
+                .map(comment -> toResponse(comment, userDetails))
                 .toList();
 
         return new CommentSliceResponse(result, comments.hasNext(), nextCursor);
+    }
+
+    private CommentResponse toResponse(Comment comment, UserDetails userDetails) {
+        boolean isOwner = isOwner(comment, userDetails);
+        boolean isAdmin = isAdmin(userDetails);
+
+        return commentConverter.toCommentResponse(comment, isOwner, isOwner || isAdmin);
+    }
+
+    private boolean isOwner(Comment comment, UserDetails userDetails) {
+        return userDetails != null
+                && comment.getUser() != null
+                && comment.getUser().getEmail().equals(userDetails.getUsername());
+    }
+
+    private boolean isAdmin(UserDetails userDetails) {
+        if (userDetails == null) {
+            return false;
+        }
+
+        return userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(authority -> authority.equals("ROLE_ADMIN"));
     }
 
 }

--- a/src/main/java/com/fmi/domain/comment/service/CommentService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -197,8 +198,14 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다"));
 
-        if (!comment.getUser().getEmail().equals(userDetails.getUsername())) {
-            throw new RuntimeException("작성자만 수정할 수 있습니다.");
+        // 작성자이거나 관리자인 경우 삭제 가능
+        boolean isOwner = comment.getUser().getEmail().equals(userDetails.getUsername());
+        boolean isAdmin = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(authority -> authority.equals("ROLE_ADMIN"));
+
+        if (!isOwner && !isAdmin) {
+            throw new RuntimeException("작성자 또는 관리자만 삭제할 수 있습니다.");
         }
 
         comment.getPost().decreaseCommentCount(); // 댓글 수 감소

--- a/src/main/java/com/fmi/domain/comment/web/controller/CommentController.java
+++ b/src/main/java/com/fmi/domain/comment/web/controller/CommentController.java
@@ -64,7 +64,7 @@ public class CommentController {
     }
 
     @PutMapping(value = "/{commentId}")
-    @Operation(summary = "댓글 수정")
+    @Operation(summary = "댓글 수정", description = "작성자만 수정할 수 있습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 수정 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "COMMON400: 잘못된 요청입니다"),
@@ -84,7 +84,7 @@ public class CommentController {
     }
 
     @DeleteMapping(value = "/{commentId}")
-    @Operation(summary = "댓글 삭제")
+    @Operation(summary = "댓글 삭제", description = "작성자 또는 관리자(ROLE_ADMIN)만 삭제할 수 있습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 삭제 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),

--- a/src/main/java/com/fmi/domain/comment/web/controller/CommentController.java
+++ b/src/main/java/com/fmi/domain/comment/web/controller/CommentController.java
@@ -6,6 +6,8 @@ import com.fmi.domain.comment.service.CommentService;
 import com.fmi.domain.comment.web.dto.CreateCommentDto;
 import com.fmi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +30,16 @@ public class CommentController {
     @PostMapping(value = "/{postId}")
     @Operation(summary = "댓글 생성")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"댓글 내용\", \"authorId\": 34, \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"likeCount\": 0, \"parentId\": null, \"canEdit\": true, \"canDelete\": true}}"
+                            )
+                    )
+            ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "COMMON400: 잘못된 요청입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "POST404-NOT_FOUND: 존재하지 않는 게시글입니다"),
@@ -48,7 +59,16 @@ public class CommentController {
     @GetMapping("/{postId}")
     @Operation(summary = "게시글 댓글 조회 (커서 기반 무한스크롤)")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"comments\": [{\"id\": 12, \"content\": \"댓글 내용\", \"authorId\": 34, \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"likeCount\": 2, \"parentId\": null, \"canEdit\": false, \"canDelete\": true}], \"hasNext\": true, \"cursor\": 12}}"
+                            )
+                    )
+            ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "LIST400-INVALID_CURSOR: 유효하지 않은 커서입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "POST404-NOT_FOUND: 존재하지 않는 게시글입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "COMMON500: 서버 에러")
@@ -56,9 +76,10 @@ public class CommentController {
     public ResponseEntity<ApiResponse<CommentSliceResponse>> getComments(
             @PathVariable Long postId,
             @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        CommentSliceResponse response = commentService.getComments(postId, cursor, size);
+        CommentSliceResponse response = commentService.getComments(postId, cursor, size, userDetails);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
@@ -66,7 +87,16 @@ public class CommentController {
     @PutMapping(value = "/{commentId}")
     @Operation(summary = "댓글 수정", description = "작성자만 수정할 수 있습니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"수정된 댓글\", \"authorId\": 34, \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"likeCount\": 1, \"parentId\": null, \"canEdit\": true, \"canDelete\": true}}"
+                            )
+                    )
+            ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "COMMON400: 잘못된 요청입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "COMMON403: 금지된 요청입니다"),
@@ -86,7 +116,16 @@ public class CommentController {
     @DeleteMapping(value = "/{commentId}")
     @Operation(summary = "댓글 삭제", description = "작성자 또는 관리자(ROLE_ADMIN)만 삭제할 수 있습니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"삭제된 댓글\", \"authorId\": 34, \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"likeCount\": 1, \"parentId\": null, \"canEdit\": false, \"canDelete\": true}}"
+                            )
+                    )
+            ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "COMMON401: 인증이 필요합니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "COMMON403: 금지된 요청입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "COMMENT404-NOT_FOUND: 존재하지 않는 댓글입니다"),

--- a/src/main/java/com/fmi/domain/notice/data/Notice.java
+++ b/src/main/java/com/fmi/domain/notice/data/Notice.java
@@ -62,5 +62,13 @@ public class Notice {
     public void setViewCount(Integer viewCount) {
         this.viewCount = viewCount;
     }
+
+    public void update(String title, String content, NoticeCategory category, Boolean pinned) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+        this.pinned = pinned;
+        this.updatedAt = LocalDateTime.now();
+    }
 }
 

--- a/src/main/java/com/fmi/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/fmi/domain/notice/service/NoticeService.java
@@ -7,6 +7,8 @@ import com.fmi.domain.notice.repository.NoticeRepository;
 import com.fmi.domain.notice.web.dto.NoticeListDTO;
 import com.fmi.domain.notice.web.dto.NoticeResponseDTO;
 import com.fmi.domain.notice.web.dto.NoticeCreateRequestDTO;
+import com.fmi.domain.notice.web.dto.NoticeUpdateRequestDTO;
+import com.fmi.domain.noticecomment.repository.NoticeCommentRepository;
 import com.fmi.domain.notification.service.NotificationService;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
@@ -28,6 +30,7 @@ public class NoticeService {
     private final NoticeRepository noticeRepository;
     private final NoticeConverter noticeConverter;
     private final NotificationService notificationService;
+    private final NoticeCommentRepository noticeCommentRepository;
     private final StringRedisTemplate stringRedisTemplate;
     
     /**
@@ -110,6 +113,33 @@ public class NoticeService {
         );
 
         return saved.getNoticeId();
+    }
+
+    /**
+     * 공지사항 수정 (관리자)
+     */
+    @Transactional
+    public NoticeResponseDTO updateNotice(Long noticeId, NoticeUpdateRequestDTO request) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOTICE_NOT_FOUND));
+
+        NoticeCategory category = request.getCategory() == null ? notice.getCategory() : request.getCategory();
+        Boolean pinned = request.getPinned() == null ? notice.getPinned() : request.getPinned();
+        notice.update(request.getTitle(), request.getContent(), category, pinned);
+
+        return noticeConverter.toResponseDTO(notice);
+    }
+
+    /**
+     * 공지사항 삭제 (관리자)
+     */
+    @Transactional
+    public void deleteNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOTICE_NOT_FOUND));
+
+        noticeCommentRepository.deleteByNoticeNoticeId(noticeId);
+        noticeRepository.delete(notice);
     }
 }
 

--- a/src/main/java/com/fmi/domain/notice/web/dto/NoticeUpdateRequestDTO.java
+++ b/src/main/java/com/fmi/domain/notice/web/dto/NoticeUpdateRequestDTO.java
@@ -1,0 +1,20 @@
+package com.fmi.domain.notice.web.dto;
+
+import com.fmi.domain.notice.data.enums.NoticeCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class NoticeUpdateRequestDTO {
+    @Schema(description = "제목", example = "공지 수정 제목")
+    @NotBlank
+    private String title;
+    @Schema(description = "내용", example = "공지 수정 내용입니다.")
+    @NotBlank
+    private String content;
+    @Schema(description = "카테고리", example = "GENERAL")
+    private NoticeCategory category;
+    @Schema(description = "상단 고정 여부", example = "false")
+    private Boolean pinned;
+}

--- a/src/main/java/com/fmi/domain/noticecomment/converter/NoticeCommentConverter.java
+++ b/src/main/java/com/fmi/domain/noticecomment/converter/NoticeCommentConverter.java
@@ -1,0 +1,35 @@
+package com.fmi.domain.noticecomment.converter;
+
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.notice.data.Notice;
+import com.fmi.domain.noticecomment.data.NoticeComment;
+import com.fmi.domain.noticecomment.response.NoticeCommentResponse;
+import com.fmi.domain.noticecomment.web.dto.CreateNoticeCommentDto;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class NoticeCommentConverter {
+
+    public NoticeComment toEntity(CreateNoticeCommentDto dto, User user, Notice notice, NoticeComment parent) {
+        return NoticeComment.builder()
+                .user(user)
+                .notice(notice)
+                .parent(parent)
+                .content(dto.getContent())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public NoticeCommentResponse toResponse(NoticeComment comment) {
+        return NoticeCommentResponse.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .authorName(comment.getUser().getNickname())
+                .createdAt(comment.getCreatedAt())
+                .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/fmi/domain/noticecomment/converter/NoticeCommentConverter.java
+++ b/src/main/java/com/fmi/domain/noticecomment/converter/NoticeCommentConverter.java
@@ -24,12 +24,23 @@ public class NoticeCommentConverter {
     }
 
     public NoticeCommentResponse toResponse(NoticeComment comment) {
+        return toResponse(comment, false, false);
+    }
+
+    public NoticeCommentResponse toResponse(NoticeComment comment, boolean canEdit, boolean canDelete) {
+        User author = comment.getUser();
+        Long authorId = author != null ? author.getId() : null;
+        String authorName = author != null ? author.getNickname() : null;
+
         return NoticeCommentResponse.builder()
                 .id(comment.getId())
                 .content(comment.getContent())
-                .authorName(comment.getUser().getNickname())
+                .authorId(authorId)
+                .authorName(authorName)
                 .createdAt(comment.getCreatedAt())
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .canEdit(canEdit)
+                .canDelete(canDelete)
                 .build();
     }
 }

--- a/src/main/java/com/fmi/domain/noticecomment/data/NoticeComment.java
+++ b/src/main/java/com/fmi/domain/noticecomment/data/NoticeComment.java
@@ -1,0 +1,66 @@
+package com.fmi.domain.noticecomment.data;
+
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.notice.data.Notice;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "notice_comment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoticeComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private NoticeComment parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<NoticeComment> replies = new ArrayList<>();
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/fmi/domain/noticecomment/repository/NoticeCommentRepository.java
+++ b/src/main/java/com/fmi/domain/noticecomment/repository/NoticeCommentRepository.java
@@ -1,0 +1,25 @@
+package com.fmi.domain.noticecomment.repository;
+
+import com.fmi.domain.noticecomment.data.NoticeComment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeCommentRepository extends JpaRepository<NoticeComment, Long> {
+
+    @Query("select c from NoticeComment c join fetch c.user left join fetch c.parent " +
+            "where c.notice.noticeId = :noticeId order by c.id desc")
+    Slice<NoticeComment> findTopByNoticeIdOrderByIdDesc(@Param("noticeId") Long noticeId, Pageable pageable);
+
+    @Query("select c from NoticeComment c join fetch c.user left join fetch c.parent " +
+            "where c.notice.noticeId = :noticeId and c.id < :cursor order by c.id desc")
+    Slice<NoticeComment> findByNoticeIdAndIdLessThanOrderByIdDesc(@Param("noticeId") Long noticeId,
+                                                                  @Param("cursor") Long cursor,
+                                                                  Pageable pageable);
+
+    void deleteByNoticeNoticeId(Long noticeId);
+}

--- a/src/main/java/com/fmi/domain/noticecomment/response/NoticeCommentResponse.java
+++ b/src/main/java/com/fmi/domain/noticecomment/response/NoticeCommentResponse.java
@@ -1,0 +1,18 @@
+package com.fmi.domain.noticecomment.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoticeCommentResponse {
+    private Long id;
+    private String content;
+    private String authorName;
+    private LocalDateTime createdAt;
+    private Long parentId;
+}

--- a/src/main/java/com/fmi/domain/noticecomment/response/NoticeCommentResponse.java
+++ b/src/main/java/com/fmi/domain/noticecomment/response/NoticeCommentResponse.java
@@ -12,7 +12,10 @@ import java.time.LocalDateTime;
 public class NoticeCommentResponse {
     private Long id;
     private String content;
+    private Long authorId;
     private String authorName;
     private LocalDateTime createdAt;
     private Long parentId;
+    private boolean canEdit;
+    private boolean canDelete;
 }

--- a/src/main/java/com/fmi/domain/noticecomment/response/NoticeCommentSliceResponse.java
+++ b/src/main/java/com/fmi/domain/noticecomment/response/NoticeCommentSliceResponse.java
@@ -1,0 +1,14 @@
+package com.fmi.domain.noticecomment.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class NoticeCommentSliceResponse {
+    private List<NoticeCommentResponse> comments;
+    private boolean hasNext;
+    private Long cursor;
+}

--- a/src/main/java/com/fmi/domain/noticecomment/service/NoticeCommentService.java
+++ b/src/main/java/com/fmi/domain/noticecomment/service/NoticeCommentService.java
@@ -55,10 +55,10 @@ public class NoticeCommentService {
 
         NoticeComment comment = noticeCommentConverter.toEntity(dto, user, notice, parent);
         NoticeComment saved = noticeCommentRepository.save(comment);
-        return noticeCommentConverter.toResponse(saved);
+        return toResponse(saved, userDetails);
     }
 
-    public NoticeCommentSliceResponse getComments(Long noticeId, Long cursor, int size) {
+    public NoticeCommentSliceResponse getComments(Long noticeId, Long cursor, int size, UserDetails userDetails) {
         if (!noticeRepository.existsById(noticeId)) {
             throw new GeneralException(ErrorStatus._NOTICE_NOT_FOUND);
         }
@@ -76,7 +76,7 @@ public class NoticeCommentService {
 
         List<NoticeCommentResponse> result = comments.stream()
                 .limit(size)
-                .map(noticeCommentConverter::toResponse)
+                .map(comment -> toResponse(comment, userDetails))
                 .toList();
 
         return new NoticeCommentSliceResponse(result, comments.hasNext(), nextCursor);
@@ -96,7 +96,7 @@ public class NoticeCommentService {
         }
 
         comment.updateContent(dto.getContent());
-        return noticeCommentConverter.toResponse(comment);
+        return toResponse(comment, userDetails);
     }
 
     @Transactional
@@ -118,6 +118,29 @@ public class NoticeCommentService {
         }
 
         noticeCommentRepository.delete(comment);
-        return noticeCommentConverter.toResponse(comment);
+        return toResponse(comment, userDetails);
+    }
+
+    private NoticeCommentResponse toResponse(NoticeComment comment, UserDetails userDetails) {
+        boolean isOwner = isOwner(comment, userDetails);
+        boolean isAdmin = isAdmin(userDetails);
+
+        return noticeCommentConverter.toResponse(comment, isOwner, isOwner || isAdmin);
+    }
+
+    private boolean isOwner(NoticeComment comment, UserDetails userDetails) {
+        return userDetails != null
+                && comment.getUser() != null
+                && comment.getUser().getEmail().equals(userDetails.getUsername());
+    }
+
+    private boolean isAdmin(UserDetails userDetails) {
+        if (userDetails == null) {
+            return false;
+        }
+
+        return userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(authority -> authority.equals("ROLE_ADMIN"));
     }
 }

--- a/src/main/java/com/fmi/domain/noticecomment/service/NoticeCommentService.java
+++ b/src/main/java/com/fmi/domain/noticecomment/service/NoticeCommentService.java
@@ -15,6 +15,7 @@ import com.fmi.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -107,7 +108,12 @@ public class NoticeCommentService {
         NoticeComment comment = noticeCommentRepository.findById(commentId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._COMMENT_NOT_FOUND));
 
-        if (!comment.getUser().getEmail().equals(userDetails.getUsername())) {
+        boolean isOwner = comment.getUser().getEmail().equals(userDetails.getUsername());
+        boolean isAdmin = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(authority -> authority.equals("ROLE_ADMIN"));
+
+        if (!isOwner && !isAdmin) {
             throw new GeneralException(ErrorStatus._FORBIDDEN);
         }
 

--- a/src/main/java/com/fmi/domain/noticecomment/service/NoticeCommentService.java
+++ b/src/main/java/com/fmi/domain/noticecomment/service/NoticeCommentService.java
@@ -1,0 +1,117 @@
+package com.fmi.domain.noticecomment.service;
+
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.domain.notice.data.Notice;
+import com.fmi.domain.notice.repository.NoticeRepository;
+import com.fmi.domain.noticecomment.converter.NoticeCommentConverter;
+import com.fmi.domain.noticecomment.data.NoticeComment;
+import com.fmi.domain.noticecomment.repository.NoticeCommentRepository;
+import com.fmi.domain.noticecomment.response.NoticeCommentResponse;
+import com.fmi.domain.noticecomment.response.NoticeCommentSliceResponse;
+import com.fmi.domain.noticecomment.web.dto.CreateNoticeCommentDto;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeCommentService {
+
+    private final NoticeRepository noticeRepository;
+    private final UserRepository userRepository;
+    private final NoticeCommentRepository noticeCommentRepository;
+    private final NoticeCommentConverter noticeCommentConverter;
+
+    @Transactional
+    public NoticeCommentResponse createComment(Long noticeId, CreateNoticeCommentDto dto, UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._NOTICE_NOT_FOUND));
+
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        NoticeComment parent = null;
+        if (dto.getParentId() != null) {
+            parent = noticeCommentRepository.findById(dto.getParentId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._COMMENT_NOT_FOUND));
+            if (!parent.getNotice().getNoticeId().equals(noticeId)) {
+                throw new GeneralException(ErrorStatus._BAD_REQUEST);
+            }
+        }
+
+        NoticeComment comment = noticeCommentConverter.toEntity(dto, user, notice, parent);
+        NoticeComment saved = noticeCommentRepository.save(comment);
+        return noticeCommentConverter.toResponse(saved);
+    }
+
+    public NoticeCommentSliceResponse getComments(Long noticeId, Long cursor, int size) {
+        if (!noticeRepository.existsById(noticeId)) {
+            throw new GeneralException(ErrorStatus._NOTICE_NOT_FOUND);
+        }
+
+        Slice<NoticeComment> comments;
+        if (cursor == null) {
+            comments = noticeCommentRepository.findTopByNoticeIdOrderByIdDesc(noticeId, Pageable.ofSize(size));
+        } else {
+            comments = noticeCommentRepository.findByNoticeIdAndIdLessThanOrderByIdDesc(noticeId, cursor, Pageable.ofSize(size));
+        }
+
+        Long nextCursor = comments.hasNext()
+                ? comments.getContent().get(comments.getContent().size() - 1).getId()
+                : null;
+
+        List<NoticeCommentResponse> result = comments.stream()
+                .limit(size)
+                .map(noticeCommentConverter::toResponse)
+                .toList();
+
+        return new NoticeCommentSliceResponse(result, comments.hasNext(), nextCursor);
+    }
+
+    @Transactional
+    public NoticeCommentResponse updateComment(Long commentId, CreateNoticeCommentDto dto, UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        NoticeComment comment = noticeCommentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._COMMENT_NOT_FOUND));
+
+        if (!comment.getUser().getEmail().equals(userDetails.getUsername())) {
+            throw new GeneralException(ErrorStatus._FORBIDDEN);
+        }
+
+        comment.updateContent(dto.getContent());
+        return noticeCommentConverter.toResponse(comment);
+    }
+
+    @Transactional
+    public NoticeCommentResponse deleteComment(Long commentId, UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        NoticeComment comment = noticeCommentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._COMMENT_NOT_FOUND));
+
+        if (!comment.getUser().getEmail().equals(userDetails.getUsername())) {
+            throw new GeneralException(ErrorStatus._FORBIDDEN);
+        }
+
+        noticeCommentRepository.delete(comment);
+        return noticeCommentConverter.toResponse(comment);
+    }
+}

--- a/src/main/java/com/fmi/domain/noticecomment/web/controller/NoticeCommentController.java
+++ b/src/main/java/com/fmi/domain/noticecomment/web/controller/NoticeCommentController.java
@@ -34,7 +34,7 @@ public class NoticeCommentController {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"댓글 내용\", \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null}}"
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"댓글 내용\", \"authorId\": 34, \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null, \"canEdit\": true, \"canDelete\": true}}"
                             )
                     )
             ),
@@ -77,7 +77,7 @@ public class NoticeCommentController {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"comments\": [{\"id\": 12, \"content\": \"댓글 내용\", \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null}], \"hasNext\": true, \"cursor\": 12}}"
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"comments\": [{\"id\": 12, \"content\": \"댓글 내용\", \"authorId\": 34, \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null, \"canEdit\": true, \"canDelete\": true}], \"hasNext\": true, \"cursor\": 12}}"
                             )
                     )
             ),
@@ -95,9 +95,10 @@ public class NoticeCommentController {
     public ResponseEntity<ApiResponse<NoticeCommentSliceResponse>> getComments(
             @PathVariable Long noticeId,
             @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        NoticeCommentSliceResponse response = noticeCommentService.getComments(noticeId, cursor, size);
+        NoticeCommentSliceResponse response = noticeCommentService.getComments(noticeId, cursor, size, userDetails);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
@@ -110,7 +111,7 @@ public class NoticeCommentController {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"수정된 댓글\", \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null}}"
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"수정된 댓글\", \"authorId\": 34, \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null, \"canEdit\": true, \"canDelete\": true}}"
                             )
                     )
             ),
@@ -143,7 +144,7 @@ public class NoticeCommentController {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"삭제된 댓글\", \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null}}"
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"삭제된 댓글\", \"authorId\": 34, \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null, \"canEdit\": false, \"canDelete\": true}}"
                             )
                     )
             ),

--- a/src/main/java/com/fmi/domain/noticecomment/web/controller/NoticeCommentController.java
+++ b/src/main/java/com/fmi/domain/noticecomment/web/controller/NoticeCommentController.java
@@ -1,0 +1,168 @@
+package com.fmi.domain.noticecomment.web.controller;
+
+import com.fmi.domain.noticecomment.response.NoticeCommentResponse;
+import com.fmi.domain.noticecomment.response.NoticeCommentSliceResponse;
+import com.fmi.domain.noticecomment.service.NoticeCommentService;
+import com.fmi.domain.noticecomment.web.dto.CreateNoticeCommentDto;
+import com.fmi.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/notices")
+@RequiredArgsConstructor
+@Tag(name = "NoticeComment", description = "공지사항 댓글 API")
+public class NoticeCommentController {
+
+    private final NoticeCommentService noticeCommentService;
+
+    @PostMapping("/{noticeId}/comments")
+    @Operation(summary = "공지사항 댓글 생성", description = "인증된 사용자(관리자 포함)만 작성할 수 있습니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"댓글 내용\", \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null}}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "NOTICE404-NOT_FOUND: 존재하지 않는 공지사항입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"NOTICE404-NOT_FOUND\", \"message\": \"존재하지 않는 공지사항입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "COMMENT404-NOT_FOUND: 존재하지 않는 댓글입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"COMMENT404-NOT_FOUND\", \"message\": \"존재하지 않는 댓글입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<ApiResponse<NoticeCommentResponse>> createComment(
+            @PathVariable Long noticeId,
+            @Valid @RequestBody CreateNoticeCommentDto request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        NoticeCommentResponse response = noticeCommentService.createComment(noticeId, request, userDetails);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @GetMapping("/{noticeId}/comments")
+    @Operation(summary = "공지사항 댓글 조회 (커서 기반 무한스크롤)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"comments\": [{\"id\": 12, \"content\": \"댓글 내용\", \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null}], \"hasNext\": true, \"cursor\": 12}}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "NOTICE404-NOT_FOUND: 존재하지 않는 공지사항입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"NOTICE404-NOT_FOUND\", \"message\": \"존재하지 않는 공지사항입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<ApiResponse<NoticeCommentSliceResponse>> getComments(
+            @PathVariable Long noticeId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") int size) {
+
+        NoticeCommentSliceResponse response = noticeCommentService.getComments(noticeId, cursor, size);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @PutMapping("/comments/{commentId}")
+    @Operation(summary = "공지사항 댓글 수정", description = "작성자만 수정할 수 있으며, 관리자도 본인이 작성한 댓글만 수정 가능합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"수정된 댓글\", \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null}}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "COMMENT404-NOT_FOUND: 존재하지 않는 댓글입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"COMMENT404-NOT_FOUND\", \"message\": \"존재하지 않는 댓글입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<ApiResponse<NoticeCommentResponse>> updateComment(
+            @PathVariable Long commentId,
+            @Valid @RequestBody CreateNoticeCommentDto request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        NoticeCommentResponse response = noticeCommentService.updateComment(commentId, request, userDetails);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    @Operation(summary = "공지사항 댓글 삭제", description = "작성자만 삭제할 수 있으며, 관리자도 본인이 작성한 댓글만 삭제 가능합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": true, \"code\": \"COMMON200\", \"message\": \"성공\", \"result\": {\"id\": 12, \"content\": \"삭제된 댓글\", \"authorName\": \"닉네임\", \"createdAt\": \"2024-01-01T00:00:00\", \"parentId\": null}}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "COMMENT404-NOT_FOUND: 존재하지 않는 댓글입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"COMMENT404-NOT_FOUND\", \"message\": \"존재하지 않는 댓글입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<ApiResponse<NoticeCommentResponse>> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        NoticeCommentResponse response = noticeCommentService.deleteComment(commentId, userDetails);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+}

--- a/src/main/java/com/fmi/domain/noticecomment/web/controller/NoticeCommentController.java
+++ b/src/main/java/com/fmi/domain/noticecomment/web/controller/NoticeCommentController.java
@@ -135,7 +135,7 @@ public class NoticeCommentController {
     }
 
     @DeleteMapping("/comments/{commentId}")
-    @Operation(summary = "공지사항 댓글 삭제", description = "작성자만 삭제할 수 있으며, 관리자도 본인이 작성한 댓글만 삭제 가능합니다.")
+    @Operation(summary = "공지사항 댓글 삭제", description = "작성자 또는 관리자(ROLE_ADMIN)만 삭제할 수 있습니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",

--- a/src/main/java/com/fmi/domain/noticecomment/web/dto/CreateNoticeCommentDto.java
+++ b/src/main/java/com/fmi/domain/noticecomment/web/dto/CreateNoticeCommentDto.java
@@ -1,0 +1,17 @@
+package com.fmi.domain.noticecomment.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateNoticeCommentDto {
+    @NotBlank
+    private String content;
+    private Long parentId;
+}

--- a/src/main/resources/db/migration/V13__create_notice_comment_table.sql
+++ b/src/main/resources/db/migration/V13__create_notice_comment_table.sql
@@ -1,0 +1,16 @@
+-- 공지사항 댓글 테이블 생성
+CREATE TABLE IF NOT EXISTS notice_comment (
+    comment_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    notice_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    parent_id BIGINT NULL,
+    content TEXT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NULL,
+    CONSTRAINT fk_notice_comment_notice FOREIGN KEY (notice_id) REFERENCES notice(id) ON DELETE CASCADE,
+    CONSTRAINT fk_notice_comment_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_notice_comment_parent FOREIGN KEY (parent_id) REFERENCES notice_comment(comment_id) ON DELETE CASCADE,
+    INDEX idx_notice_comment_notice (notice_id),
+    INDEX idx_notice_comment_parent (parent_id),
+    INDEX idx_notice_comment_notice_cursor (notice_id, comment_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## 🧩 관련 이슈

- close feature/#142

## 🛠️ 작업 내용

- 공지사항(Notice)에 댓글 및 대댓글 기능 추가
- 공지사항 수정 및 삭제 기능 추가 (관리자 전용)

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
