### PR TITLE
fix: Post API 누락, 게시글 조회 필터링 - 기간 파라미터 제거

### DIFF
--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepository.java
@@ -1,5 +1,6 @@
 package com.fmi.domain.chatroom.repository;
 
+import com.fmi.domain.auth.data.User;
 import com.fmi.domain.chatroom.data.ChatRoomParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,8 +10,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomParticipant,Long>, ChatRoomParticipantRepositoryCustom {
+public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomParticipant, Long>, ChatRoomParticipantRepositoryCustom {
     boolean existsByUser_IdAndChatRoom_Id(Long userId, Long roomId);
+
     Optional<ChatRoomParticipant> findByUser_IdAndChatRoom_Id(Long userId, Long roomId);
 
     Optional<ChatRoomParticipant> findByChatRoom_IdAndUser_Id(Long roomId, Long userId);
@@ -18,11 +20,19 @@ public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomPar
     List<ChatRoomParticipant> findAllByChatRoom_Id(Long roomId);
 
     @Query("SELECT cp FROM ChatRoomParticipant cp " +
-           "JOIN FETCH cp.user u " +
-           "JOIN NotificationSettings ns ON ns.user = cp.user " +
-           "WHERE cp.unreadCount > 0 " +
-           "AND cp.firstUnreadAt <= :threshold " +
-           "AND ns.chatEnabled = true " +
-           "AND cp.lastRemindedAt IS NULL")
+            "JOIN FETCH cp.user u " +
+            "JOIN NotificationSettings ns ON ns.user = cp.user " +
+            "WHERE cp.unreadCount > 0 " +
+            "AND cp.firstUnreadAt <= :threshold " +
+            "AND ns.chatEnabled = true " +
+            "AND cp.lastRemindedAt IS NULL")
     List<ChatRoomParticipant> findParticipantsForReminder(@Param("threshold") LocalDateTime threshold);
+
+    @Query("""
+                SELECT COUNT(crp)
+                FROM ChatRoomParticipant crp
+                WHERE crp.user = :user
+                  AND crp.participantState = 'ACTIVE'
+            """)
+    long countActiveChatRoomsByUser(@Param("user") User user);
 }

--- a/src/main/java/com/fmi/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/fmi/domain/post/converter/PostConverter.java
@@ -4,6 +4,7 @@ import com.fmi.domain.auth.data.User;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.web.dto.request.PostCreateRequest;
 import com.fmi.domain.post.web.dto.response.*;
+import com.fmi.domain.user.web.dto.response.UserPostResponse;
 
 import java.util.List;
 
@@ -31,7 +32,7 @@ public final class PostConverter {
         return new PostUpdateResponse(post.getId());
     }
 
