### PR TITLE
fix: @AuthenticationPrincipal UserDetails 기반으로 사용자 조회 일원화

### DIFF
--- a/src/main/java/com/fmi/domain/inquiry/web/controller/InquiryController.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/controller/InquiryController.java
@@ -1,11 +1,14 @@
 package com.fmi.domain.inquiry.web.controller;
 
 import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.inquiry.service.InquiryService;
  
 import com.fmi.domain.inquiry.web.dto.response.InquiryDetailDTO;
 import com.fmi.domain.inquiry.web.dto.response.InquiryListDTO;
 import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -19,6 +22,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 public class InquiryController {
     
     private final InquiryService inquiryService;
+    private final UserRepository userRepository;
     
     /**
      * 1:1 개인 문의 작성
@@ -40,7 +45,12 @@ public class InquiryController {
     })
     public ApiResponse<Long> createInquiry(
             @Valid @RequestBody com.fmi.domain.inquiry.web.dto.request.InquiryCreateRequestDTO request,
-            @AuthenticationPrincipal User user) {
+            @AuthenticationPrincipal UserDetails userDetails) {
+        User user = null;
+        if (userDetails != null) {
+            user = userRepository.findByEmail(userDetails.getUsername())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+        }
         Long inquiryId = inquiryService.createInquiry(request, user);
         return ApiResponse.onSuccess(inquiryId);
     }
@@ -56,10 +66,12 @@ public class InquiryController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 문의 내역 조회 성공")
     })
     public ApiResponse<Page<InquiryListDTO>> getMyInquiries(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<InquiryListDTO> inquiries = inquiryService.getMyInquiries(user, pageable);
         return ApiResponse.onSuccess(inquiries);
@@ -96,8 +108,10 @@ public class InquiryController {
     })
     public ApiResponse<InquiryDetailDTO> getInquiryDetail(
             @PathVariable Long inquiryId,
-            @AuthenticationPrincipal User user) {
+            @AuthenticationPrincipal UserDetails userDetails) {
         
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         InquiryDetailDTO inquiry = inquiryService.getInquiryDetail(inquiryId, user);
         return ApiResponse.onSuccess(inquiry);
     }

--- a/src/main/java/com/fmi/domain/notification/web/controller/NotificationController.java
+++ b/src/main/java/com/fmi/domain/notification/web/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.fmi.domain.notification.web.controller;
 
 import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.notification.service.NotificationService;
 import com.fmi.domain.notification.web.dto.response.NotificationListDTO;
 import com.fmi.domain.notification.web.dto.response.NotificationSettingsDTO;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
     
     private final NotificationService notificationService;
+    private final UserRepository userRepository;
     private static final int MAX_BATCH_SIZE = 1000;
     
     /**
@@ -41,11 +44,13 @@ public class NotificationController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 목록 조회 성공")
     })
     public ApiResponse<Page<NotificationListDTO>> getMyNotifications(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(required = false, defaultValue = "false") Boolean unreadOnly,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<NotificationListDTO> notifications = notificationService.getMyNotifications(user, unreadOnly, pageable);
         return ApiResponse.onSuccess(notifications);
@@ -62,7 +67,9 @@ public class NotificationController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 설정 조회 성공")
     })
-    public ApiResponse<NotificationSettingsDTO> getSettings(@AuthenticationPrincipal User user) {
+    public ApiResponse<NotificationSettingsDTO> getSettings(@AuthenticationPrincipal UserDetails userDetails) {
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         NotificationSettingsDTO settings = notificationService.getSettings(user);
         return ApiResponse.onSuccess(settings);
     }
@@ -79,8 +86,10 @@ public class NotificationController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 설정 변경 성공")
     })
     public ApiResponse<NotificationSettingsDTO> updateSettings(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody com.fmi.domain.notification.web.dto.request.NotificationSettingsUpdateDTO request) {
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         NotificationSettingsDTO settings = notificationService.updateSettings(user, request);
         return ApiResponse.onSuccess(settings);
     }
@@ -105,9 +114,11 @@ public class NotificationController {
             )
     })
     public ApiResponse<String> markAsReadBatch(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody IdsRequest request
     ) {
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         validateBatch(request);
         int updated = notificationService.markAsReadBatch(user, request.getIds());
         return ApiResponse.onSuccess(updated + "개의 알림을 읽음 처리했습니다.");
@@ -143,9 +154,11 @@ public class NotificationController {
             )
     })
     public ApiResponse<String> deleteBatch(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody IdsRequest request
     ) {
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         validateBatch(request);
         int deleted = notificationService.deleteBatch(user, request.getIds());
         return ApiResponse.onSuccess(deleted + "개의 알림을 삭제했습니다.");

--- a/src/main/java/com/fmi/domain/report/web/controller/BlockController.java
+++ b/src/main/java/com/fmi/domain/report/web/controller/BlockController.java
@@ -1,15 +1,19 @@
 package com.fmi.domain.report.web.controller;
 
 import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.userblock.data.BlockedUser;
 import com.fmi.domain.userblock.service.BlockService;
 import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,6 +26,7 @@ import java.util.List;
 public class BlockController {
 
     private final BlockService blockService;
+    private final UserRepository userRepository;
 
     @PostMapping("/{userId}/block")
     @Operation(summary = "유저 차단", description = "로그인 사용자가 대상 유저를 차단합니다.")
@@ -31,8 +36,10 @@ public class BlockController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USER404-NOT_FOUND: 존재하지 않는 회원입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "USER409-ALREADY_BLOCKED: 이미 차단한 사용자입니다")
     })
-    public ApiResponse<String> block(@AuthenticationPrincipal User me, @PathVariable Long userId) {
-        blockService.block(me.getId(), userId);
+    public ApiResponse<String> block(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long userId) {
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+        blockService.block(user.getId(), userId);
         return ApiResponse.onSuccess("OK");
     }
 
@@ -43,8 +50,10 @@ public class BlockController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USER404-NOT_FOUND: 존재하지 않는 회원입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USER404-NOT_BLOCKED: 차단되지 않은 사용자입니다")
     })
-    public ApiResponse<String> unblock(@AuthenticationPrincipal User me, @PathVariable Long userId) {
-        blockService.unblock(me.getId(), userId);
+    public ApiResponse<String> unblock(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long userId) {
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+        blockService.unblock(user.getId(), userId);
         return ApiResponse.onSuccess("OK");
     }
 
@@ -53,8 +62,10 @@ public class BlockController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "차단 유저 목록 조회 성공")
     })
-    public ApiResponse<List<Long>> list(@AuthenticationPrincipal User me) {
-        List<BlockedUser> blocks = blockService.list(me.getId());
+    public ApiResponse<List<Long>> list(@AuthenticationPrincipal UserDetails userDetails) {
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+        List<BlockedUser> blocks = blockService.list(user.getId());
         List<Long> ids = blocks.stream().map(b -> b.getBlocked().getId()).toList();
         return ApiResponse.onSuccess(ids);
     }

--- a/src/main/java/com/fmi/domain/report/web/controller/ReportController.java
+++ b/src/main/java/com/fmi/domain/report/web/controller/ReportController.java
@@ -1,11 +1,14 @@
 package com.fmi.domain.report.web.controller;
 
 import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.report.data.enums.ReportStatus;
 import com.fmi.domain.report.service.ReportService;
 import com.fmi.domain.report.web.dto.request.ReportCreateRequestDTO;
 import com.fmi.domain.report.web.dto.response.ReportListDTO;
 import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -18,6 +21,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 public class ReportController {
     
     private final ReportService reportService;
+    private final UserRepository userRepository;
     
     /**
      * 신고하기 (통합)
@@ -56,8 +61,10 @@ public class ReportController {
     })
     public ApiResponse<Long> createReport(
             @Valid @RequestBody ReportCreateRequestDTO request,
-            @AuthenticationPrincipal User user) {
+            @AuthenticationPrincipal UserDetails userDetails) {
         
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         Long reportId = reportService.createReport(request, user);
         return ApiResponse.onSuccess(reportId);
     }
@@ -72,12 +79,14 @@ public class ReportController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "신고 내역 조회 성공")
     })
     public ApiResponse<Page<ReportListDTO>> getMyReports(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal UserDetails userDetails,
             @Parameter(description = "신고 상태 필터 (PENDING=접수, REVIEWED=처리중, RESOLVED=처리완료)", required = false)
             @RequestParam(required = false) ReportStatus status,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         
+        User user = userRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<ReportListDTO> reports = reportService.getMyReports(user, status, pageable);
         return ApiResponse.onSuccess(reports);


### PR DESCRIPTION
## 🧩 관련 이슈

- close fix/#158

## 🛠️ 작업 내용

- @AuthenticationPrincipal User로 받아 null 가능했던 컨트롤러들을 UserDetails로 변경하고, UserRepository로 실제 User 엔티티를 조회하도록 수정

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
