### PR TITLE
feat: 채팅 응답에 게시글 카테고리 추가 

### DIFF
--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -8,6 +8,7 @@ import com.fmi.domain.chatroom.data.ChatRoomParticipant;
 import com.fmi.domain.post.data.Post;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.*;
@@ -26,6 +27,7 @@ public class ChatRoomConverter {
         var postInfo = PostInfoDTO.builder()
                 .postId(post.getId())
                 .postType(post.getPostType())
+                .category(post.getCategory())
                 .title(post.getTitle())
                 .address(post.getAddress())
                 .thumbnailUrl(thumbnailUrl)
@@ -39,18 +41,18 @@ public class ChatRoomConverter {
                 .build();
     }
 
-    public static List<ChatRoomSummaryDTO> toChatRoomSummaryListDTO(List<ChatRoomParticipant> participants, User currentUser) {
+    public static List<ChatRoomSummaryDTO> toChatRoomSummaryListDTO(List<ChatRoomParticipant> participants, User currentUser, Map<Long, String> thumbnailMap) {
         return participants.stream()
                 .map(pt -> {
                     User contactUser = pt.getChatRoom().getOtherParticipant(currentUser.getId());
 
-                    return toChatRoomSummaryDTO(pt, contactUser);
+                    return toChatRoomSummaryDTO(pt, contactUser, thumbnailMap);
                 })
                 .collect(Collectors.toList());
     }
 
 
-    public static ChatRoomSummaryDTO toChatRoomSummaryDTO(ChatRoomParticipant participant, User contactUser) {
+    public static ChatRoomSummaryDTO toChatRoomSummaryDTO(ChatRoomParticipant participant, User contactUser, Map<Long, String> thumbnailMap) {
 
         ContactUserDTO contactUserDTO = ContactUserDTO.builder()
                 .userId(contactUser.getId())
@@ -59,11 +61,13 @@ public class ChatRoomConverter {
                 .build();
 
         Post post = participant.getChatRoom().getPost();
-//        String thumbnailUrl = post.getImages().isEmpty() ? null : post.getImages().get(0).getImgUrl();
-        String thumbnailUrl = null;
+
+        String thumbnailUrl = thumbnailMap.get(post.getId());
+
         PostInfoDTO postInfoDTO = PostInfoDTO.builder()
                 .postId(post.getId())
                 .postType(post.getPostType())
+                .category(post.getCategory())
                 .title(post.getTitle())
                 .address(post.getAddress())
                 .thumbnailUrl(thumbnailUrl)

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
@@ -26,7 +26,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.*;
 
@@ -118,7 +120,14 @@ public class ChatRoomService {
     private MyChatListDTO buildChatListResponse(Slice<ChatRoomParticipant> participantSlice, User user) {
         List<ChatRoomParticipant> participants = participantSlice.getContent();
 
-        List<ChatRoomSummaryDTO> summaryDTOs = ChatRoomConverter.toChatRoomSummaryListDTO(participants, user);
+        List<Long> postIds = participants.stream()
+                .map(p -> p.getChatRoom().getPost().getId())
+                .distinct()
+                .collect(Collectors.toList());
+
+        Map<Long, String> thumbnailMap = postImageService.findThumbnailUrlMap(postIds);
+
+        List<ChatRoomSummaryDTO> summaryDTOs = ChatRoomConverter.toChatRoomSummaryListDTO(participants, user, thumbnailMap);
 
         Long nextCursor = null;
         if (!participants.isEmpty() && participantSlice.hasNext()) {

--- a/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
@@ -1,8 +1,13 @@
 package com.fmi.domain.chatroom.web.dto;
 
+import com.fmi.domain.Enum.Category;
 import com.fmi.domain.chatmessage.data.enums.MessageType;
 import com.fmi.domain.post.data.PostType;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -37,6 +42,7 @@ public class ChatRoomResponseDTO {
     public static class PostInfoDTO {
         private Long postId;
         private PostType postType;
+        private Category category;
         private String title;
         private String address;
         private String thumbnailUrl;

--- a/src/main/java/com/fmi/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostImageRepository.java
@@ -30,4 +30,7 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long>, Pos
     @Modifying
     @Query("delete from PostImage pi where pi.post = :post")
     void deleteAllByPost(@Param("post") Post post);
+
+    List<PostImage> findByPostIdInAndImageType(List<Long> postIds, ImageType imageType);
+
 }

--- a/src/main/java/com/fmi/domain/post/service/PostImageService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostImageService.java
@@ -100,4 +100,19 @@ public class PostImageService {
 
         return postImageRepository.countImagesGroupByPostId(postIds);
     }
+
+    @Transactional(readOnly = true)
+    public Map<Long, String> findThumbnailUrlMap(List<Long> postIds) {
+        if (postIds == null || postIds.isEmpty()) return Map.of();
+
+        List<PostImage> thumbnails =
+                postImageRepository.findByPostIdInAndImageType(postIds, ImageType.THUMBNAIL);
+
+        return thumbnails.stream()
+                .collect(Collectors.toMap(
+                        pi -> pi.getPost().getId(),
+                        PostImage::getImgUrl
+                ));
+    }
+
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #198 

## 🛠️ 작업 내용

- 채팅관련 api에서 게시글 정보를 응답하는 부분에서 category 컬럼을 추가했습니다.
- 썸네일 처리가 바뀌면서 내 채팅방 목록에서 썸네일이 null 처리가 되어있던 부분을 수정했습니다. 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
