### PR TITLE
feat: 비회원 문의 IP 저장 및 블랙리스트 차단 기능 추가

### DIFF
--- a/src/main/java/com/fmi/domain/admin/dto/AdminInquiryResponse.java
+++ b/src/main/java/com/fmi/domain/admin/dto/AdminInquiryResponse.java
@@ -37,5 +37,8 @@ public class AdminInquiryResponse {
     private String userNickname;
     @Schema(description = "사용자 이메일", example = "user@example.com")
     private String userEmail;
+
+    @Schema(description = "문의 IP", example = "192.0.2.1")
+    private String ip;
 }
 

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -14,6 +14,7 @@ import com.fmi.domain.inquiry.data.enums.InquiryCategory;
 import com.fmi.domain.inquiry.data.enums.InquiryStatus;
 import com.fmi.domain.inquiry.data.enums.InquiryType;
 import com.fmi.domain.inquiry.repository.InquiryRepository;
+import com.fmi.domain.ipblock.service.IpBlacklistService;
 import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.report.data.Report;
 import com.fmi.domain.report.data.enums.ReportStatus;
@@ -52,6 +53,7 @@ public class AdminService {
     private final CommentRepository commentRepository;
     private final UserCategoryRepository userCategoryRepository;
     private final InquiryCommentService inquiryCommentService;
+    private final IpBlacklistService ipBlacklistService;
 
     public Page<AdminInquiryResponse> getInquiryPage(InquiryType type,
                                                      InquiryStatus status,
@@ -69,6 +71,7 @@ public class AdminService {
                 .userNickname(inquiry.getUser() != null ? inquiry.getUser().getNickname() : null)
                 .userEmail(inquiry.getEmail() != null ? inquiry.getEmail() :
                         inquiry.getUser() != null ? inquiry.getUser().getEmail() : null)
+                .ip(inquiry.getIp())
                 .build());
     }
 
@@ -134,6 +137,13 @@ public class AdminService {
         List<InquiryCommentResponse> comments =
                 inquiryCommentService.getCommentsForDetail(inquiry.getId(), userDetails);
         return inquiryConverter.toDetailDTO(inquiry, comments);
+    }
+
+    @Transactional
+    public void blockInquiryIp(Long inquiryId, String reason) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INQUIRY_NOT_FOUND));
+        ipBlacklistService.blockIp(inquiry.getIp(), reason);
     }
 
     /**

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -5,6 +5,7 @@ import com.fmi.domain.admin.dto.AdminInquiryResponse;
 import com.fmi.domain.admin.dto.AdminReportResponse;
 import com.fmi.domain.admin.dto.AdminUserDetailResponse;
 import com.fmi.domain.admin.service.AdminService;
+import com.fmi.domain.admin.web.dto.AdminIpBlockRequest;
 import com.fmi.domain.admin.web.dto.AdminSignupRequest;
 import com.fmi.domain.auth.converter.AuthConverter;
 import com.fmi.domain.auth.response.SignupResponse;
@@ -241,6 +242,48 @@ public class AdminController {
     public ApiResponse<String> updateInquiryStatus(@PathVariable Long inquiryId,
                                                    @Valid @RequestBody com.fmi.domain.inquiry.web.dto.request.InquiryStatusUpdateRequestDTO request) {
         inquiryService.updateStatus(inquiryId, request.getStatus());
+        return ApiResponse.onSuccess("OK");
+    }
+
+    @PostMapping("/inquiries/{inquiryId}/block-ip")
+    @Operation(summary = "문의 IP 차단(관리자)", description = "문의에 저장된 IP를 블랙리스트에 등록합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "IP 차단 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "INQUIRY404-NOT_FOUND: 존재하지 않는 문의입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"INQUIRY404-NOT_FOUND\", \"message\": \"존재하지 않는 문의입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "INQUIRY400-IP_NOT_FOUND: 문의에 IP 정보가 없습니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"INQUIRY400-IP_NOT_FOUND\", \"message\": \"문의에 IP 정보가 없습니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "INQUIRY409-IP_ALREADY_BLOCKED: 이미 차단된 IP입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"INQUIRY409-IP_ALREADY_BLOCKED\", \"message\": \"이미 차단된 IP입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ApiResponse<String> blockInquiryIp(@PathVariable Long inquiryId,
+                                              @RequestBody(required = false) AdminIpBlockRequest request) {
+        String reason = request != null ? request.getReason() : null;
+        adminService.blockInquiryIp(inquiryId, reason);
         return ApiResponse.onSuccess("OK");
     }
 

--- a/src/main/java/com/fmi/domain/admin/web/dto/AdminIpBlockRequest.java
+++ b/src/main/java/com/fmi/domain/admin/web/dto/AdminIpBlockRequest.java
@@ -1,0 +1,15 @@
+package com.fmi.domain.admin.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminIpBlockRequest {
+
+    @Schema(description = "차단 사유", example = "스팸 문의 반복")
+    private String reason;
+}

--- a/src/main/java/com/fmi/domain/inquiry/data/Inquiry.java
+++ b/src/main/java/com/fmi/domain/inquiry/data/Inquiry.java
@@ -47,6 +47,9 @@ public class Inquiry {
     @Column(length = 255)
     private String email;  // 비회원 문의 시 이메일
 
+    @Column(length = 45)
+    private String ip;  // 비회원 문의 시 IP
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
@@ -248,11 +248,24 @@ public class InquiryService {
     }
 
     private void checkGuestRateLimit(String ip) {
-        String key = "inquiry:guest:lock:" + ip;
-        Boolean isFirstRequest = stringRedisTemplate.opsForValue()
-                .setIfAbsent(key, "y", Duration.ofMinutes(5));
-        if (!Boolean.TRUE.equals(isFirstRequest)) {
-            throw new GeneralException(ErrorStatus._INQUIRY_GUEST_RATE_LIMIT);
+        String countKey = "inquiry:guest:count:" + ip;
+
+        // 요청 횟수 증가
+        Long count = stringRedisTemplate.opsForValue().increment(countKey);
+
+        // 첫 요청이면 3분 TTL 설정
+        if (count != null && count == 1) {
+            stringRedisTemplate.expire(countKey, Duration.ofMinutes(3));
+        }
+
+        // 5회 이상이면 자동 블랙리스트 등록
+        if (count != null && count >= 5) {
+            // 아직 블랙리스트에 없으면 추가
+            if (!ipBlacklistService.isBlocked(ip)) {
+                ipBlacklistService.blockIp(ip, "자동 차단: 3분 내 5회 이상 문의 요청");
+            }
+            stringRedisTemplate.delete(countKey);
+            throw new GeneralException(ErrorStatus._INQUIRY_IP_BLOCKED);
         }
     }
 

--- a/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
@@ -13,6 +13,7 @@ import com.fmi.domain.inquiry.web.dto.response.InquiryDetailDTO;
 import com.fmi.domain.inquiry.web.dto.response.InquiryListDTO;
 import com.fmi.domain.inquirycomment.response.InquiryCommentResponse;
 import com.fmi.domain.inquirycomment.service.InquiryCommentService;
+import com.fmi.domain.ipblock.service.IpBlacklistService;
 import com.fmi.domain.notification.data.enums.NotificationType;
 import com.fmi.domain.notification.data.enums.ReferenceType;
 import com.fmi.domain.notification.service.NotificationService;
@@ -23,10 +24,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
@@ -40,15 +44,22 @@ public class InquiryService {
     private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
     private final InquiryCommentService inquiryCommentService;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final IpBlacklistService ipBlacklistService;
 
     /**
      * 1:1 개인 문의 생성
      */
     @Transactional
