### PR TITLE
fix: Post/PostImage/PostFavorite 구조 변경 미반영으로 Repository JPQL 오류 및 순환 참조 발생

### DIFF
--- a/src/main/java/com/fmi/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostImageRepository.java
@@ -20,10 +20,10 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long>, Pos
     Optional<PostImage> findByPost_IdAndImageType(Long postId, ImageType imageType);
 
     @Query("""
-                select pi
-                from PostImage pi
-                where pi.post.id in :postIds
-                  and pi.isThumbnail = true
+            select pi
+            from PostImage pi
+            where pi.post.id in :postIds
+              and pi.imageType = com.fmi.domain.post.data.ImageType.THUMBNAIL
             """)
     List<PostImage> findThumbnailImagesByPostIds(@Param("postIds") List<Long> postIds);
 

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -191,4 +191,18 @@ public class PostQueryService {
 
         return PostConverter.toShareResponse(post, thumbnailImageUrl);
     }
+
+
+    //즐찾 조회
+    @Transactional(readOnly = true)
+    public List<PostBriefResponse> getFavoritePost(UserDetails userDetails) {
+        User user = userQueryService.findUser(userDetails.getUsername());
+
+        List<PostFavorite> favorites = postFavoriteRepository.findByUserAndIsFavoriteTrue(user);
+        List<Post> posts = favorites.stream()
+                .map(PostFavorite::getPost)
+                .toList();
+
+        return getPostBriefResponseList(posts, user);
+    }
 }

--- a/src/main/java/com/fmi/domain/postfavorite/repository/PostFavoriteRepository.java
+++ b/src/main/java/com/fmi/domain/postfavorite/repository/PostFavoriteRepository.java
@@ -47,10 +47,25 @@ public interface PostFavoriteRepository extends JpaRepository<PostFavorite, Long
     List<Long> findFavoritePostIdsByUserAndPostIds(@Param("user") User user,
                                                    @Param("postIds") List<Long> postIds);
 
-
-    @Query("SELECT pf FROM PostFavorite pf JOIN FETCH pf.post p LEFT JOIN FETCH p.images WHERE pf.user = :user AND pf.isFavorite = true ORDER BY pf.id DESC")
+    @Query("""
+                SELECT pf
+                FROM PostFavorite pf
+                JOIN FETCH pf.post p
+                WHERE pf.user = :user
+                  AND pf.isFavorite = true
+                ORDER BY pf.id DESC
+            """)
     Slice<PostFavorite> findByUserAndIsFavoriteTrueOrderByIdDesc(@Param("user") User user, Pageable pageable);
 
-    @Query("SELECT pf FROM PostFavorite pf JOIN FETCH pf.post p LEFT JOIN FETCH p.images WHERE pf.user = :user AND pf.isFavorite = true AND pf.id < :cursor ORDER BY pf.id DESC")
-    Slice<PostFavorite> findByUserAndIsFavoriteTrueAndIdLessThanOrderByIdDesc(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable);
+    @Query("""
+                SELECT pf
+                FROM PostFavorite pf
+                JOIN FETCH pf.post p
+                WHERE pf.user = :user
+                  AND pf.isFavorite = true
+                  AND pf.id < :cursor
+                ORDER BY pf.id DESC
+            """)
+    Slice<PostFavorite> findByUserAndIsFavoriteTrueAndIdLessThanOrderByIdDesc(@Param("user") User user, @Param("cursor") Long cursor, Pageable pageable
+    );
 }

--- a/src/main/java/com/fmi/domain/postfavorite/service/PostFavoriteService.java
+++ b/src/main/java/com/fmi/domain/postfavorite/service/PostFavoriteService.java
@@ -1,11 +1,12 @@
 package com.fmi.domain.postfavorite.service;
 
 import com.fmi.domain.auth.data.User;
-import com.fmi.domain.post.service.PostQueryService;
-import com.fmi.domain.post.web.dto.response.PostBriefResponse;
+import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.postfavorite.data.PostFavorite;
 import com.fmi.domain.postfavorite.repository.PostFavoriteRepository;
 import com.fmi.domain.post.data.Post;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
 import com.fmi.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -20,13 +21,14 @@ import java.util.stream.Collectors;
 public class PostFavoriteService {
     private final PostFavoriteRepository favoriteRepository;
     private final UserQueryService userQueryService;
-    private final PostQueryService postQueryService;
+    private final PostRepository postRepository;
 
 
     @Transactional
     public void togglePostFavorite(UserDetails userDetails, Long postId) {
         User user = userQueryService.findUser(userDetails.getUsername());
-        Post post = postQueryService.findById(postId);
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._POST_NOT_FOUND));
 
         PostFavorite postFavorite = favoriteRepository.findByUserAndPost(user, post).orElse(null);
 
@@ -43,20 +45,6 @@ public class PostFavoriteService {
         PostFavorite postFavorite = PostFavorite.create(user, post);
 
         favoriteRepository.save(postFavorite);
-    }
-
-
-    //즐찾 조회
-    @Transactional(readOnly = true)
-    public List<PostBriefResponse> getFavoritePost(UserDetails userDetails) {
-        User user = userQueryService.findUser(userDetails.getUsername());
-
-        List<PostFavorite> favorites = favoriteRepository.findByUserAndIsFavoriteTrue(user);
-        List<Post> posts = favorites.stream()
-                .map(PostFavorite::getPost)
-                .toList();
-
-        return postQueryService.getPostBriefResponseList(posts, user);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
+++ b/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
@@ -1,5 +1,6 @@
 package com.fmi.domain.postfavorite.web.controller;
 
+import com.fmi.domain.post.service.PostQueryService;
 import com.fmi.domain.post.web.dto.response.PostBriefResponse;
 import com.fmi.domain.postfavorite.service.PostFavoriteService;
 import com.fmi.global.apiPayload.ApiResponse;
@@ -20,6 +21,7 @@ import java.util.List;
 @Tag(name = "Post", description = "게시글 관련 API")
 public class PostFavoriteController {
     private final PostFavoriteService postFavoriteService;
+    private final PostQueryService postQueryService;
 
     @PutMapping("/post/{postId}/favorites")
     @Operation(
@@ -55,7 +57,7 @@ public class PostFavoriteController {
     @GetMapping("/users/me/favorites")
     public ResponseEntity<ApiResponse<List<PostBriefResponse>>> getFavoritePost(@AuthenticationPrincipal UserDetails userDetails) {
 
-        List<PostBriefResponse> response = postFavoriteService.getFavoritePost(userDetails);
+        List<PostBriefResponse> response = postQueryService.getFavoritePost(userDetails);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #183 

## 🛠️ 작업 내용

- PostFavoriteRepository 쿼리 post.images 여전히 남아 있는 문제 해결
- PostQueryService, PostFavoriteService 순환참조 문제 해결

## 📢 참고 및 특이사항


## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
