### PR TITLE
feat: 문의/신고 슬랙 알림

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    // slack
+    implementation 'com.slack.api:slack-api-client:1.45.3'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ repositories {
 	mavenCentral()
 }
 
+ext['kotlin.version'] = '2.1.0'
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -60,14 +62,6 @@ dependencies {
 
     // slack
     implementation 'com.slack.api:slack-api-client:1.46.0'
-    constraints {
-        implementation("org.jetbrains.kotlin:kotlin-stdlib:2.1.0") {
-            because("SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744 (CVE-2020-29582) remediation")
-        }
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.1.0") {
-            because("Align Kotlin stdlib-jdk8 with fixed kotlin-stdlib")
-        }
-    }
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // slack
-    implementation 'com.slack.api:slack-api-client:1.45.3'
+    implementation 'com.slack.api:slack-api-client:1.46.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,15 @@ dependencies {
 
     // slack
     implementation 'com.slack.api:slack-api-client:1.46.0'
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-stdlib:2.1.0") {
+            because("SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744 (CVE-2020-29582) remediation")
+        }
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.1.0") {
+            because("Align Kotlin stdlib-jdk8 with fixed kotlin-stdlib")
+        }
+    }
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 
     // slack
     implementation 'com.slack.api:slack-api-client:1.46.0'
+    implementation platform("org.jetbrains.kotlin:kotlin-bom:2.1.0")
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/posts/{postId}","/posts").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                         // 공지사항, 공개 문의 - 공개 API (경로 개편)
-                        .requestMatchers("/notices/**", "/inquiries/public/**").permitAll()
+                        .requestMatchers("/notices/**", "/inquiries/public/**", "/inquiries").permitAll()
                         // 관리자 전용 API 보호
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/java/com/fmi/domain/inquiry/event/InquiryEvent.java
+++ b/src/main/java/com/fmi/domain/inquiry/event/InquiryEvent.java
@@ -1,0 +1,30 @@
+package com.fmi.domain.inquiry.event;
+
+import com.fmi.domain.inquiry.data.Inquiry;
+
+import java.time.LocalDateTime;
+
+public record InquiryEvent(
+        String title,
+        String content,
+        String categoryDescription,
+        String email,
+        LocalDateTime createdAt
+) {
+    public static InquiryEvent from(Inquiry inquiry) {
+        String categoryLabel = inquiry.getCategory().getDescription();
+
+        String resolvedEmail = (inquiry.getUser() != null)
+                ? inquiry.getUser().getEmail()
+                : inquiry.getEmail();
+
+        return new InquiryEvent(
+                inquiry.getTitle(),
+                inquiry.getContent(),
+                categoryLabel,
+                resolvedEmail,
+                inquiry.getCreatedAt() != null ? inquiry.getCreatedAt() : LocalDateTime.now()
+        );
+    }
+
+}

--- a/src/main/java/com/fmi/domain/inquiry/listener/InquiryEventListener.java
+++ b/src/main/java/com/fmi/domain/inquiry/listener/InquiryEventListener.java
@@ -1,0 +1,23 @@
+package com.fmi.domain.inquiry.listener;
+
+import com.fmi.domain.inquiry.event.InquiryEvent;
+import com.fmi.global.service.SlackService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class InquiryEventListener {
+
+    private final SlackService slackService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleInquiryEvent(InquiryEvent event) {
+
+        slackService.sendInquiryNotification(event);
+    }
+}