-    public Long createInquiry(InquiryCreateRequestDTO request, UserDetails userDetails) {
+    public Long createInquiry(InquiryCreateRequestDTO request, UserDetails userDetails, String clientIp) {
 
         User user = null;
         String resolvedEmail;
+        String normalizedIp = normalizeIp(clientIp);
+
+        if (ipBlacklistService.isBlocked(normalizedIp)) {
+            throw new GeneralException(ErrorStatus._INQUIRY_IP_BLOCKED);
+        }
 
         if (userDetails != null) {
             user = userRepository.findByEmail(userDetails.getUsername())
@@ -59,6 +70,7 @@ public class InquiryService {
                 throw new GeneralException(ErrorStatus._INQUIRY_GUEST_EMAIL_REQUIRED);
             }
             resolvedEmail = request.getEmail().trim();
+            checkGuestRateLimit(normalizedIp);
         }
 
         Inquiry saved = inquiryRepository.save(
@@ -69,6 +81,7 @@ public class InquiryService {
                         .inquiryType(InquiryType.PRIVATE)
                         .user(user) // 회원이면 user 세팅
                         .email(user == null ? resolvedEmail : null) // 비회원이면 email 컬럼 세팅
+                        .ip(normalizedIp)
                         .build()
         );
 
@@ -225,6 +238,22 @@ public class InquiryService {
             case PENDING -> "보류";
             case ANSWERED -> "답변완료";
         };
+    }
+
+    private String normalizeIp(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return "unknown";
+        }
+        return ip.trim();
+    }
+
+    private void checkGuestRateLimit(String ip) {
+        String key = "inquiry:guest:lock:" + ip;
+        Boolean isFirstRequest = stringRedisTemplate.opsForValue()
+                .setIfAbsent(key, "y", Duration.ofMinutes(5));
+        if (!Boolean.TRUE.equals(isFirstRequest)) {
+            throw new GeneralException(ErrorStatus._INQUIRY_GUEST_RATE_LIMIT);
+        }
     }
 
     private boolean isAdmin(UserDetails userDetails) {

--- a/src/main/java/com/fmi/domain/inquiry/web/controller/InquiryController.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/controller/InquiryController.java
@@ -39,9 +39,29 @@ public class InquiryController {
      * POST /api/inquiries
      */
     @PostMapping
-    @Operation(summary = "1:1 개인 문의 작성", description = "비회원도 가능하며, 비회원인 경우 email을 포함할 수 있습니다.")
+    @Operation(summary = "1:1 개인 문의 작성", description = "비회원도 가능하며, 비회원인 경우 email 필수입니다.")
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "문의 작성 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "문의 작성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "INQUIRY400-GUEST_EMAIL_REQUIRED: 비회원 문의는 이메일이 필수입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"INQUIRY400-GUEST_EMAIL_REQUIRED\", \"message\": \"비회원 문의는 이메일이 필수입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "INQUIRY403-IP_BLOCKED: 차단된 IP입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"INQUIRY403-IP_BLOCKED\", \"message\": \"차단된 IP입니다.\"}"
+                            )
+                    )
+            )
     })
     public ApiResponse<Long> createInquiry(
             @Valid @RequestBody com.fmi.domain.inquiry.web.dto.request.InquiryCreateRequestDTO request,

--- a/src/main/java/com/fmi/domain/inquiry/web/controller/InquiryController.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/controller/InquiryController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -44,8 +45,10 @@ public class InquiryController {
     })
     public ApiResponse<Long> createInquiry(
             @Valid @RequestBody com.fmi.domain.inquiry.web.dto.request.InquiryCreateRequestDTO request,
-            @AuthenticationPrincipal UserDetails userDetails) {
-        Long inquiryId = inquiryService.createInquiry(request, userDetails);
+            @AuthenticationPrincipal UserDetails userDetails,
+            HttpServletRequest httpServletRequest) {
+        String clientIp = getClientIpAddress(httpServletRequest);
+        Long inquiryId = inquiryService.createInquiry(request, userDetails, clientIp);
         return ApiResponse.onSuccess(inquiryId);
     }
     
