### PR TITLE
fix: 카카오 로그인 User 재조회로 LazyInitializationException 방지

### DIFF
--- a/src/main/java/com/fmi/domain/auth/service/SocialLoginService.java
+++ b/src/main/java/com/fmi/domain/auth/service/SocialLoginService.java
@@ -31,64 +31,68 @@ public class SocialLoginService {
         String providerId = String.valueOf(kakaoId);
 
         // 이미 존재하는 소셜 계정인지 확인
-        return socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId)
-                .map(existingAccount -> {
-                    log.info("기존 카카오 계정 찾음: providerId={}, userId={}", providerId, existingAccount.getUser().getId());
-                    return existingAccount.getUser();
-                })
+        Optional<SocialAccounts> existingAccount = socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId);
+        if (existingAccount.isPresent()) {
+            log.info("기존 카카오 계정 찾음: providerId={}, userId={}", providerId, existingAccount.get().getUser().getId());
+            return reloadUser(existingAccount.get().getUser());
+        }
+
+        log.info("새 카카오 계정 생성 시작: providerId={}", providerId);
+
+        // 이메일이 없으면 대체 이메일 생성
+        String effectiveEmail = (email != null && !email.isBlank())
+                ? email
+                : ("kakao_" + providerId + "@kakao.local");
+
+        // 사용자 존재 여부 확인(이메일 기준)
+        User user = userRepository.findByEmail(effectiveEmail)
                 .orElseGet(() -> {
-                    log.info("새 카카오 계정 생성 시작: providerId={}", providerId);
-                    
-                    // 이메일이 없으면 대체 이메일 생성
-                    String effectiveEmail = (email != null && !email.isBlank())
-                            ? email
-                            : ("kakao_" + providerId + "@kakao.local");
-
-                    // 사용자 존재 여부 확인(이메일 기준)
-                    User user = userRepository.findByEmail(effectiveEmail)
-                            .orElseGet(() -> {
-                                log.info("새 사용자 생성: email={}", effectiveEmail);
-                                User u = AuthConverter.toSocialUserEntity(
-                                        kakaoId,
-                                        email,
-                                        nickname,
-                                        profileImageUrl,
-                                        passwordEncoder.encode("{noop}-" + providerId)
-                                );
-                                return userRepository.save(u);
-                            });
-
-                    // 동시성 문제 방지를 위해 저장 전 다시 한 번 확인
-                    // (다른 스레드가 이미 저장했을 수 있음)
-                    Optional<SocialAccounts> existingAccount = socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId);
-                    if (existingAccount.isPresent()) {
-                        log.info("동시 요청으로 인해 이미 소셜 계정이 생성됨: providerId={}, userId={}", providerId, existingAccount.get().getUser().getId());
-                        return existingAccount.get().getUser();
-                    }
-
-                    // 소셜 계정 연결 저장
-                    try {
-                        SocialAccounts account = SocialAccounts.builder()
-                                .user(user)
-                                .provider(Provider.KAKAO)
-                                .providerId(providerId)
-                                .build();
-                        SocialAccounts savedAccount = socialAccountsRepository.save(account);
-                        log.info("소셜 계정 저장 성공: socialId={}, providerId={}, userId={}", savedAccount.getSocialId(), providerId, user.getId());
-                        return user;
-                    } catch (DataIntegrityViolationException e) {
-                        log.warn("소셜 계정 저장 중 중복 키 위반 발생 (동시 요청 가능성): providerId={}, error={}", providerId, e.getMessage());
-                        // 중복 키 위반 시 다시 조회해서 반환
-                        Optional<SocialAccounts> retryAccount = socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId);
-                        if (retryAccount.isPresent()) {
-                            log.info("중복 키 위반 후 재조회 성공: providerId={}, userId={}", providerId, retryAccount.get().getUser().getId());
-                            return retryAccount.get().getUser();
-                        }
-                        // 재조회도 실패한 경우
-                        log.error("소셜 계정 저장 실패 후 재조회도 실패: providerId={}, 원본 에러: {}", providerId, e.getMessage(), e);
-                        throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
-                    }
+                    log.info("새 사용자 생성: email={}", effectiveEmail);
+                    User u = AuthConverter.toSocialUserEntity(
+                            kakaoId,
+                            email,
+                            nickname,
+                            profileImageUrl,
+                            passwordEncoder.encode("{noop}-" + providerId)
+                    );
+                    return userRepository.save(u);
                 });
+
+        // 동시성 문제 방지를 위해 저장 전 다시 한 번 확인
+        // (다른 스레드가 이미 저장했을 수 있음)
+        Optional<SocialAccounts> existingAccountAfterUser = socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId);
+        if (existingAccountAfterUser.isPresent()) {
+            log.info("동시 요청으로 인해 이미 소셜 계정이 생성됨: providerId={}, userId={}", providerId, existingAccountAfterUser.get().getUser().getId());
+            return reloadUser(existingAccountAfterUser.get().getUser());
+        }
+
+        // 소셜 계정 연결 저장
+        try {
+            SocialAccounts account = SocialAccounts.builder()
+                    .user(user)
+                    .provider(Provider.KAKAO)
+                    .providerId(providerId)
+                    .build();
+            SocialAccounts savedAccount = socialAccountsRepository.save(account);
+            log.info("소셜 계정 저장 성공: socialId={}, providerId={}, userId={}", savedAccount.getSocialId(), providerId, user.getId());
+            return reloadUser(user);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("소셜 계정 저장 중 중복 키 위반 발생 (동시 요청 가능성): providerId={}, error={}", providerId, e.getMessage());
+            // 중복 키 위반 시 다시 조회해서 반환
+            Optional<SocialAccounts> retryAccount = socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId);
+            if (retryAccount.isPresent()) {
+                log.info("중복 키 위반 후 재조회 성공: providerId={}, userId={}", providerId, retryAccount.get().getUser().getId());
+                return reloadUser(retryAccount.get().getUser());
+            }
+            // 재조회도 실패한 경우
+            log.error("소셜 계정 저장 실패 후 재조회도 실패: providerId={}, 원본 에러: {}", providerId, e.getMessage(), e);
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private User reloadUser(User user) {
+        return userRepository.findById(user.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
     }
 }
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close fix/#159

## 🛠️ 작업 내용

- LazyInitializationException 재발 방지 로직

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
