### PR TITLE
feat: 채팅방 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/fmi/domain/chatroom/data/ChatRoom.java
+++ b/src/main/java/com/fmi/domain/chatroom/data/ChatRoom.java
@@ -2,6 +2,8 @@ package com.fmi.domain.chatroom.data;
 
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.post.data.Post;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,7 +48,7 @@ public class ChatRoom {
                 .map(ChatRoomParticipant::getUser) // 실제 User 객체를 꺼냅니다.
                 .filter(user -> !user.getId().equals(userId)) // 나 자신이 아닌 사용자를 필터링
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException("채팅방에 다른 참여자가 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_INVALID_STATE));
     }
 
     /**

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
@@ -133,4 +133,20 @@ public class ChatRoomService {
 
         chatRoomParticipant.leftChatRoom(lastMsgId);
     }
+
+    public ChatRoomResultDTO getChatRoomDetail(Long roomId, User user) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
+
+        if (!chatRoom.isParticipant(user)) {
+            throw new GeneralException(ErrorStatus._CHATROOM_ACCESS_DENIED);
+        }
+
+        User opponent = chatRoom.getOtherParticipant(user.getId());
+
+        Post post = chatRoom.getPost();
+
+        return ChatRoomConverter.toChatRoomResultDTO(chatRoom, opponent, post);
+    }
+
 }

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -107,6 +107,23 @@ public class ChatRoomController {
         return ApiResponse.of(SuccessStatus._CHATROOM_LEFT);
     }
 
+    @Operation(summary = "채팅방 상세 조회", description = "특정 채팅방의 상세 정보(상대방 정보, 게시글 요약 등)를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "CHATROOM_FOUND: 기존 채팅방을 조회합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CHATROOM_ACCESS_DENIED: 해당 채팅방에 접근 권한이 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHATROOM_NOT_FOUND: 존재하지 않는 채팅방입니다.")
+    })
+    @GetMapping("/chats/{roomId}")
+    public ApiResponse<ChatRoomResultDTO> getChatRoomDetail(@PathVariable("roomId") Long roomId, @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername();
+        User user = userService.findUser(email);
+
+        ChatRoomResultDTO responseDTO = chatRoomService.getChatRoomDetail(roomId, user);
+
+        return ApiResponse.of(SuccessStatus._CHATROOM_FOUND, responseDTO);
+    }
+
+
     @MessageMapping("/rooms/{roomId}/enter")
     public void enter(@DestinationVariable Long roomId, Principal p, StompHeaderAccessor acc) {
         Long userId = Long.parseLong(p.getName());

--- a/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
@@ -61,6 +61,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM404-NOT_FOUND", "존재하지 않는 채팅방입니다."),
     _PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM404-PARTICIPANT_NOT_FOUND", "참여 중인 채팅방이 아닙니다."),
     _CHATROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CHATROOM403-ACCESS_DENIED", "해당 채팅방에 접근 권한이 없습니다."),
+    _CHATROOM_INVALID_STATE(HttpStatus.INTERNAL_SERVER_ERROR, "CHATROOM500-INVALID_STATE", "채팅방 데이터 상태가 올바르지 않습니다."),
 
     // 채팅 관련 응답
     _IMAGE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "IMAGE400-NOT_PROVIDED", "전송할 이미지가 없습니다."),

--- a/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
@@ -60,6 +60,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _CHATROOM_NOT_ALLOWED(HttpStatus.FORBIDDEN, "CHATROOM403-NOT_ALLOWED", "자신의 글에는 채팅할 수 없습니다."),
     _CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM404-NOT_FOUND", "존재하지 않는 채팅방입니다."),
     _PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM404-PARTICIPANT_NOT_FOUND", "참여 중인 채팅방이 아닙니다."),
+    _CHATROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CHATROOM403-ACCESS_DENIED", "해당 채팅방에 접근 권한이 없습니다."),
 
     // 채팅 관련 응답
     _IMAGE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "IMAGE400-NOT_PROVIDED", "전송할 이미지가 없습니다."),


### PR DESCRIPTION
## 🧩 관련 이슈

- close #164 

## 🛠️ 작업 내용

- 채팅방 상세 정보를 조회할 수 있는 API를 추가했습니다. 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
