### PR TITLE
Fix/#201 Post API 누락 부분 수정

### DIFF
--- a/src/main/java/com/fmi/domain/post/converter/util/PostConverter.java
+++ b/src/main/java/com/fmi/domain/post/converter/util/PostConverter.java
@@ -18,6 +18,7 @@ public final class PostConverter {
                 request.longitude(),
                 request.postType(),
                 request.category(),
+                request.content(),
                 request.temporarySave(),
                 request.date(),
                 request.radius(),
@@ -32,7 +33,7 @@ public final class PostConverter {
         return new PostUpdateResponse(post.getId());
     }
 
-    public static PostGetResponse toGetResponse(Post post, boolean isFavorite, long viewCount, boolean isNew, boolean isHot, long favoriteCount, List<PostImageResponse> imageList, UserPostResponse userPostResponse) {
+    public static PostGetResponse toGetResponse(Post post, boolean isFavorite, long viewCount, boolean isNew, boolean isHot, long favoriteCount, boolean isMine, List<PostImageResponse> imageList, UserPostResponse userPostResponse) {
         return new PostGetResponse(
                 post.getId(),
                 post.getTitle(),
@@ -50,6 +51,7 @@ public final class PostConverter {
                 isNew,
                 isHot,
                 post.getCreatedAt(),
+                isMine,
                 imageList,
                 userPostResponse
         );

--- a/src/main/java/com/fmi/domain/post/data/Post.java
+++ b/src/main/java/com/fmi/domain/post/data/Post.java
@@ -68,13 +68,14 @@ public class Post {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private Post(String title, String address, double latitude, double longitude, PostType postType, Category category, boolean temporarySave, LocalDateTime date, Radius radius, User user) {
+    private Post(String title, String address, double latitude, double longitude, PostType postType, Category category, String content, boolean temporarySave, LocalDateTime date, Radius radius, User user) {
         this.title = title;
         this.address = address;
         this.latitude = latitude;
         this.longitude = longitude;
         this.postType = postType;
         this.category = category;
+        this.content = content;
         this.temporarySave = temporarySave;
         this.date = date;
         this.radius = radius;
@@ -84,8 +85,8 @@ public class Post {
         this.viewCount = 0;
     }
 
-    public static Post create(String title, String address, double latitude, double longitude, PostType postType, Category category, boolean temporarySave, LocalDateTime date, Radius radius, User user) {
-        return new Post(title, address, latitude, longitude, postType, category, temporarySave, date, radius, user);
+    public static Post create(String title, String address, double latitude, double longitude, PostType postType, Category category, String content, boolean temporarySave, LocalDateTime date, Radius radius, User user) {
+        return new Post(title, address, latitude, longitude, postType, category, content, temporarySave, date, radius, user);
     }
 
     public boolean isNew() {

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -47,6 +47,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     Slice<Post> findByUserAndTemporarySaveFalseOrderByIdDesc(User user, Pageable pageable);
 
     Slice<Post> findByUserAndTemporarySaveFalseAndIdLessThanOrderByIdDesc(User user, Long cursor, Pageable pageable);
+
     long countByUser(User user);
 
 
@@ -65,5 +66,37 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 //    List<Post> findHotPost(Pageable pageable);
 
     Long countByUserAndTemporarySaveFalse(User user);
+
+    @Query(value = """
+            SELECT p.*
+            FROM post p
+            WHERE MATCH(p.title, p.content)
+            AGAINST (:keyword IN BOOLEAN MODE)
+              AND p.id < :cursor
+            ORDER BY p.id DESC
+            LIMIT :size
+            """, nativeQuery = true)
+    List<Post> searchByKeywordWithCursor(@Param("keyword") String keyword,
+                                         @Param("cursor") Long cursor,
+                                         @Param("size") int size);
+
+    @Query(value = """
+            SELECT p.*
+            FROM post p
+            WHERE MATCH(p.title, p.content)
+            AGAINST (:keyword IN BOOLEAN MODE)
+            ORDER BY p.id DESC
+            LIMIT :size
+            """, nativeQuery = true)
+    List<Post> searchByKeyword(@Param("keyword") String keyword,
+                               @Param("size") int size);
+
+    @Query("""
+                select count(p)
+                from Post p
+                where (p.title like concat('%', :keyword, '%')
+                    or p.content like concat('%', :keyword, '%'))
+            """)
+    long countByKeyword(@Param("keyword") String keyword);
 
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -91,12 +91,12 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     List<Post> searchByKeyword(@Param("keyword") String keyword,
                                @Param("size") int size);
 
-    @Query("""
-                select count(p)
-                from Post p
-                where (p.title like concat('%', :keyword, '%')
-                    or p.content like concat('%', :keyword, '%'))
-            """)
-    long countByKeyword(@Param("keyword") String keyword);
+    @Query(value = """
+                SELECT COUNT(*)
+                FROM post p
+                WHERE MATCH(p.title, p.content)
+                AGAINST (:keyword IN BOOLEAN MODE)
+            """, nativeQuery = true)
+    long countByKeywordFulltext(@Param("keyword") String keyword);
 
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -29,32 +29,47 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         QPost post = QPost.post;
         QPostFavorite postFavorite = QPostFavorite.postFavorite;
 
-        BooleanExpression whereQuery = Expressions.allOf(
+        BooleanExpression baseWhere = Expressions.allOf(
                 addressStartsWith(post, address),
                 equalsPostType(post, postType),
                 equalsPostStatus(post, postStatus),
-                equalsCategory(post, category),
+                equalsCategory(post, category)
+        );
+
+        BooleanExpression pageWhere = Expressions.allOf(
+                baseWhere,
                 cursorCondition(post, sortType, cursor)
         );
+
+        Long postCount = queryFactory
+                .select(post.id.countDistinct())
+                .from(post)
+                .leftJoin(postFavorite).on(
+                        postFavorite.post.eq(post),
+                        postFavorite.isFavorite.isTrue()
+                )
+                .where(baseWhere)
+                .fetchOne();
+
+        if (Objects.isNull(postCount)) postCount = 0L;
 
         List<Post> posts;
         if (Objects.equals(sortType, SortType.MOST_FAVORITED)) {
             posts = queryFactory.select(post)
-                    .from(post).leftJoin(postFavorite).on(
+                    .from(post)
+                    .leftJoin(postFavorite).on(
                             postFavorite.post.eq(post),
                             postFavorite.isFavorite.isTrue()
-                    ).where(whereQuery)
-                    .groupBy(post.id)
-                    .orderBy(
-                            postFavorite.favorite_id.count().desc(),
-                            post.id.desc()
                     )
+                    .where(pageWhere)
+                    .groupBy(post.id)
+                    .orderBy(postFavorite.favorite_id.count().desc(), post.id.desc())
                     .limit(size + 1)
                     .fetch();
         } else {
             posts = queryFactory
                     .selectFrom(post)
-                    .where(whereQuery)
+                    .where(pageWhere)
                     .orderBy(orderBySortType(post, sortType))
                     .limit(size + 1)
                     .fetch();
@@ -68,7 +83,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         Long nextCursor = (hasNext && !posts.isEmpty()) ? posts.get(posts.size() - 1).getId() : null;
 
         if (posts.isEmpty()) {
-            return new PostPageResponse(List.of(), null, false);
+            return new PostPageResponse(List.of(), 0L, null, false);
         }
 
         List<Long> postIdList = posts.stream().map(Post::getId).toList();
@@ -159,7 +174,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 })
                 .toList();
 
-        return new PostPageResponse(postList, nextCursor, hasNext);
+        return new PostPageResponse(postList, postCount, nextCursor, hasNext);
     }
 
     private BooleanExpression addressStartsWith(QPost post, String address) {

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -58,7 +58,7 @@ public class PostQueryService {
 
         boolean isFavorite = false;
         boolean canIncreaseViewCount;
-
+        boolean isMine = false;
         if (Objects.nonNull(userDetails)) {
             User user = userQueryService.findUser(userDetails.getUsername());
 
@@ -68,6 +68,11 @@ public class PostQueryService {
             isFavorite = Objects.nonNull(favorite) && favorite.isFavorite();
 
             canIncreaseViewCount = canIncreaseViewCount(postId, user.getId());
+
+            if (Objects.equals(user.getId(), post.getUser().getId())) {
+                isMine = true;
+            }
+
         } else {
             canIncreaseViewCount = canIncreaseViewCount(postId, clientIp);
         }
@@ -93,6 +98,7 @@ public class PostQueryService {
                 post.isNew(),
                 false,
                 favoriteCount,
+                isMine,
                 imageList,
                 UserConverter.toUserPostResponse(user, userPostCount, chatRoomCount)
         );
@@ -148,6 +154,43 @@ public class PostQueryService {
                 cursor,
                 size,
                 userId);
+    }
+
+    @Transactional(readOnly = true)
+    public PostPageResponse searchByKeyword(String keyword, Long cursor, int size, UserDetails userDetails) {
+        User user = userQueryService.findUserIfNullReturnNull(userDetails);
+        int limit = size + 1;
+
+        long postCount = postRepository.countByKeyword(keyword);
+
+        List<Post> fetched = (cursor == null)
+                ? postRepository.searchByKeyword(keyword, limit)
+                : postRepository.searchByKeywordWithCursor(keyword, cursor, limit);
+
+        boolean hasNext = fetched.size() > size;
+
+        if (hasNext) {
+            fetched = fetched.subList(0, size);
+        }
+
+        Long nextCursor = fetched.isEmpty() ? null : fetched.get(fetched.size() - 1).getId();
+
+        Map<Long, Long> favoriteCountMap = postFavoriteService.getFavoriteCountMap(fetched);
+        Map<Long, Boolean> myFavoriteMap = postFavoriteService.getIsFavoriteMap(user, fetched);
+        Map<Long, String> thumbnailMap = postImageService.findThumbnailUrlByPostList(fetched);
+        Map<Long, Integer> postImageCountMap = postImageService.countImageByPostList(fetched);
+
+        List<PostBriefResponse> responseList = fetched.stream()
+                .map(post -> PostConverter.toPostBriefResponse(
+                        post,
+                        myFavoriteMap.getOrDefault(post.getId(), false),
+                        thumbnailMap.getOrDefault(post.getId(), null),
+                        favoriteCountMap.getOrDefault(post.getId(), 0L),
+                        postImageCountMap.getOrDefault(post.getId(), 0)
+                ))
+                .toList();
+
+        return new PostPageResponse(responseList, postCount, nextCursor, hasNext);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -28,12 +28,14 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.text.Normalizer;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -161,7 +163,11 @@ public class PostQueryService {
         User user = userQueryService.findUserIfNullReturnNull(userDetails);
         int limit = size + 1;
 
-        long postCount = postRepository.countByKeyword(keyword);
+        keyword = sanitizeForBooleanFulltext(keyword);
+
+        if (keyword.isBlank()) return new PostPageResponse(List.of(), 0L, null, false);
+
+        long postCount = postRepository.countByKeywordFulltext(keyword);
 
         List<Post> fetched = (cursor == null)
                 ? postRepository.searchByKeyword(keyword, limit)
@@ -191,6 +197,30 @@ public class PostQueryService {
                 .toList();
 
         return new PostPageResponse(responseList, postCount, nextCursor, hasNext);
+    }
+
+    private String sanitizeForBooleanFulltext(String input) {
+        if (Objects.isNull(input)) return "";
+
+        String s = Normalizer.normalize(input, Normalizer.Form.NFKC).trim();
+        if (s.isEmpty()) return "";
+
+        s = s.replaceAll("[^0-9A-Za-z가-힣\\s]", " ");
+
+        s = s.replaceAll("\\s+", " ").trim();
+        if (s.isEmpty()) return "";
+
+        if (s.length() > 100) {
+            s = s.substring(0, 100);
+        }
+
+        String[] tokens = s.split("\\s+");
+
+        return Arrays.stream(tokens)
+                .filter(token -> !token.isEmpty())
+                .limit(10)
+                .map(token -> token + "*")
+                .collect(Collectors.joining(" "));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -14,9 +14,11 @@ import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.utils.IpUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -26,7 +28,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
@@ -48,7 +49,7 @@ public class PostController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "415", description = "FILE415-EXT_UNSUPPORTED: 허용되지 않는 확장자입니다"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "FILE500-UPLOAD_IO: 업로드 중 오류가 발생했습니다")
     })
-    public ResponseEntity<ApiResponse<PostCreateResponse>> createPost(@RequestPart("request") PostCreateRequest request,
+    public ResponseEntity<ApiResponse<PostCreateResponse>> createPost(@RequestPart("request") @Valid PostCreateRequest request,
                                                                       @RequestPart(value = "image", required = false) List<MultipartFile> images,
                                                                       @AuthenticationPrincipal UserDetails userDetails) {
 
@@ -87,6 +88,74 @@ public class PostController {
         PostPageResponse response = postQueryService.getPostListByFilterOrSort(postType, postStatus, category, address, sortType, cursor, size, userDetails);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @GetMapping("/search/keyword")
+    @Operation(
+            summary = "게시글 키워드 검색 (무한스크롤)",
+            description = """
+                키워드로 게시글을 검색합니다. (title/content 기준)
+
+                - 무한스크롤: 첫 요청은 cursor 없이 호출하고, 이후 응답의 nextCursor를 cursor로 넣어 다음 페이지를 요청합니다.
+                - size: 한 번에 가져올 개수 (기본 20)
+
+                예)
+                - 첫 요청: /posts/search/keyword?keyword=지갑&size=20
+                - 다음 요청: /posts/search/keyword?keyword=지갑&cursor=98&size=20
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON200",
+                                          "message": "성공",
+                                          "result": {
+                                            "postList": [
+                                              {
+                                                "id": 101,
+                                                "title": "지갑 분실했어요",
+                                                "summary": "어제 강남역 근처에서...",
+                                                "thumbnailUrl": "https://example.com/thumb.png",
+                                                "address": "서울 강남구",
+                                                "postStatus": "SEARCHING",
+                                                "postType": "LOST",
+                                                "category": "WALLET",
+                                                "favoriteCount": 3,
+                                                "isFavorite": false,
+                                                "viewCount": 12,
+                                                "isNew": true,
+                                                "isHot": false,
+                                                "createdAt": "2024-01-01T00:00:00",
+                                                "imageCount": 1
+                                              }
+                                            ],
+                                            "postCount": 42,
+                                            "nextCursor": 101,
+                                            "hasNext": true
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    })
+    public ResponseEntity<ApiResponse<PostPageResponse>> searchByKeywordK(@RequestParam String keyword,
+                                                                          @AuthenticationPrincipal UserDetails userDetails,
+                                                                          @RequestParam(required = false) Long cursor,
+                                                                          @RequestParam(required = false, defaultValue = "20") int size) {
+
+        PostPageResponse postPageResponse = postQueryService.searchByKeyword(keyword, cursor, size, userDetails);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(postPageResponse));
     }
 
     @GetMapping("/{postId}")

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -148,7 +148,7 @@ public class PostController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터", content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     })
-    public ResponseEntity<ApiResponse<PostPageResponse>> searchByKeywordK(@RequestParam String keyword,
+    public ResponseEntity<ApiResponse<PostPageResponse>> searchByKeyword(@RequestParam String keyword,
                                                                           @AuthenticationPrincipal UserDetails userDetails,
                                                                           @RequestParam(required = false) Long cursor,
                                                                           @RequestParam(required = false, defaultValue = "20") int size) {

--- a/src/main/java/com/fmi/domain/post/web/dto/response/PostGetResponse.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/response/PostGetResponse.java
@@ -26,6 +26,7 @@ public record PostGetResponse(
         boolean isNew,
         boolean isHot,
         LocalDateTime createdAt,
+        boolean isMine,
         List<PostImageResponse> imageResponseList,
         UserPostResponse postUserInformation) {
 }

--- a/src/main/java/com/fmi/domain/post/web/dto/response/PostPageResponse.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/response/PostPageResponse.java
@@ -3,6 +3,7 @@ package com.fmi.domain.post.web.dto.response;
 import java.util.List;
 
 public record PostPageResponse(List<PostBriefResponse> postList,
+                               Long postCount,
                                Long nextCursor,
                                boolean hasNext) {
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #201 

## 🛠️ 작업 내용

- 게시글 상세 조회시 내 게시글인지 유무 값

- 게시글 목록 검색 기능

- 게시글 목록 필터 시 전체 게시글 수

- 게시글 생성시 content 필드값 DB에 넣지 않는 이슈

## 📢 참고 및 특이사항



## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
