### PR TITLE
fix: 게시글(POST) - 타인 페이지 조회시 Post 가져오는 로직 에러 수정

### DIFF
--- a/src/main/java/com/fmi/domain/post/data/Post.java
+++ b/src/main/java/com/fmi/domain/post/data/Post.java
@@ -57,6 +57,7 @@ public class Post {
     private LocalDate date;
 
     @Column(name = "radius")
+    @Enumerated(EnumType.STRING)
     private Radius radius;
 
     @Column(name = "updated_at")

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -44,12 +44,9 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     @Query("SELECT DISTINCT p FROM Post p WHERE p.user = :user AND p.temporarySave = false")
     List<Post> findAllPublishedWithImagesByUser(@Param("user") User user);
 
-    @Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.images WHERE p.user = :user AND p.temporarySave = false ORDER BY p.id DESC")
-    Slice<Post> findPublishedByUserOrderByIdDesc(@Param("user") User user, Pageable pageable);
+    Slice<Post> findByUserAndTemporarySaveFalseOrderByIdDesc(User user, Pageable pageable);
 
-    @Query("SELECT DISTINCT p FROM Post p LEFT JOIN FETCH p.images WHERE p.user = :user AND p.temporarySave = false AND p.id < :cursor ORDER BY p.id DESC")
-    Slice<Post> findPublishedByUserAndIdLessThanOrderByIdDesc(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable);
-
+    Slice<Post> findByUserAndTemporarySaveFalseAndIdLessThanOrderByIdDesc(User user, Long cursor, Pageable pageable);
     long countByUser(User user);
 
 

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -98,8 +98,8 @@ public class UserService {
         switch (resolvedType) {
             case POSTS -> {
                 Slice<Post> postSlice = (cursor == null)
-                        ? postRepository.findPublishedByUserOrderByIdDesc(targetUser, pageRequest)
-                        : postRepository.findPublishedByUserAndIdLessThanOrderByIdDesc(targetUser, cursor, pageRequest);
+                        ? postRepository.findByUserAndTemporarySaveFalseOrderByIdDesc(targetUser, pageRequest)
+                        : postRepository.findByUserAndTemporarySaveFalseAndIdLessThanOrderByIdDesc(targetUser, cursor, pageRequest);
 
                 List<Post> postList = postSlice.getContent();
                 posts = postQueryService.getPostBriefResponseList(postList, me);


### PR DESCRIPTION
## 🧩 관련 이슈

- close #181 

## 🛠️ 작업 내용

- Post entity Radius @Enumerated(EnumType.STRING) 설정 누락
- 타인 페이지 조회시 Post 가져오는 로직 수정

## 📢 참고 및 특이사항


## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
