### PR TITLE
fix: 타인페이지 즐겨찾기 계산 에러 수정

### DIFF
--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -124,7 +124,7 @@ public class UserService {
                 favorites = getFavoritePostsFromSlice(favoriteSlice);
                 hasNext = favoriteSlice.hasNext();
                 if (hasNext && !favoriteSlice.getContent().isEmpty()) {
-                    nextCursor = favoriteSlice.getContent().get(favoriteSlice.getContent().size() - 1).getId();
+                    nextCursor = favoriteSlice.getContent().get(favoriteSlice.getContent().size() - 1).getFavorite_id();
                 }
             }
         }

--- a/src/main/resources/templates/emails/password-reset-email.html
+++ b/src/main/resources/templates/emails/password-reset-email.html
@@ -175,7 +175,7 @@
                   <tr>
                     <td style="text-align: center; width: 100%">
                       <a
-                        href="https://www.finditem.kr/email-login"
+                        href="https://www.finditem.kr/login/email"
                         style="
                           text-decoration: none;
                           color: #f6fffc;


### PR DESCRIPTION
## 🧩 관련 이슈

- close fix#177

## 🛠️ 작업 내용

- 비밀번호 재설정 메일의 로그인 링크 경로 수정
- 타인 페이지 즐겨찾기 커서 계산 오류 수정

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