@@ -107,6 +110,32 @@ public class InquiryController {
 
         InquiryDetailDTO inquiry = inquiryService.getInquiryDetail(inquiryId, userDetails);
         return ApiResponse.onSuccess(inquiry);
+    }
+
+    private String getClientIpAddress(HttpServletRequest request) {
+        if (request == null) {
+            return "unknown";
+        }
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+        }
+        if (ip != null && ip.contains(",")) {
+            ip = ip.split(",")[0].trim();
+        }
+        return ip != null ? ip : "unknown";
     }
 }
 

--- a/src/main/java/com/fmi/domain/inquiry/web/dto/request/InquiryCreateRequestDTO.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/dto/request/InquiryCreateRequestDTO.java
@@ -1,6 +1,7 @@
 package com.fmi.domain.inquiry.web.dto.request;
 
 import com.fmi.domain.inquiry.data.enums.InquiryCategory;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
@@ -11,7 +12,8 @@ public class InquiryCreateRequestDTO {
     @NotBlank
     private String content;
     private InquiryCategory category;
-    private String email; // 비회원 문의 시 이메일 (선택)
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email; // 비회원 문의 시 이메일 (비회원 필수)
 }
 
 

--- a/src/main/java/com/fmi/domain/ipblock/data/IpBlacklist.java
+++ b/src/main/java/com/fmi/domain/ipblock/data/IpBlacklist.java
@@ -1,0 +1,33 @@
+package com.fmi.domain.ipblock.data;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ip_blacklist")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IpBlacklist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 45, unique = true)
+    private String ip;
+
+    @Column(length = 255)
+    private String reason;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/fmi/domain/ipblock/repository/IpBlacklistRepository.java
+++ b/src/main/java/com/fmi/domain/ipblock/repository/IpBlacklistRepository.java
@@ -1,0 +1,11 @@
+package com.fmi.domain.ipblock.repository;
+
+import com.fmi.domain.ipblock.data.IpBlacklist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface IpBlacklistRepository extends JpaRepository<IpBlacklist, Long> {
+    boolean existsByIp(String ip);
+    Optional<IpBlacklist> findByIp(String ip);
+}

