### PR TITLE
refactor: 타인 페이지 조회 api 수정

### DIFF
--- a/src/main/java/com/fmi/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/fmi/domain/comment/repository/CommentRepository.java
@@ -20,6 +20,12 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
     @Query("SELECT c FROM Comment c JOIN FETCH c.post WHERE c.user = :user")
     List<Comment> findAllWithPostByUser(@Param("user") User user);
 
+    @Query("SELECT c FROM Comment c JOIN FETCH c.post WHERE c.user = :user ORDER BY c.id DESC")
+    Slice<Comment> findByUserOrderByIdDesc(@Param("user") User user, Pageable pageable);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.post WHERE c.user = :user AND c.id < :cursor ORDER BY c.id DESC")
+    Slice<Comment> findByUserAndIdLessThanOrderByIdDesc(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable);
+
     long countByUser(User user);
 
     @Query("select c from Comment c where c.post.id = :postId order by c.id desc")

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -42,6 +42,12 @@ public interface PostRepository extends JpaRepository<Post,Long>, PostRepository
     @Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.images WHERE p.user = :user AND p.temporarySave = false")
     List<Post> findAllPublishedWithImagesByUser(@Param("user") User user);
 
+    @Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.images WHERE p.user = :user AND p.temporarySave = false ORDER BY p.id DESC")
+    Slice<Post> findPublishedByUserOrderByIdDesc(@Param("user") User user, Pageable pageable);
+
+    @Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.images WHERE p.user = :user AND p.temporarySave = false AND p.id < :cursor ORDER BY p.id DESC")
+    Slice<Post> findPublishedByUserAndIdLessThanOrderByIdDesc(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable);
+
     long countByUser(User user);
 
 

--- a/src/main/java/com/fmi/domain/postfavorite/repository/PostFavoriteRepository.java
+++ b/src/main/java/com/fmi/domain/postfavorite/repository/PostFavoriteRepository.java
@@ -8,6 +8,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -25,4 +28,10 @@ public interface PostFavoriteRepository extends JpaRepository<PostFavorite,Long>
 
     @Query("SELECT pf.post.id FROM PostFavorite pf WHERE pf.user = :user AND pf.post IN :posts AND pf.isFavorite = true")
     Set<Long> findPostIdsByUserAndPostIn(@Param("user") User user, @Param("posts") List<Post> posts);
+
+    @Query("SELECT pf FROM PostFavorite pf JOIN FETCH pf.post p LEFT JOIN FETCH p.images WHERE pf.user = :user AND pf.isFavorite = true ORDER BY pf.id DESC")
+    Slice<PostFavorite> findByUserAndIsFavoriteTrueOrderByIdDesc(@Param("user") User user, Pageable pageable);
+
+    @Query("SELECT pf FROM PostFavorite pf JOIN FETCH pf.post p LEFT JOIN FETCH p.images WHERE pf.user = :user AND pf.isFavorite = true AND pf.id < :cursor ORDER BY pf.id DESC")
+    Slice<PostFavorite> findByUserAndIsFavoriteTrueAndIdLessThanOrderByIdDesc(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable);
 }

--- a/src/main/java/com/fmi/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/fmi/domain/user/converter/UserConverter.java
@@ -72,5 +72,25 @@ public class UserConverter {
                 .favorites(favorites)
                 .build();
     }
+
+    public static UserOtherPageResponse toUserOtherPageResponse(
+            User user,
+            List<PostListResponse> posts,
+            List<UserCommentSummaryResponse> comments,
+            List<PostListResponse> favorites,
+            Long nextCursor,
+            boolean hasNext
+    ) {
+        return UserOtherPageResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileImg(user.getProfile_img())
+                .posts(posts)
+                .comments(comments)
+                .favorites(favorites)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
 }
 

--- a/src/main/java/com/fmi/domain/user/response/UserOtherPageResponse.java
+++ b/src/main/java/com/fmi/domain/user/response/UserOtherPageResponse.java
@@ -20,5 +20,7 @@ public class UserOtherPageResponse {
     private List<PostListResponse> posts;
     private List<UserCommentSummaryResponse> comments;
     private List<PostListResponse> favorites;
+    private Long nextCursor;
+    private boolean hasNext;
 }
 

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.fmi.domain.user.service;
 import com.fmi.domain.Enum.UserOtherPageType;
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.domain.comment.data.Comment;
 import com.fmi.domain.comment.repository.CommentRepository;
 import com.fmi.domain.post.converter.PostConverter;
 import com.fmi.domain.post.data.Post;
@@ -31,6 +32,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -65,7 +69,7 @@ public class UserService {
     }
 
     /**
-     * 타인 페이지 조회
+     * 타인 페이지 조회 (커서 기반 페이지네이션)
      * type 파라미터에 따라 조회할 데이터를 분리합니다.
      * - posts: 게시글만 조회
      * - comments: 댓글만 조회
@@ -73,7 +77,7 @@ public class UserService {
      * - 미지정 또는 기본값: posts (게시글만 조회)
      */
     @Transactional(readOnly = true)
