### PR TITLE
fix: 리프레시 토큰 재발급 시 access 토큰 클레임 구성 수정 및 로그인/재발급 토큰 구조 통일

### DIFF
--- a/src/main/java/com/fmi/domain/auth/service/AuthService.java
+++ b/src/main/java/com/fmi/domain/auth/service/AuthService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -175,6 +176,13 @@ public class AuthService {
         }
         
         return new AuthenticateResult(user, isTemporaryPassword);
+    }
+
+    /**
+     * 활성 사용자 조회 (deletedAt이 null인 사용자만)
+     */
+    public Optional<User> findActiveUserByEmail(String email) {
+        return userRepository.findByEmail(email);
     }
     
     @Data

--- a/src/main/java/com/fmi/domain/auth/web/controller/AuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.fmi.domain.auth.response.SignupResponse;
 import com.fmi.domain.auth.service.AuthService;
 import com.fmi.domain.auth.web.dto.LoginRequest;
 import com.fmi.domain.auth.web.dto.SignupRequest;
+import com.fmi.domain.auth.repository.SocialAccountsRepository;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.security.JwtTokenProvider;
 import com.fmi.security.RefreshTokenStore;
@@ -33,6 +34,7 @@ public class AuthController {
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenStore refreshTokenStore;
+    private final SocialAccountsRepository socialAccountsRepository;
 
     @Value("${jwt.cookie.name:refresh_token}")
     private String refreshCookieName;
@@ -122,6 +124,7 @@ public class AuthController {
         var claims = new java.util.HashMap<String, Object>();
         claims.put("userId", user.getId());
         claims.put("role", user.getRole().name());
+        claims.put("purpose", "access");
         if (isTemporaryPassword) {
             claims.put("isTemporaryPassword", true);  // JWT에 임시 비밀번호 플래그 포함
         }
@@ -242,11 +245,21 @@ public class AuthController {
             return ResponseEntity.status(401).body(ApiResponse.onFailure("AUTH401-INVALID_REFRESH", "유효하지 않은 리프레시(대조 실패)", null));
         }
 
+        var userOpt = authService.findActiveUserByEmail(email);
+        if (userOpt.isEmpty()) {
+            return ResponseEntity.status(401).body(ApiResponse.onFailure("AUTH401-INVALID_REFRESH", "유효하지 않은 리프레시(사용자 없음)", null));
+        }
+        var user = userOpt.get();
+
         // RTR: 기존 리프레시 폐기, 새 리프레시/쿠키 발급
         refreshTokenStore.revoke(jti);
 
         var claims = new java.util.HashMap<String, Object>();
-        claims.put("purpose", "refresh");
+        claims.put("userId", user.getId());
+        claims.put("role", user.getRole().name());
+        claims.put("purpose", "access");
+        socialAccountsRepository.findByUser(user)
+                .ifPresent(account -> claims.put("provider", account.getProvider().name()));
         String accessToken = jwtTokenProvider.createAccessToken(email, claims);
 
         String newJti = java.util.UUID.randomUUID().toString();

--- a/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
@@ -139,6 +139,7 @@ public class KakaoAuthController {
         claims.put("userId", localUser.getId());
         claims.put("role", localUser.getRole().name());
         claims.put("provider", "KAKAO");
+        claims.put("purpose", "access");
         String accessToken = jwtTokenProvider.createAccessToken(localUser.getEmail(), claims);
 
         String jti = UUID.randomUUID().toString();


### PR DESCRIPTION
## 🧩 관련 이슈

- close fix/#162

## 🛠️ 작업 내용

- 리프레시 토큰 재발급 시 access 토큰 클레임 구성 수정 및 로그인/재발급 토큰 구조 통일


## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