-    public static PostGetResponse toGetResponse(Post post, boolean isFavorite, long viewCount, long chatRoomCount, boolean isNew, boolean isHot, long favoriteCount, long userPostCount, List<PostImageResponse> imageList) {
+    public static PostGetResponse toGetResponse(Post post, boolean isFavorite, long viewCount, boolean isNew, boolean isHot, long favoriteCount, List<PostImageResponse> imageList, UserPostResponse userPostResponse) {
         return new PostGetResponse(
                 post.getId(),
                 post.getTitle(),
@@ -49,9 +50,8 @@ public final class PostConverter {
                 isNew,
                 isHot,
                 post.getCreatedAt(),
-                chatRoomCount,
-                userPostCount,
-                imageList
+                imageList,
+                userPostResponse
         );
     }
 

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
@@ -14,8 +14,6 @@ public interface PostRepositoryCustom {
                                                  PostStatus postStatus,
                                                  Category category,
                                                  String address,
-                                                 LocalDate startDate,
-                                                 LocalDate endDate,
                                                  SortType sortType,
                                                  Long cursor,
                                                  int size,

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -13,7 +13,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -26,7 +25,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public PostPageResponse searchPostsByFiltersAndSort(PostType postType, PostStatus postStatus, Category category, String address, LocalDate startDate, LocalDate endDate, SortType sortType, Long cursor, int size, Long userId) {
+    public PostPageResponse searchPostsByFiltersAndSort(PostType postType, PostStatus postStatus, Category category, String address, SortType sortType, Long cursor, int size, Long userId) {
         QPost post = QPost.post;
         QPostFavorite postFavorite = QPostFavorite.postFavorite;
 
@@ -35,8 +34,6 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 equalsPostType(post, postType),
                 equalsPostStatus(post, postStatus),
                 equalsCategory(post, category),
-                geDate(post, startDate),
-                leDate(post, endDate),
                 cursorCondition(post, sortType, cursor)
         );
 
@@ -183,14 +180,6 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
     private BooleanExpression equalsCategory(QPost post, Category category) {
         return Objects.isNull(category) ? null : post.category.eq(category);
-    }
-
-    private BooleanExpression geDate(QPost post, LocalDate startDate) {
-        return Objects.isNull(startDate) ? null : post.createdAt.goe(startDate.atStartOfDay());
-    }
-
-    private BooleanExpression leDate(QPost post, LocalDate endDate) {
-        return Objects.isNull(endDate) ? null : post.createdAt.loe(endDate.atTime(23, 59, 59));
     }
 
     private OrderSpecifier<?>[] orderBySortType(QPost post, SortType sortType) {

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -3,7 +3,7 @@ package com.fmi.domain.post.service;
 import com.fmi.domain.Enum.Category;
 import com.fmi.domain.Enum.SortType;
 import com.fmi.domain.auth.data.User;
-import com.fmi.domain.chatroom.repository.ChatRoomRepository;
+import com.fmi.domain.chatroom.repository.ChatRoomParticipantRepository;
 import com.fmi.domain.post.converter.PostConverter;
 import com.fmi.domain.post.converter.PostImageConverter;
 import com.fmi.domain.post.data.Post;
@@ -16,6 +16,7 @@ import com.fmi.domain.post.web.dto.response.*;
 import com.fmi.domain.postfavorite.data.PostFavorite;
 import com.fmi.domain.postfavorite.repository.PostFavoriteRepository;
 import com.fmi.domain.postfavorite.service.PostFavoriteService;
+import com.fmi.domain.user.converter.UserConverter;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import com.fmi.service.UserQueryService;
@@ -42,19 +43,16 @@ public class PostQueryService {
     private final PostImageRepository postImageRepository;
     private final UserQueryService userQueryService;
     private final PostFavoriteRepository postFavoriteRepository;
-    private final ChatRoomRepository chatRoomRepository;
     private final PostFavoriteService postFavoriteService;
     private final PostImageService postImageService;
     private final StringRedisTemplate stringRedisTemplate;
+    private final ChatRoomParticipantRepository chatRoomParticipantRepository;
 
 
     // 게시글 단일 조회
     @Transactional
     public PostGetResponse getPost(Long postId, UserDetails userDetails, String clientIp) {
         Post post = findById(postId);
-
-        Long chatRoomCount = chatRoomRepository.countByPostId(postId);
-        Long userPostCount = postRepository.countByUserAndTemporarySaveFalse(post.getUser());
 
         List<PostImageResponse> imageList = PostImageConverter.toResponseList(postImageRepository.findByPost(post));
 
@@ -83,16 +81,20 @@ public class PostQueryService {
 
         long favoriteCount = postFavoriteService.countByPostAndIsFavoriteTrue(post);
 
+        User user = post.getUser();
+        long userPostCount = postRepository.countByUserAndTemporarySaveFalse(user);
+        long chatRoomCount = chatRoomParticipantRepository.countActiveChatRoomsByUser(user);
+
+
         return PostConverter.toGetResponse(
                 post,
                 isFavorite,
                 viewCount,
-                chatRoomCount,
                 post.isNew(),
                 false,
                 favoriteCount,
-                userPostCount,
-                imageList
+                imageList,
+                UserConverter.toUserPostResponse(user, userPostCount, chatRoomCount)
         );
     }
 
@@ -129,8 +131,6 @@ public class PostQueryService {
                                                       PostStatus postStatus,
                                                       Category category,
                                                       String address,
-                                                      LocalDate startDate,
-                                                      LocalDate endDate,
                                                       SortType sortType,
                                                       Long cursor,
                                                       int size,
@@ -144,8 +144,6 @@ public class PostQueryService {
                 postStatus,
                 category,
                 address,
-                startDate,
-                endDate,
                 sortType,
                 cursor,
                 size,

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -78,14 +78,12 @@ public class PostController {
     public ResponseEntity<ApiResponse<PostPageResponse>> searchPostFilterOrSort(@RequestParam(required = false) PostType postType,
                                                                                 @RequestParam(required = false, defaultValue = "SEARCHING") PostStatus postStatus,
                                                                                 @RequestParam(required = false) Category category,
-                                                                                @RequestParam String address,
-                                                                                @RequestParam(required = false) LocalDate startDate,
-                                                                                @RequestParam(required = false) LocalDate endDate,
+                                                                                @RequestParam(required = false) String address,
                                                                                 @RequestParam(required = false, defaultValue = "LATEST") SortType sortType,
                                                                                 @AuthenticationPrincipal UserDetails userDetails,
                                                                                 @RequestParam(required = false) Long cursor,
                                                                                 @RequestParam(required = false, defaultValue = "20") int size) {
-        PostPageResponse response = postQueryService.getPostListByFilterOrSort(postType, postStatus, category, address, startDate, endDate, sortType, cursor, size, userDetails);
+        PostPageResponse response = postQueryService.getPostListByFilterOrSort(postType, postStatus, category, address, sortType, cursor, size, userDetails);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }

--- a/src/main/java/com/fmi/domain/post/web/dto/response/PostGetResponse.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/response/PostGetResponse.java
@@ -4,6 +4,7 @@ import com.fmi.domain.Enum.Category;
 import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.data.Radius;
+import com.fmi.domain.user.web.dto.response.UserPostResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -25,7 +26,6 @@ public record PostGetResponse(
         boolean isNew,
         boolean isHot,
         LocalDateTime createdAt,
-        Long chatRoomCount,
-        Long userPostCount,
-        List<PostImageResponse> imageResponseList) {
+        List<PostImageResponse> imageResponseList,
+        UserPostResponse postUserInformation) {
 }

--- a/src/main/java/com/fmi/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/fmi/domain/user/converter/UserConverter.java
@@ -8,6 +8,7 @@ import com.fmi.domain.user.response.UserCommentSummaryResponse;
 import com.fmi.domain.user.response.UserOtherPageResponse;
 import com.fmi.domain.user.response.UserProfileResponse;
 import com.fmi.domain.user.web.dto.UserUpdateRequest;
+import com.fmi.domain.user.web.dto.response.UserPostResponse;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -91,6 +92,16 @@ public class UserConverter {
                 .nextCursor(nextCursor)
                 .hasNext(hasNext)
                 .build();
+    }
+
+    public static UserPostResponse toUserPostResponse(User user, long postCount, long chattingCount) {
+        return new UserPostResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getProfile_img(),
+                postCount,
+                chattingCount
+        );
     }
 }
 

--- a/src/main/java/com/fmi/domain/user/web/dto/response/UserPostResponse.java
+++ b/src/main/java/com/fmi/domain/user/web/dto/response/UserPostResponse.java
@@ -1,0 +1,11 @@
+package com.fmi.domain.user.web.dto.response;
+
+public record UserPostResponse(
+        Long userId,
+        String nickName,
+        String profileImage,
+        long postCount,
+        long chattingCount
+) {
+
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close #185 

## 🛠️ 작업 내용


- Post 리스트 조회시 생성일 기준 필터링 파라미터 제거

- Post 리스트 조회시 필터링 주소 required = false 누락 추가

- Post 상세 조회시 response 데이터 누락 ( USER 데이터 - 닉네임, 프로필 이미지 추가)

- Post 상세 조회시 response 데이터 위치 조정

## 📢 참고 및 특이사항

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