-    public UserOtherPageResponse getOtherUserPage(Long userId, UserOtherPageType type) {
+    public UserOtherPageResponse getOtherUserPage(Long userId, UserOtherPageType type, Long cursor, int size) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
@@ -82,27 +86,57 @@ public class UserService {
         List<PostListResponse> posts = Collections.emptyList();
         List<UserCommentSummaryResponse> comments = Collections.emptyList();
         List<PostListResponse> favorites = Collections.emptyList();
+        Long nextCursor = null;
+        boolean hasNext = false;
 
         UserOtherPageType resolvedType = type == null ? UserOtherPageType.POSTS : type;
+        PageRequest pageRequest = PageRequest.of(0, size);
+
         switch (resolvedType) {
-            case POSTS -> posts = postRepository.findAllPublishedWithImagesByUser(user).stream()
-                    .map(post -> postConverter.toPostListResponse(post, null, null, false))
-                    .toList();
-            case COMMENTS -> comments = commentRepository.findAllWithPostByUser(user).stream()
-                    .map(UserConverter::toUserCommentSummaryResponse)
-                    .toList();
-            case FAVORITES -> favorites = getFavoritePostsByUser(user);
+            case POSTS -> {
+                Slice<Post> postSlice = cursor == null
+                        ? postRepository.findPublishedByUserOrderByIdDesc(user, pageRequest)
+                        : postRepository.findPublishedByUserAndIdLessThanOrderByIdDesc(user, cursor, pageRequest);
+                posts = postSlice.getContent().stream()
+                        .map(post -> postConverter.toPostListResponse(post, null, null, false))
+                        .toList();
+                hasNext = postSlice.hasNext();
+                if (hasNext && !postSlice.getContent().isEmpty()) {
+                    nextCursor = postSlice.getContent().get(postSlice.getContent().size() - 1).getId();
+                }
+            }
+            case COMMENTS -> {
+                Slice<Comment> commentSlice = cursor == null
+                        ? commentRepository.findByUserOrderByIdDesc(user, pageRequest)
+                        : commentRepository.findByUserAndIdLessThanOrderByIdDesc(user, cursor, pageRequest);
+                comments = commentSlice.getContent().stream()
+                        .map(UserConverter::toUserCommentSummaryResponse)
+                        .toList();
+                hasNext = commentSlice.hasNext();
+                if (hasNext && !commentSlice.getContent().isEmpty()) {
+                    nextCursor = commentSlice.getContent().get(commentSlice.getContent().size() - 1).getId();
+                }
+            }
+            case FAVORITES -> {
+                Slice<PostFavorite> favoriteSlice = cursor == null
+                        ? postFavoriteRepository.findByUserAndIsFavoriteTrueOrderByIdDesc(user, pageRequest)
+                        : postFavoriteRepository.findByUserAndIsFavoriteTrueAndIdLessThanOrderByIdDesc(user, cursor, pageRequest);
+                favorites = getFavoritePostsFromSlice(favoriteSlice);
+                hasNext = favoriteSlice.hasNext();
+                if (hasNext && !favoriteSlice.getContent().isEmpty()) {
+                    nextCursor = favoriteSlice.getContent().get(favoriteSlice.getContent().size() - 1).getId();
+                }
+            }
         }
 
-        return UserConverter.toUserOtherPageResponse(user, posts, comments, favorites);
+        return UserConverter.toUserOtherPageResponse(user, posts, comments, favorites, nextCursor, hasNext);
     }
 
     /**
-     * 특정 사용자의 즐겨찾기 게시글 조회
+     * Slice에서 즐겨찾기 게시글 목록 변환
      */
-    private List<PostListResponse> getFavoritePostsByUser(User user) {
-        List<PostFavorite> favorites = postFavoriteRepository.findByUserAndIsFavoriteTrue(user);
-        List<Post> posts = favorites.stream()
+    private List<PostListResponse> getFavoritePostsFromSlice(Slice<PostFavorite> favoriteSlice) {
+        List<Post> posts = favoriteSlice.getContent().stream()
                 .map(PostFavorite::getPost)
                 .toList();
 

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -108,12 +108,17 @@ public class UserController {
     @GetMapping("/{userId}/page")
     @Operation(summary = "타인 페이지 조회", description = """
             다른 사용자의 닉네임, 프로필 이미지, 게시글, 작성 댓글, 즐겨찾기 목록을 조회합니다.
-            
+
             **type 파라미터:**
             - type=posts → 게시글만 조회
             - type=comments → 댓글만 조회
             - type=favorites → 즐겨찾기만 조회
             - type 미지정 → 기본 탭(posts) 조회
+
+            **페이지네이션:**
+            - cursor: 다음 페이지 시작점 (이전 응답의 nextCursor 값)
+            - size: 한 페이지당 항목 수 (기본값 10)
+            - 응답의 hasNext가 true이면 nextCursor로 다음 페이지 요청 가능
             """)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "타인 페이지 조회 성공"),
@@ -140,9 +145,11 @@ public class UserController {
     })
     public ApiResponse<UserOtherPageResponse> getUserOtherPage(
             @PathVariable Long userId,
-            @RequestParam(required = false, defaultValue = "posts") UserOtherPageType type
+            @RequestParam(required = false, defaultValue = "posts") UserOtherPageType type,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") int size
     ) {
-        UserOtherPageResponse response = userService.getOtherUserPage(userId, type);
+        UserOtherPageResponse response = userService.getOtherUserPage(userId, type, cursor, size);
         return ApiResponse.onSuccess(response);
     }
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close refactor/#174

## 🛠️ 작업 내용

- 타인 페이지 조회 API에 페이지네이션 기능 추가
- 게시글, 댓글, 즐겨찾기 목록에 페이지 단위 조회 지원

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
