### PR TITLE
fix: kakao login LazyInitializationException 방지

### DIFF
--- a/src/main/java/com/fmi/domain/auth/repository/SocialAccountsRepository.java
+++ b/src/main/java/com/fmi/domain/auth/repository/SocialAccountsRepository.java
@@ -4,11 +4,16 @@ import com.fmi.domain.auth.data.SocialAccounts;
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.Enum.Provider;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface SocialAccountsRepository extends JpaRepository<SocialAccounts, Long> {
     Optional<SocialAccounts> findByProviderAndProviderId(Provider provider, String providerId);
+    @Query("select sa from SocialAccounts sa join fetch sa.user where sa.provider = :provider and sa.providerId = :providerId")
+    Optional<SocialAccounts> findByProviderAndProviderIdWithUser(@Param("provider") Provider provider,
+                                                                 @Param("providerId") String providerId);
     Optional<SocialAccounts> findByUser(User user);
 }
 

--- a/src/main/java/com/fmi/domain/auth/service/SocialLoginService.java
+++ b/src/main/java/com/fmi/domain/auth/service/SocialLoginService.java
@@ -31,7 +31,7 @@ public class SocialLoginService {
         String providerId = String.valueOf(kakaoId);
 
         // 이미 존재하는 소셜 계정인지 확인
-        return socialAccountsRepository.findByProviderAndProviderId(Provider.KAKAO, providerId)
+        return socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId)
                 .map(existingAccount -> {
                     log.info("기존 카카오 계정 찾음: providerId={}, userId={}", providerId, existingAccount.getUser().getId());
                     return existingAccount.getUser();
@@ -60,7 +60,7 @@ public class SocialLoginService {
 
                     // 동시성 문제 방지를 위해 저장 전 다시 한 번 확인
                     // (다른 스레드가 이미 저장했을 수 있음)
-                    Optional<SocialAccounts> existingAccount = socialAccountsRepository.findByProviderAndProviderId(Provider.KAKAO, providerId);
+                    Optional<SocialAccounts> existingAccount = socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId);
                     if (existingAccount.isPresent()) {
                         log.info("동시 요청으로 인해 이미 소셜 계정이 생성됨: providerId={}, userId={}", providerId, existingAccount.get().getUser().getId());
                         return existingAccount.get().getUser();
@@ -79,7 +79,7 @@ public class SocialLoginService {
                     } catch (DataIntegrityViolationException e) {
                         log.warn("소셜 계정 저장 중 중복 키 위반 발생 (동시 요청 가능성): providerId={}, error={}", providerId, e.getMessage());
                         // 중복 키 위반 시 다시 조회해서 반환
-                        Optional<SocialAccounts> retryAccount = socialAccountsRepository.findByProviderAndProviderId(Provider.KAKAO, providerId);
+                        Optional<SocialAccounts> retryAccount = socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId);
                         if (retryAccount.isPresent()) {
                             log.info("중복 키 위반 후 재조회 성공: providerId={}, userId={}", providerId, retryAccount.get().getUser().getId());
                             return retryAccount.get().getUser();


### PR DESCRIPTION
## 🧩 관련 이슈

- close fix#154 

## 🛠️ 작업 내용

- 카카오 로그인 요청 시 LazyInitializationException 제거
- 백엔드 500 에러 방지

## 📢 참고 및 특이사항



## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