--- a/src/main/java/com/fmi/domain/ipblock/service/IpBlacklistService.java
+++ b/src/main/java/com/fmi/domain/ipblock/service/IpBlacklistService.java
@@ -1,0 +1,38 @@
+package com.fmi.domain.ipblock.service;
+
+import com.fmi.domain.ipblock.data.IpBlacklist;
+import com.fmi.domain.ipblock.repository.IpBlacklistRepository;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class IpBlacklistService {
+
+    private final IpBlacklistRepository ipBlacklistRepository;
+
+    @Transactional(readOnly = true)
+    public boolean isBlocked(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return false;
+        }
+        return ipBlacklistRepository.existsByIp(ip);
+    }
+
+    @Transactional
+    public void blockIp(String ip, String reason) {
+        if (ip == null || ip.isBlank()) {
+            throw new GeneralException(ErrorStatus._INQUIRY_IP_NOT_FOUND);
+        }
+        if (ipBlacklistRepository.existsByIp(ip)) {
+            throw new GeneralException(ErrorStatus._IP_ALREADY_BLOCKED);
+        }
+        ipBlacklistRepository.save(IpBlacklist.builder()
+                .ip(ip)
+                .reason(reason)
+                .build());
+    }
+}

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -10,8 +10,6 @@ import com.fmi.domain.user.web.dto.PasswordVerifyRequest;
 import com.fmi.domain.user.web.dto.ProfileImageUpdateRequest;
 import com.fmi.domain.user.web.dto.UserUpdateRequest;
 import com.fmi.global.apiPayload.ApiResponse;
-import com.fmi.global.apiPayload.code.status.ErrorStatus;
-import com.fmi.global.apiPayload.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -25,8 +23,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.regex.Pattern;
 
 @RestController
 @RequestMapping("/users")