--- a/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
@@ -1,6 +1,7 @@
 package com.fmi.domain.inquiry.service;
 
 import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.inquiry.converter.InquiryConverter;
 import com.fmi.domain.inquiry.data.Inquiry;
 import com.fmi.domain.inquiry.data.InquiryReply;
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,12 +38,16 @@ public class InquiryService {
     private final NotificationService notificationService;
     private final EmailService emailService;
     private final ApplicationEventPublisher eventPublisher;
-    
+    private final UserRepository userRepository;
+
     /**
      * 1:1 개인 문의 생성
      */
     @Transactional
-    public Long createInquiry(InquiryCreateRequestDTO request, User user) {
+    public Long createInquiry(InquiryCreateRequestDTO request, UserDetails userDetails) {
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
         Inquiry.InquiryBuilder builder = Inquiry.builder()
                 .title(request.getTitle())
                 .content(request.getContent())

--- a/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
@@ -2,27 +2,28 @@ package com.fmi.domain.inquiry.service;
 
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.inquiry.converter.InquiryConverter;
+import com.fmi.domain.inquiry.data.Inquiry;
 import com.fmi.domain.inquiry.data.InquiryReply;
-import com.fmi.domain.inquiry.data.enums.InquiryCategory;
 import com.fmi.domain.inquiry.data.enums.InquiryStatus;
 import com.fmi.domain.inquiry.data.enums.InquiryType;
+import com.fmi.domain.inquiry.event.InquiryEvent;
 import com.fmi.domain.inquiry.repository.InquiryReplyRepository;
 import com.fmi.domain.inquiry.repository.InquiryRepository;
 import com.fmi.domain.inquiry.web.dto.request.InquiryCreateRequestDTO;
 import com.fmi.domain.inquiry.web.dto.response.InquiryDetailDTO;
 import com.fmi.domain.inquiry.web.dto.response.InquiryListDTO;
+import com.fmi.domain.notification.data.enums.NotificationType;
 import com.fmi.domain.notification.data.enums.ReferenceType;
+import com.fmi.domain.notification.service.NotificationService;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
+import com.fmi.service.EmailService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.fmi.domain.inquiry.data.Inquiry;
-import com.fmi.domain.notification.data.enums.NotificationType;
-import com.fmi.domain.notification.service.NotificationService;
-import com.fmi.service.EmailService;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +35,7 @@ public class InquiryService {
     private final InquiryConverter inquiryConverter;
     private final NotificationService notificationService;
     private final EmailService emailService;
+    private final ApplicationEventPublisher eventPublisher;
     
     /**
      * 1:1 개인 문의 생성
@@ -53,6 +55,8 @@ public class InquiryService {
         }
 
         Inquiry saved = inquiryRepository.save(builder.build());
+
+        eventPublisher.publishEvent(InquiryEvent.from(saved));
         
         // 문의 접수 이메일 발송
         try {

--- a/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
@@ -45,22 +45,31 @@ public class InquiryService {
      */
     @Transactional
     public Long createInquiry(InquiryCreateRequestDTO request, UserDetails userDetails) {
-        User user = userRepository.findByEmail(userDetails.getUsername())
-                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        Inquiry.InquiryBuilder builder = Inquiry.builder()
-                .title(request.getTitle())
-                .content(request.getContent())
-                .category(request.getCategory())
-                .inquiryType(InquiryType.PRIVATE)  // 항상 1:1 개인 문의로 설정
-                .user(user);
+        User user = null;
+        String resolvedEmail;
 
-        // 비회원 문의인 경우 이메일 설정
-        if (user == null && request.getEmail() != null && !request.getEmail().isBlank()) {
-            builder.email(request.getEmail());
+        if (userDetails != null) {
+            user = userRepository.findByEmail(userDetails.getUsername())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+            resolvedEmail = user.getEmail();
+        } else {
+            if (request.getEmail() == null || request.getEmail().isBlank()) {
+                throw new GeneralException(ErrorStatus._INQUIRY_GUEST_EMAIL_REQUIRED);
+            }
+            resolvedEmail = request.getEmail().trim();
         }
 
-        Inquiry saved = inquiryRepository.save(builder.build());
+        Inquiry saved = inquiryRepository.save(
+                Inquiry.builder()
+                        .title(request.getTitle())
+                        .content(request.getContent())
+                        .category(request.getCategory())
+                        .inquiryType(InquiryType.PRIVATE)
+                        .user(user) // 회원이면 user 세팅
+                        .email(user == null ? resolvedEmail : null) // 비회원이면 email 컬럼 세팅
+                        .build()
+        );
 
         eventPublisher.publishEvent(InquiryEvent.from(saved));
         

--- a/src/main/java/com/fmi/domain/inquiry/web/controller/InquiryController.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/controller/InquiryController.java
@@ -1,10 +1,7 @@
 package com.fmi.domain.inquiry.web.controller;
 
 import com.fmi.domain.auth.data.User;
-import com.fmi.domain.inquiry.data.enums.InquiryCategory;
-import com.fmi.domain.inquiry.data.enums.InquiryStatus;
 import com.fmi.domain.inquiry.service.InquiryService;
- 
 import com.fmi.domain.inquiry.web.dto.response.InquiryDetailDTO;
 import com.fmi.domain.inquiry.web.dto.response.InquiryListDTO;
 import com.fmi.global.apiPayload.ApiResponse;
@@ -21,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -42,8 +40,8 @@ public class InquiryController {
     })
     public ApiResponse<Long> createInquiry(
             @Valid @RequestBody com.fmi.domain.inquiry.web.dto.request.InquiryCreateRequestDTO request,
-            @AuthenticationPrincipal User user) {
-        Long inquiryId = inquiryService.createInquiry(request, user);
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Long inquiryId = inquiryService.createInquiry(request, userDetails);
         return ApiResponse.onSuccess(inquiryId);
     }
     

--- a/src/main/java/com/fmi/domain/report/event/ReportEvent.java
+++ b/src/main/java/com/fmi/domain/report/event/ReportEvent.java
@@ -1,0 +1,17 @@
+package com.fmi.domain.report.event;
+
+import com.fmi.domain.report.data.enums.ReportType;
+import org.hibernate.tool.schema.TargetType;
+
+import java.time.LocalDateTime;
+
+public record ReportEvent(
+        Long reportId,
+        TargetType targetType,
+        Long targetId,
+        ReportType reportType,
+        String reason,
+        Long reporterId,
+        String reporterNickname,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/fmi/domain/report/event/ReportEvent.java
+++ b/src/main/java/com/fmi/domain/report/event/ReportEvent.java
@@ -1,14 +1,14 @@
 package com.fmi.domain.report.event;
 
+import com.fmi.domain.report.data.enums.ReportTargetType;
 import com.fmi.domain.report.data.enums.ReportType;
-import org.hibernate.tool.schema.TargetType;
 
 import java.time.LocalDateTime;
 
 public record ReportEvent(
         Long reportId,
-        TargetType targetType,
         Long targetId,
+        ReportTargetType targetType,
         ReportType reportType,
         String reason,
         Long reporterId,

--- a/src/main/java/com/fmi/domain/report/event/ReportEvent.java
+++ b/src/main/java/com/fmi/domain/report/event/ReportEvent.java
@@ -1,5 +1,7 @@
 package com.fmi.domain.report.event;
 
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.report.data.Report;
 import com.fmi.domain.report.data.enums.ReportTargetType;
 import com.fmi.domain.report.data.enums.ReportType;
 
@@ -14,4 +16,17 @@ public record ReportEvent(
         Long reporterId,
         String reporterNickname,
         LocalDateTime createdAt
-) {}
+) {
+    public static ReportEvent from(Report report, User reporter) {
+        return new ReportEvent(
+                report.getReportId(),
+                report.getTargetId(),
+                report.getTargetType(),
+                report.getReportType(),
+                report.getReason(),
+                reporter.getId(),
+                reporter.getNickname(),
+                report.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fmi/domain/report/listener/ReportListener.java
+++ b/src/main/java/com/fmi/domain/report/listener/ReportListener.java
@@ -1,0 +1,26 @@
+package com.fmi.domain.report.listener;
+
+import com.fmi.domain.report.event.ReportEvent;
+import com.fmi.global.service.SlackService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReportListener {
+
+    private final SlackService slackService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onReportCreated(ReportEvent event) {
+        try {
+            slackService.sendReportNotification(event);
+        } catch (Exception e) {
+            log.error("신고 슬랙 알림 전송 실패. reportId={}", event.reportId(), e);
+        }
+    }
+}

--- a/src/main/java/com/fmi/domain/report/service/ReportService.java
+++ b/src/main/java/com/fmi/domain/report/service/ReportService.java
@@ -72,17 +72,7 @@ public class ReportService {
         
         Report saved = reportRepository.save(report);
 
-        eventPublisher.publishEvent(new ReportEvent(
-                saved.getReportId(),
-                saved.getTargetId(),
-                saved.getTargetType(),
-                saved.getReportType(),
-                saved.getReason(),
-                user.getId(),
-                user.getNickname(),
-                saved.getCreatedAt()
-        ));
-
+        eventPublisher.publishEvent(ReportEvent.from(saved, user));
 
         // 신고 접수 이메일 발송 (신고자에게)
         try {

--- a/src/main/java/com/fmi/domain/report/service/ReportService.java
+++ b/src/main/java/com/fmi/domain/report/service/ReportService.java
@@ -48,8 +48,7 @@ public class ReportService {
      */
     @Transactional
     public Long createReport(ReportCreateRequestDTO request, UserDetails userDetails) {
-        String email = userDetails.getUsername();
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findByEmail(userDetails.getUsername())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
         // 중복 신고 확인

--- a/src/main/java/com/fmi/domain/report/service/ReportService.java
+++ b/src/main/java/com/fmi/domain/report/service/ReportService.java
@@ -4,7 +4,9 @@ import com.fmi.domain.auth.data.User;
 import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.chatmessage.repository.ChatMessageRepository;
 import com.fmi.domain.comment.repository.CommentRepository;
+import com.fmi.domain.notification.data.enums.NotificationType;
 import com.fmi.domain.notification.data.enums.ReferenceType;
+import com.fmi.domain.notification.service.NotificationService;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.report.converter.ReportConverter;
@@ -16,14 +18,13 @@ import com.fmi.domain.report.web.dto.request.ReportCreateRequestDTO;
 import com.fmi.domain.report.web.dto.response.ReportListDTO;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
+import com.fmi.service.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.fmi.domain.notification.service.NotificationService;
-import com.fmi.domain.notification.data.enums.NotificationType;
-import com.fmi.service.EmailService;
 
 @Service
 @RequiredArgsConstructor
@@ -38,12 +39,16 @@ public class ReportService {
     private final ReportConverter reportConverter;
     private final NotificationService notificationService;
     private final EmailService emailService;
-    
+
     /**
      * 신고하기 (통합)
      */
     @Transactional
-    public Long createReport(ReportCreateRequestDTO request, User user) {
+    public Long createReport(ReportCreateRequestDTO request, UserDetails userDetails) {
+        String email = userDetails.getUsername();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
         // 중복 신고 확인
         reportRepository.findByReporterAndTargetTypeAndTargetId(
                 user, request.getTargetType(), request.getTargetId())

--- a/src/main/java/com/fmi/domain/report/service/ReportService.java
+++ b/src/main/java/com/fmi/domain/report/service/ReportService.java
@@ -13,6 +13,7 @@ import com.fmi.domain.report.converter.ReportConverter;
 import com.fmi.domain.report.data.Report;
 import com.fmi.domain.report.data.enums.ReportStatus;
 import com.fmi.domain.report.data.enums.ReportTargetType;
+import com.fmi.domain.report.event.ReportEvent;
 import com.fmi.domain.report.repository.ReportRepository;
 import com.fmi.domain.report.web.dto.request.ReportCreateRequestDTO;
 import com.fmi.domain.report.web.dto.response.ReportListDTO;
@@ -20,6 +21,7 @@ import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import com.fmi.service.EmailService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -39,6 +41,7 @@ public class ReportService {
     private final ReportConverter reportConverter;
     private final NotificationService notificationService;
     private final EmailService emailService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 신고하기 (통합)
@@ -69,7 +72,19 @@ public class ReportService {
                 .build();
         
         Report saved = reportRepository.save(report);
-        
+
+        eventPublisher.publishEvent(new ReportEvent(
+                saved.getReportId(),
+                saved.getTargetId(),
+                saved.getTargetType(),
+                saved.getReportType(),
+                saved.getReason(),
+                user.getId(),
+                user.getNickname(),
+                saved.getCreatedAt()
+        ));
+
+
         // 신고 접수 이메일 발송 (신고자에게)
         try {
             String targetTitle = getTargetTitle(saved.getTargetType(), saved.getTargetId());

--- a/src/main/java/com/fmi/domain/report/web/controller/ReportController.java
+++ b/src/main/java/com/fmi/domain/report/web/controller/ReportController.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -56,9 +57,9 @@ public class ReportController {
     })
     public ApiResponse<Long> createReport(
             @Valid @RequestBody ReportCreateRequestDTO request,
-            @AuthenticationPrincipal User user) {
+            @AuthenticationPrincipal UserDetails userDetails) {
         
-        Long reportId = reportService.createReport(request, user);
+        Long reportId = reportService.createReport(request, userDetails);
         return ApiResponse.onSuccess(reportId);
     }
     

--- a/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
@@ -71,7 +71,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // 문의 관련 응답
     _INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY404-NOT_FOUND", "존재하지 않는 문의입니다."),
     _INQUIRY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "INQUIRY403-ACCESS_DENIED", "해당 문의를 조회할 권한이 없습니다."),
-    
+    _INQUIRY_GUEST_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "INQUIRY400-GUEST_EMAIL_REQUIRED", "비회원 문의는 이메일이 필수입니다."),
+
     // 신고 관련 응답
     _REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "REPORT409-ALREADY_EXISTS", "이미 신고한 대상입니다."),
     _REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT404-NOT_FOUND", "존재하지 않는 신고입니다."),

--- a/src/main/java/com/fmi/global/service/SlackService.java
+++ b/src/main/java/com/fmi/global/service/SlackService.java
@@ -1,0 +1,43 @@
+package com.fmi.global.service;
+
+import com.fmi.domain.inquiry.event.InquiryEvent;
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import com.slack.api.webhook.Payload;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+public class SlackService {
+
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
+
+    public void sendInquiryNotification(InquiryEvent event) {
+        try {
+            Slack slack = Slack.getInstance();
+
+            Payload payload = Payload.builder()
+                    .text("🔔 *새로운 1:1 문의가 등록되었습니다!*")
+                    .attachments(List.of(Attachment.builder()
+                            .color("#36a64f")
+                            .fields(List.of(
+                                    new Field("문의 제목", event.title(), false),
+                                    new Field("카테고리", "📍 " + event.categoryDescription(), true),
+                                    new Field("작성자(이메일)", event.email(), true),
+                                    new Field("문의 내용", event.content(), false),
+                                    new Field("작성일시", event.createdAt().toString(), true)
+                            )).build()))
+                    .build();
+
+            slack.send(webhookUrl, payload);
+        } catch (Exception e) {
+            log.error("슬랙 알림 전송 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/fmi/global/service/SlackService.java
+++ b/src/main/java/com/fmi/global/service/SlackService.java
@@ -15,8 +15,8 @@ import java.util.List;
 @Slf4j
 public class SlackService {
 
-    @Value("${slack.webhook.url}")
-    private String webhookUrl;
+    @Value("${slack.webhook.inquiry-url}")
+    private String inquiryWebhookUrl;
 
     public void sendInquiryNotification(InquiryEvent event) {
         try {
@@ -35,7 +35,7 @@ public class SlackService {
                             )).build()))
                     .build();
 
-            slack.send(webhookUrl, payload);
+            slack.send(inquiryWebhookUrl, payload);
         } catch (Exception e) {
             log.error("슬랙 알림 전송 실패", e);
         }

--- a/src/main/java/com/fmi/global/service/SlackService.java
+++ b/src/main/java/com/fmi/global/service/SlackService.java
@@ -1,6 +1,7 @@
 package com.fmi.global.service;
 
 import com.fmi.domain.inquiry.event.InquiryEvent;
+import com.fmi.domain.report.event.ReportEvent;
 import com.slack.api.Slack;
 import com.slack.api.model.Attachment;
 import com.slack.api.model.Field;
@@ -9,35 +10,78 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Service
 @Slf4j
 public class SlackService {
 
+    private final Slack slack = Slack.getInstance();
+
     @Value("${slack.webhook.inquiry-url}")
     private String inquiryWebhookUrl;
 
+    @Value("${slack.webhook.report-url}")
+    private String reportWebhookUrl;
+
+    private static final DateTimeFormatter DATE_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
     public void sendInquiryNotification(InquiryEvent event) {
         try {
-            Slack slack = Slack.getInstance();
-
             Payload payload = Payload.builder()
                     .text("🔔 *새로운 1:1 문의가 등록되었습니다!*")
-                    .attachments(List.of(Attachment.builder()
-                            .color("#36a64f")
-                            .fields(List.of(
-                                    new Field("문의 제목", event.title(), false),
-                                    new Field("카테고리", "📍 " + event.categoryDescription(), true),
-                                    new Field("작성자(이메일)", event.email(), true),
-                                    new Field("문의 내용", event.content(), false),
-                                    new Field("작성일시", event.createdAt().toString(), true)
-                            )).build()))
+                    .attachments(List.of(
+                            Attachment.builder()
+                                    .color("#36a64f")
+                                    .fields(List.of(
+                                            new Field("문의 제목", event.title(), false),
+                                            new Field("카테고리", "📍 " + event.categoryDescription(), false),
+                                            new Field("작성자(이메일)", event.email(), false),
+                                            new Field("작성일시", format(event.createdAt()), false),
+                                            new Field("문의 내용", event.content(), false)
+                                    ))
+                                    .build()
+                    ))
                     .build();
 
             slack.send(inquiryWebhookUrl, payload);
         } catch (Exception e) {
-            log.error("슬랙 알림 전송 실패", e);
+            log.error("슬랙 문의 알림 전송 실패", e);
         }
+    }
+
+    public void sendReportNotification(ReportEvent event) {
+        try {
+            Payload payload = Payload.builder()
+                    .text("🚨 *신고가 접수되었습니다!*")
+                    .attachments(List.of(
+                            Attachment.builder()
+                                    .color("#d40e0d")
+                                    .fields(List.of(
+                                            new Field("신고 유형", "⚠️ " + event.reportType().getDescription(), false),
+                                            new Field("신고 항목", "📍 " + event.targetType().getDescription() + " (id=" + event.targetId() + ")", false),
+                                            new Field("사유", normalizeReason(event.reason()), false),
+                                            new Field("신고자", event.reporterNickname() + " (id=" + event.reporterId() + ")", false),
+                                            new Field("접수 시각", format(event.createdAt()), false)
+                                    ))
+                                    .build()
+                    ))
+                    .build();
+
+            slack.send(reportWebhookUrl, payload);
+        } catch (Exception e) {
+            log.error("슬랙 신고 알림 전송 실패. reportId={}", event.reportId(), e);
+        }
+    }
+
+    private String normalizeReason(String reason) {
+        return (reason == null || reason.isBlank()) ? "(사유 없음)" : reason;
+    }
+
+    private String format(LocalDateTime time) {
+        return (time == null) ? "-" : time.format(DATE_FORMAT);
     }
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #133 

## 🛠️ 작업 내용

- 문의 등록시 슬랙 알림을 전송합니다.
- 신고 등록시 슬랙 알림을 전송합니다. 

## 📢 참고 및 특이사항

- 이벤트로 Slack 알림을 분리해 관심사 분리 및 확장성을 확보하고, AFTER_COMMIT로 정합성을 보장했습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
