### PR TITLE
feat: 타인 페이지 조회 API 수정

### DIFF
--- a/src/main/java/com/fmi/domain/Enum/UserOtherPageType.java
+++ b/src/main/java/com/fmi/domain/Enum/UserOtherPageType.java
@@ -1,0 +1,31 @@
+package com.fmi.domain.Enum;
+
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum UserOtherPageType {
+    POSTS("posts"),
+    COMMENTS("comments"),
+    FAVORITES("favorites");
+
+    private final String paramValue;
+
+    UserOtherPageType(String paramValue) {
+        this.paramValue = paramValue;
+    }
+
+    public static UserOtherPageType fromParam(String value) {
+        if (value == null || value.isBlank()) {
+            return POSTS;
+        }
+        String normalized = value.trim().toLowerCase();
+        return Arrays.stream(values())
+                .filter(type -> type.paramValue.equals(normalized))
+                .findFirst()
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_PAGE_TYPE_INVALID));
+    }
+}

--- a/src/main/java/com/fmi/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/fmi/domain/user/converter/UserConverter.java
@@ -60,7 +60,8 @@ public class UserConverter {
     public static UserOtherPageResponse toUserOtherPageResponse(
             User user,
             List<PostListResponse> posts,
-            List<UserCommentSummaryResponse> comments
+            List<UserCommentSummaryResponse> comments,
+            List<PostListResponse> favorites
     ) {
         return UserOtherPageResponse.builder()
                 .userId(user.getId())
@@ -68,6 +69,7 @@ public class UserConverter {
                 .profileImg(user.getProfile_img())
                 .posts(posts)
                 .comments(comments)
+                .favorites(favorites)
                 .build();
     }
 }

--- a/src/main/java/com/fmi/domain/user/response/UserOtherPageResponse.java
+++ b/src/main/java/com/fmi/domain/user/response/UserOtherPageResponse.java
@@ -19,5 +19,6 @@ public class UserOtherPageResponse {
     private String profileImg;
     private List<PostListResponse> posts;
     private List<UserCommentSummaryResponse> comments;
+    private List<PostListResponse> favorites;
 }
 

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -4,8 +4,12 @@ import com.fmi.domain.auth.data.User;
 import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.comment.repository.CommentRepository;
 import com.fmi.domain.post.converter.PostConverter;
+import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.post.response.PostListResponse;
+import com.fmi.domain.post.service.PostService;
+import com.fmi.domain.postfavorite.data.PostFavorite;
+import com.fmi.domain.postfavorite.repository.PostFavoriteRepository;
 import com.fmi.domain.user.converter.UserConverter;
 import com.fmi.domain.user.response.ImageUploadResponse;
 import com.fmi.domain.user.response.UserCommentSummaryResponse;
@@ -28,7 +32,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -43,6 +49,8 @@ public class UserService {
     private final PostConverter postConverter;
     private final CommentRepository commentRepository;
     private final EmailService emailService;
+    private final PostFavoriteRepository postFavoriteRepository;
+    private final PostService postService;
 
     /**
      * 내 정보 조회
@@ -57,22 +65,67 @@ public class UserService {
 
     /**
      * 타인 페이지 조회
+     * type 파라미터에 따라 조회할 데이터를 분리합니다.
+     * - posts: 게시글만 조회
+     * - comments: 댓글만 조회
+     * - favorites: 즐겨찾기만 조회
+     * - 미지정 또는 기본값: posts (게시글만 조회)
      */
     @Transactional(readOnly = true)
-    public UserOtherPageResponse getOtherUserPage(Long userId) {
+    public UserOtherPageResponse getOtherUserPage(Long userId, String type) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        List<PostListResponse> posts = postRepository.findAllPublishedWithImagesByUser(user).stream()
-                .map(post -> postConverter.toPostListResponse(post, null,null,false))
+        // type에 따라 필요한 데이터만 조회
+        List<PostListResponse> posts = Collections.emptyList();
+        List<UserCommentSummaryResponse> comments = Collections.emptyList();
+        List<PostListResponse> favorites = Collections.emptyList();
+
+        // type이 null이거나 "posts"인 경우 게시글 조회
+        if (type == null || type.equals("posts")) {
+            posts = postRepository.findAllPublishedWithImagesByUser(user).stream()
+                    .map(post -> postConverter.toPostListResponse(post, null, null, false))
+                    .toList();
+        }
+        // type이 "comments"인 경우 댓글 조회
+        else if (type.equals("comments")) {
+            comments = commentRepository.findAllWithPostByUser(user).stream()
+                    .map(UserConverter::toUserCommentSummaryResponse)
+                    .toList();
+        }
+        // type이 "favorites"인 경우 즐겨찾기 조회
+        else if (type.equals("favorites")) {
+            favorites = getFavoritePostsByUser(user);
+        }
+
+        return UserConverter.toUserOtherPageResponse(user, posts, comments, favorites);
+    }
+
+    /**
+     * 특정 사용자의 즐겨찾기 게시글 조회
+     */
+    private List<PostListResponse> getFavoritePostsByUser(User user) {
+        List<PostFavorite> favorites = postFavoriteRepository.findByUserAndIsFavoriteTrue(user);
+        List<Post> posts = favorites.stream()
+                .map(PostFavorite::getPost)
                 .toList();
 
-        List<UserCommentSummaryResponse> comments = commentRepository.findAllWithPostByUser(user).stream()
-                .map(UserConverter::toUserCommentSummaryResponse)
-                .toList();
+        if (posts.isEmpty()) {
+            return Collections.emptyList();
+        }
 
-        return UserConverter.toUserOtherPageResponse(user, posts, comments);
+        List<Long> postIds = posts.stream().map(Post::getId).toList();
+        Map<Long, Long> viewCounts = postService.getViewCountsFromRedis(postIds);
+
+        return posts.stream()
+                .map(post -> postConverter.toPostListResponse(
+                        post,
+                        null,
+                        viewCounts.getOrDefault(post.getId(), 0L),
+                        true
+                ))
+                .toList();
     }
 
     /**

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.fmi.domain.user.service;
 
+import com.fmi.domain.Enum.UserOtherPageType;
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.comment.repository.CommentRepository;
@@ -72,7 +73,7 @@ public class UserService {
      * - 미지정 또는 기본값: posts (게시글만 조회)
      */
     @Transactional(readOnly = true)
-    public UserOtherPageResponse getOtherUserPage(Long userId, String type) {
+    public UserOtherPageResponse getOtherUserPage(Long userId, UserOtherPageType type) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
@@ -82,21 +83,15 @@ public class UserService {
         List<UserCommentSummaryResponse> comments = Collections.emptyList();
         List<PostListResponse> favorites = Collections.emptyList();
 
-        // type이 null이거나 "posts"인 경우 게시글 조회
-        if (type == null || type.equals("posts")) {
-            posts = postRepository.findAllPublishedWithImagesByUser(user).stream()
+        UserOtherPageType resolvedType = type == null ? UserOtherPageType.POSTS : type;
+        switch (resolvedType) {
+            case POSTS -> posts = postRepository.findAllPublishedWithImagesByUser(user).stream()
                     .map(post -> postConverter.toPostListResponse(post, null, null, false))
                     .toList();
-        }
-        // type이 "comments"인 경우 댓글 조회
-        else if (type.equals("comments")) {
-            comments = commentRepository.findAllWithPostByUser(user).stream()
+            case COMMENTS -> comments = commentRepository.findAllWithPostByUser(user).stream()
                     .map(UserConverter::toUserCommentSummaryResponse)
                     .toList();
-        }
-        // type이 "favorites"인 경우 즐겨찾기 조회
-        else if (type.equals("favorites")) {
-            favorites = getFavoritePostsByUser(user);
+            case FAVORITES -> favorites = getFavoritePostsByUser(user);
         }
 
         return UserConverter.toUserOtherPageResponse(user, posts, comments, favorites);

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.fmi.domain.user.web.controller;
 
+import com.fmi.domain.Enum.UserOtherPageType;
 import com.fmi.domain.user.response.ImageUploadResponse;
 import com.fmi.domain.user.response.UserOtherPageResponse;
 import com.fmi.domain.user.response.UserProfileResponse;
@@ -110,6 +111,16 @@ public class UserController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "타인 페이지 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "USER400-PAGE_TYPE_INVALID: type 파라미터는 posts, comments, favorites 중 하나여야 합니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"USER400-PAGE_TYPE_INVALID\", \"message\": \"type 파라미터는 posts, comments, favorites 중 하나여야 합니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
                     description = "USER404-NOT_FOUND: 존재하지 않는 회원입니다",
                     content = @Content(
@@ -122,7 +133,7 @@ public class UserController {
     })
     public ApiResponse<UserOtherPageResponse> getUserOtherPage(
             @PathVariable Long userId,
-            @RequestParam(required = false, defaultValue = "posts") String type
+            @RequestParam(required = false, defaultValue = "posts") UserOtherPageType type
     ) {
         UserOtherPageResponse response = userService.getOtherUserPage(userId, type);
         return ApiResponse.onSuccess(response);

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -98,7 +98,15 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/page")
-    @Operation(summary = "타인 페이지 조회", description = "다른 사용자의 닉네임, 프로필 이미지, 게시글, 작성 댓글 목록을 조회합니다.")
+    @Operation(summary = "타인 페이지 조회", description = """
+            다른 사용자의 닉네임, 프로필 이미지, 게시글, 작성 댓글, 즐겨찾기 목록을 조회합니다.
+            
+            **type 파라미터:**
+            - type=posts → 게시글만 조회
+            - type=comments → 댓글만 조회
+            - type=favorites → 즐겨찾기만 조회
+            - type 미지정 → 기본 탭(posts) 조회
+            """)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "타인 페이지 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -113,9 +121,10 @@ public class UserController {
             )
     })
     public ApiResponse<UserOtherPageResponse> getUserOtherPage(
-            @PathVariable Long userId
+            @PathVariable Long userId,
+            @RequestParam(required = false, defaultValue = "posts") String type
     ) {
-        UserOtherPageResponse response = userService.getOtherUserPage(userId);
+        UserOtherPageResponse response = userService.getOtherUserPage(userId, type);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
@@ -49,6 +49,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _CURRENT_PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "USER400-PASSWORD_INCORRECT", "현재 비밀번호가 일치하지 않습니다."),
     _PASSWORD_CONFIRMATION_MISMATCH(HttpStatus.BAD_REQUEST, "USER400-PASSWORD_MISMATCH", "새 비밀번호와 확인이 일치하지 않습니다."),
     _PHONE_DUPLICATED(HttpStatus.CONFLICT, "USER409-PHONE_DUPLICATED", "이미 사용 중인 전화번호입니다."),
+    _USER_PAGE_TYPE_INVALID(HttpStatus.BAD_REQUEST, "USER400-PAGE_TYPE_INVALID", "type 파라미터는 posts, comments, favorites 중 하나여야 합니다."),
 
     // 게시글 관련 응답
     _POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST404-NOT_FOUND", "존재하지 않는 게시글입니다."),

--- a/src/main/java/com/fmi/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/fmi/global/apiPayload/exception/ExceptionAdvice.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -59,6 +60,19 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         });
 
         return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, ErrorStatus._BAD_REQUEST, request, errors);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<Object> handleMethodArgumentTypeMismatch(
+            MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+        Throwable cause = e.getCause();
+        if (cause instanceof GeneralException generalException) {
+            ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+            return handleExceptionInternal(e, errorReasonHttpStatus, null, request);
+        }
+        ErrorReasonDTO errorReason = ErrorStatus._BAD_REQUEST.getReasonHttpStatus();
+        return handleExceptionInternal(e, errorReason, null, request);
     }
 
     @ExceptionHandler

--- a/src/main/java/com/fmi/global/converter/UserOtherPageTypeConverter.java
+++ b/src/main/java/com/fmi/global/converter/UserOtherPageTypeConverter.java
@@ -1,0 +1,14 @@
+package com.fmi.global.converter;
+
+import com.fmi.domain.Enum.UserOtherPageType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserOtherPageTypeConverter implements Converter<String, UserOtherPageType> {
+    @Override
+    public UserOtherPageType convert(@NonNull String source) {
+        return UserOtherPageType.fromParam(source);
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close feature/#166

## 🛠️ 작업 내용

- 타인 페이지 API를 type 쿼리스트링 기반으로 분리 조회
- 즐겨찾기 탭 데이터 응답 추가

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