@@ -35,8 +31,6 @@ import java.util.regex.Pattern;
 public class UserController {
 
     private final UserService userService;
-    private static final Pattern EMAIL_PATTERN =
-            Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
 
     @PostMapping("/uploads/images")
     @Operation(summary = "이미지 업로드", description = "여러 장의 이미지를 S3에 업로드하고 URL을 반환합니다. (JPEG, PNG 형식만 지원)")
@@ -99,7 +93,6 @@ public class UserController {
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         String email = userDetails.getUsername();
-        validateEmail(email);
         UserProfileResponse response = userService.getMyProfile(email);
         return ApiResponse.onSuccess(response);
     }
@@ -156,7 +149,6 @@ public class UserController {
             @Valid @RequestBody UserUpdateRequest request
     ) {
         String email = userDetails.getUsername();
-        validateEmail(email);
         UserProfileResponse response = userService.updateMyProfile(email, request);
         return ApiResponse.onSuccess(response);
     }
@@ -202,7 +194,6 @@ public class UserController {
             @RequestBody ProfileImageUpdateRequest request
     ) {
         String email = userDetails.getUsername();
-        validateEmail(email);
         UserProfileResponse response = userService.updateProfileImage(email, request);
         return ApiResponse.onSuccess(response);
     }
@@ -238,7 +229,6 @@ public class UserController {
             @Valid @RequestBody PasswordVerifyRequest request
     ) {
         String email = userDetails.getUsername();
-        validateEmail(email);
         userService.verifyPasswordWithException(email, request);
         return ApiResponse.onSuccess(null);
     }
@@ -284,7 +274,6 @@ public class UserController {
             @Valid @RequestBody PasswordChangeRequest request
     ) {
         String email = userDetails.getUsername();
-        validateEmail(email);
         userService.changePassword(email, request);
         return ApiResponse.onSuccess(null);
     }
@@ -340,18 +329,8 @@ public class UserController {
             @Valid @RequestBody AccountDeleteRequest request
     ) {
         String email = userDetails.getUsername();
-        validateEmail(email);
         userService.deleteAccount(email, request);
         return ApiResponse.onSuccess(null);
-    }
-
-    private void validateEmail(String email) {
-        if (Objects.isNull(email) || email.isBlank()) {
-            throw new GeneralException(ErrorStatus._EMAIL_INVALID_FORMAT);
-        }
-        if (!EMAIL_PATTERN.matcher(email).matches()) {
-            throw new GeneralException(ErrorStatus._EMAIL_INVALID_FORMAT);
-        }
     }
 }
 

--- a/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
@@ -75,6 +75,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY404-NOT_FOUND", "존재하지 않는 문의입니다."),
     _INQUIRY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "INQUIRY403-ACCESS_DENIED", "해당 문의를 조회할 권한이 없습니다."),
     _INQUIRY_GUEST_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "INQUIRY400-GUEST_EMAIL_REQUIRED", "비회원 문의는 이메일이 필수입니다."),
+    _INQUIRY_GUEST_RATE_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "INQUIRY429-RATE_LIMIT", "잠시 후 다시 시도해주세요."),
+    _INQUIRY_IP_BLOCKED(HttpStatus.FORBIDDEN, "INQUIRY403-IP_BLOCKED", "차단된 IP입니다."),
+    _INQUIRY_IP_NOT_FOUND(HttpStatus.BAD_REQUEST, "INQUIRY400-IP_NOT_FOUND", "문의에 IP 정보가 없습니다."),
+    _IP_ALREADY_BLOCKED(HttpStatus.CONFLICT, "INQUIRY409-IP_ALREADY_BLOCKED", "이미 차단된 IP입니다."),
 
     // 신고 관련 응답
     _REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "REPORT409-ALREADY_EXISTS", "이미 신고한 대상입니다."),


### PR DESCRIPTION
## 🧩 관련 이슈

- close feature/#171

## 🛠️ 작업 내용

- 비회원 문의 IP 기반 제한 및 IP 블랙리스트 등록 기능 추가
- 문의에 IP 저장 및 관리자용 IP 차단 API 제공

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
