### PR TITLE
fix: Post api 인증 필요없는 api spring security 등록 누락 해결

### DIFF
--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                         // 공지사항, 공개 문의 - 공개 API (경로 개편)
                         .requestMatchers("/notices/**", "/inquiries").permitAll()
                         .requestMatchers("/users/{userId}/page").permitAll()
-                        .requestMatchers("/posts/search/**", "/posts/{postId}", "/posts/{postId}/radius").permitAll()
+                        .requestMatchers("/posts/search/**", "/posts/{postId}", "/posts/{postId}/similar", "/posts/{postId}/radius").permitAll()
                         // 관리자 전용 API 보호
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                         // 공지사항, 공개 문의 - 공개 API (경로 개편)
                         .requestMatchers("/notices/**", "/inquiries").permitAll()
                         .requestMatchers("/users/{userId}/page").permitAll()
-                        .requestMatchers("/posts/search", "/posts/{postId}").permitAll()
+                        .requestMatchers("/posts/search/**", "/posts/{postId}", "/posts/{postId}/radius").permitAll()
                         // 관리자 전용 API 보호
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/java/com/fmi/domain/post/data/PostImage.java
+++ b/src/main/java/com/fmi/domain/post/data/PostImage.java
@@ -22,7 +22,7 @@ public class PostImage {
     private ImageType imageType;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post", nullable = false)
+    @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
     private PostImage(String imgUrl, ImageType imageType, Post post) {

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -1,6 +1,5 @@
 package com.fmi.domain.post.repository;
 
-import com.fmi.domain.Enum.Type;
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.post.data.Post;
 import org.springframework.data.domain.Pageable;
@@ -12,8 +11,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
@@ -68,12 +65,12 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     Long countByUserAndTemporarySaveFalse(User user);
 
     @Query(value = """
-            SELECT p.*
-            FROM post p
-            WHERE MATCH(p.title, p.content)
+            SELECT *
+            FROM post
+            WHERE MATCH(title, content)
             AGAINST (:keyword IN BOOLEAN MODE)
-              AND p.id < :cursor
-            ORDER BY p.id DESC
+              AND id < :cursor
+            ORDER BY id DESC
             LIMIT :size
             """, nativeQuery = true)
     List<Post> searchByKeywordWithCursor(@Param("keyword") String keyword,
@@ -81,21 +78,21 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
                                          @Param("size") int size);
 
     @Query(value = """
-            SELECT p.*
-            FROM post p
-            WHERE MATCH(p.title, p.content)
+            SELECT *
+            FROM post
+            WHERE MATCH(title, content)
             AGAINST (:keyword IN BOOLEAN MODE)
-            ORDER BY p.id DESC
+            ORDER BY id DESC
             LIMIT :size
             """, nativeQuery = true)
     List<Post> searchByKeyword(@Param("keyword") String keyword,
                                @Param("size") int size);
 
     @Query(value = """
-                SELECT COUNT(*)
-                FROM post p
-                WHERE MATCH(p.title, p.content)
-                AGAINST (:keyword IN BOOLEAN MODE)
+            SELECT COUNT(*)
+            FROM post
+            WHERE MATCH(title, content)
+            AGAINST (:keyword IN BOOLEAN MODE)
             """, nativeQuery = true)
     long countByKeywordFulltext(@Param("keyword") String keyword);
 

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -64,36 +64,4 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     Long countByUserAndTemporarySaveFalse(User user);
 
-    @Query(value = """
-            SELECT *
-            FROM post
-            WHERE MATCH(title, content)
-            AGAINST (:keyword IN BOOLEAN MODE)
-              AND id < :cursor
-            ORDER BY id DESC
-            LIMIT :size
-            """, nativeQuery = true)
-    List<Post> searchByKeywordWithCursor(@Param("keyword") String keyword,
-                                         @Param("cursor") Long cursor,
-                                         @Param("size") int size);
-
-    @Query(value = """
-            SELECT *
-            FROM post
-            WHERE MATCH(title, content)
-            AGAINST (:keyword IN BOOLEAN MODE)
-            ORDER BY id DESC
-            LIMIT :size
-            """, nativeQuery = true)
-    List<Post> searchByKeyword(@Param("keyword") String keyword,
-                               @Param("size") int size);
-
-    @Query(value = """
-            SELECT COUNT(*)
-            FROM post
-            WHERE MATCH(title, content)
-            AGAINST (:keyword IN BOOLEAN MODE)
-            """, nativeQuery = true)
-    long countByKeywordFulltext(@Param("keyword") String keyword);
-
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
@@ -3,11 +3,12 @@ package com.fmi.domain.post.repository;
 
 import com.fmi.domain.Enum.Category;
 import com.fmi.domain.Enum.SortType;
+import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.web.dto.response.PostPageResponse;
 
-import java.time.LocalDate;
+import java.util.List;
 
 public interface PostRepositoryCustom {
     PostPageResponse searchPostsByFiltersAndSort(PostType postType,
@@ -18,4 +19,9 @@ public interface PostRepositoryCustom {
                                                  Long cursor,
                                                  int size,
                                                  Long userId);
+
+
+    List<Post> searchByKeywordWithCursor(String keyword, Long cursor, int size);
+
+    long countByKeyword(String keyword);
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
@@ -24,4 +24,6 @@ public interface PostRepositoryCustom {
     List<Post> searchByKeywordWithCursor(String keyword, Long cursor, int size);
 
     long countByKeyword(String keyword);
+
+    List<Post> findSimilarPosts(Long postId, int limit);
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -242,9 +242,13 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         }
 
         LocalDateTime baseDate = Objects.nonNull(base.getDate()) ? base.getDate() : base.getCreatedAt();
-
         LocalDateTime from = baseDate.minusDays(7);
         LocalDateTime to = baseDate.plusDays(7);
+
+        PostType oppositeType = Objects.equals(base.getPostType(), PostType.LOST)
+                ? PostType.FOUND
+                : PostType.LOST;
+
 
 
         return queryFactory
@@ -253,10 +257,11 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                         post.id.ne(postId),
                         post.temporarySave.isFalse(),
                         post.category.eq(base.getCategory()),
-                        post.postType.eq(base.getPostType()),
+                        post.postType.eq(oppositeType),
                         post.postStatus.eq(PostStatus.SEARCHING),
                         post.address.eq(base.getAddress()),
-                        post.date.between(from, to)
+                        post.date.isNotNull().and(post.date.between(from, to))
+                                .or(post.date.isNull().and(post.createdAt.between(from, to)))
                 )
                 .orderBy(post.createdAt.desc(), post.id.desc())
                 .limit(limit)

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -228,14 +229,42 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         return count == null ? 0L : count;
     }
 
-    private boolean hasText(String value) {
-        return value != null && !value.isBlank();
+    @Override
+    public List<Post> findSimilarPosts(Long postId, int limit) {
+        QPost post = QPost.post;
+
+        Post base = queryFactory.selectFrom(post)
+                .where(post.id.eq(postId))
+                .fetchOne();
+
+        if (Objects.isNull(base)) {
+            return List.of();
+        }
+
+        LocalDateTime baseDate = Objects.nonNull(base.getDate()) ? base.getDate() : base.getCreatedAt();
+
+        LocalDateTime from = baseDate.minusDays(7);
+        LocalDateTime to = baseDate.plusDays(7);
+
+
+        return queryFactory
+                .selectFrom(post)
+                .where(
+                        post.id.ne(postId),
+                        post.temporarySave.isFalse(),
+                        post.category.eq(base.getCategory()),
+                        post.postType.eq(base.getPostType()),
+                        post.postStatus.eq(PostStatus.SEARCHING),
+                        post.address.eq(base.getAddress()),
+                        post.date.between(from, to)
+                )
+                .orderBy(post.createdAt.desc(), post.id.desc())
+                .limit(limit)
+                .fetch();
     }
 
-
-    private BooleanExpression containsIgnoreCase(StringPath path, String keyword) {
-        if (keyword == null || keyword.isBlank()) return null;
-        return path.containsIgnoreCase(keyword);
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     private BooleanExpression addressStartsWith(QPost post, String address) {

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -6,9 +6,11 @@ import com.fmi.domain.post.data.*;
 import com.fmi.domain.post.web.dto.response.PostBriefResponse;
 import com.fmi.domain.post.web.dto.response.PostPageResponse;
 import com.fmi.domain.postfavorite.data.QPostFavorite;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -175,6 +177,65 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .toList();
 
         return new PostPageResponse(postList, postCount, nextCursor, hasNext);
+    }
+
+    @Override
+    public List<Post> searchByKeywordWithCursor(String keyword, Long cursor, int size) {
+        QPost post = QPost.post;
+
+        BooleanBuilder where = new BooleanBuilder();
+
+        if (hasText(keyword)) {
+            where.and(
+                    post.title.containsIgnoreCase(keyword)
+                            .or(post.content.containsIgnoreCase(keyword))
+            );
+        }
+
+        if (Objects.nonNull(cursor)) {
+            where.and(post.id.lt(cursor));
+        }
+
+        return queryFactory
+                .selectFrom(post)
+                .where(where)
+                .orderBy(post.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    @Override
+    public long countByKeyword(String keyword) {
+        QPost post = QPost.post;
+
+        BooleanBuilder where = new BooleanBuilder();
+
+        if (hasText(keyword)) {
+            where.and(
+                    post.title.containsIgnoreCase(keyword)
+                            .or(post.content.containsIgnoreCase(keyword))
+            );
+        } else {
+            return 0L;
+        }
+
+        Long count = queryFactory
+                .select(post.id.count())
+                .from(post)
+                .where(where)
+                .fetchOne();
+
+        return count == null ? 0L : count;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+
+    private BooleanExpression containsIgnoreCase(StringPath path, String keyword) {
+        if (keyword == null || keyword.isBlank()) return null;
+        return path.containsIgnoreCase(keyword);
     }
 
     private BooleanExpression addressStartsWith(QPost post, String address) {

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -167,11 +167,9 @@ public class PostQueryService {
 
         if (keyword.isBlank()) return new PostPageResponse(List.of(), 0L, null, false);
 
-        long postCount = postRepository.countByKeywordFulltext(keyword);
+        long postCount = postRepository.countByKeyword(keyword);
 
-        List<Post> fetched = (cursor == null)
-                ? postRepository.searchByKeyword(keyword, limit)
-                : postRepository.searchByKeywordWithCursor(keyword, cursor, limit);
+        List<Post> fetched = postRepository.searchByKeywordWithCursor(keyword, cursor, limit);
 
         boolean hasNext = fetched.size() > size;
 

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -274,4 +274,37 @@ public class PostQueryService {
 
         return getPostBriefResponseList(posts, user);
     }
+
+    @Transactional(readOnly = true)
+    public List<PostSimilarResponse> getSimilarPostList(Long postId, UserDetails userDetails) {
+        Post post = findById(postId);
+
+        List<Post> postList = postRepository.findSimilarPosts(postId, 5);
+
+        Map<Long, String> thumbnailUrlByPostList = postImageService.findThumbnailUrlByPostList(postList);
+        Map<Long, Long> favoriteCountMap = postFavoriteService.getFavoriteCountMap(postList);
+
+        Map<Long, Boolean> isFavoriteByPostId;
+        if (userDetails != null) {
+            User user = userQueryService.findUser(userDetails.getUsername());
+            isFavoriteByPostId = postFavoriteService.getIsFavoriteMap(user, postList);
+        } else {
+            isFavoriteByPostId = postList.stream()
+                    .collect(java.util.stream.Collectors.toMap(Post::getId, p -> false));
+        }
+
+        return postList.stream()
+                .map(p -> new PostSimilarResponse(
+                                p.getId(),
+                                p.getTitle(),
+                                thumbnailUrlByPostList.getOrDefault(p.getId(), null),
+                                p.getAddress(),
+                                favoriteCountMap.getOrDefault(p.getId(), 0L),
+                                isFavoriteByPostId.getOrDefault(p.getId(), false),
+                                p.getViewCount(),
+                                p.getCreatedAt()
+                        )
+                )
+                .toList();
+    }
 }

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -15,6 +15,7 @@ import com.fmi.utils.IpUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -94,15 +95,15 @@ public class PostController {
     @Operation(
             summary = "게시글 키워드 검색 (무한스크롤)",
             description = """
-                키워드로 게시글을 검색합니다. (title/content 기준)
-
-                - 무한스크롤: 첫 요청은 cursor 없이 호출하고, 이후 응답의 nextCursor를 cursor로 넣어 다음 페이지를 요청합니다.
-                - size: 한 번에 가져올 개수 (기본 20)
-
-                예)
-                - 첫 요청: /posts/search/keyword?keyword=지갑&size=20
-                - 다음 요청: /posts/search/keyword?keyword=지갑&cursor=98&size=20
-                """
+                    키워드로 게시글을 검색합니다. (title/content 기준)
+                    
+                    - 무한스크롤: 첫 요청은 cursor 없이 호출하고, 이후 응답의 nextCursor를 cursor로 넣어 다음 페이지를 요청합니다.
+                    - size: 한 번에 가져올 개수 (기본 20)
+                    
+                    예)
+                    - 첫 요청: /posts/search/keyword?keyword=지갑&size=20
+                    - 다음 요청: /posts/search/keyword?keyword=지갑&cursor=98&size=20
+                    """
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -112,36 +113,36 @@ public class PostController {
                             mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
-                                        {
-                                          "isSuccess": true,
-                                          "code": "COMMON200",
-                                          "message": "성공",
-                                          "result": {
-                                            "postList": [
-                                              {
-                                                "id": 101,
-                                                "title": "지갑 분실했어요",
-                                                "summary": "어제 강남역 근처에서...",
-                                                "thumbnailUrl": "https://example.com/thumb.png",
-                                                "address": "서울 강남구",
-                                                "postStatus": "SEARCHING",
-                                                "postType": "LOST",
-                                                "category": "WALLET",
-                                                "favoriteCount": 3,
-                                                "isFavorite": false,
-                                                "viewCount": 12,
-                                                "isNew": true,
-                                                "isHot": false,
-                                                "createdAt": "2024-01-01T00:00:00",
-                                                "imageCount": 1
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "성공",
+                                              "result": {
+                                                "postList": [
+                                                  {
+                                                    "id": 101,
+                                                    "title": "지갑 분실했어요",
+                                                    "summary": "어제 강남역 근처에서...",
+                                                    "thumbnailUrl": "https://example.com/thumb.png",
+                                                    "address": "서울 강남구",
+                                                    "postStatus": "SEARCHING",
+                                                    "postType": "LOST",
+                                                    "category": "WALLET",
+                                                    "favoriteCount": 3,
+                                                    "isFavorite": false,
+                                                    "viewCount": 12,
+                                                    "isNew": true,
+                                                    "isHot": false,
+                                                    "createdAt": "2024-01-01T00:00:00",
+                                                    "imageCount": 1
+                                                  }
+                                                ],
+                                                "postCount": 42,
+                                                "nextCursor": 101,
+                                                "hasNext": true
                                               }
-                                            ],
-                                            "postCount": 42,
-                                            "nextCursor": 101,
-                                            "hasNext": true
-                                          }
-                                        }
-                                        """
+                                            }
+                                            """
                             )
                     )
             ),
@@ -149,9 +150,9 @@ public class PostController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     })
     public ResponseEntity<ApiResponse<PostPageResponse>> searchByKeyword(@RequestParam String keyword,
-                                                                          @AuthenticationPrincipal UserDetails userDetails,
-                                                                          @RequestParam(required = false) Long cursor,
-                                                                          @RequestParam(required = false, defaultValue = "20") int size) {
+                                                                         @AuthenticationPrincipal UserDetails userDetails,
+                                                                         @RequestParam(required = false) Long cursor,
+                                                                         @RequestParam(required = false, defaultValue = "20") int size) {
 
         PostPageResponse postPageResponse = postQueryService.searchByKeyword(keyword, cursor, size, userDetails);
 
@@ -243,6 +244,72 @@ public class PostController {
 
         postService.updateRadius(postId, request, userDetails);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{postId}/similar")
+    @Operation(
+            summary = "비슷한 분실물/습득물 추천 목록 조회",
+            description = """
+                    상세 조회 페이지 하단에 노출할 “비슷한 분실물/습득물” 추천 리스트를 조회합니다.
+                    
+                    기준
+                    - 같은 카테고리 + 같은 지역(주소)
+                    - 같은 Post type (분실/습득)
+                    - 기준 게시글 날짜(createdAt) 기준 -7일 ~ +7일 범위
+                    - 최신순(createdAt DESC) 최대 5개
+                    - 로그인 시 favoriteStatus(내 즐겨찾기 여부) 포함
+                    
+                    예)
+                    - /posts/10/similar
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "성공",
+                                              "result": [
+                                                {
+                                                  "postId": 25,
+                                                  "title": "지갑 습득했습니다",
+                                                  "thumbnailImageUrl": "https://example.com/thumb.jpg",
+                                                  "address": "서울 강남구",
+                                                  "favoriteCount": 12,
+                                                  "favoriteStatus": true,
+                                                  "viewCount": 104,
+                                                  "createdAt": "2026-02-15T10:30:00"
+                                                },
+                                                {
+                                                  "postId": 24,
+                                                  "title": "카드 주웠어요",
+                                                  "thumbnailImageUrl": null,
+                                                  "address": "서울 강남구",
+                                                  "favoriteCount": 2,
+                                                  "favoriteStatus": false,
+                                                  "viewCount": 33,
+                                                  "createdAt": "2026-02-14T18:10:00"
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터", content = @Content)
+    })
+    public ResponseEntity<ApiResponse<List<PostSimilarResponse>>> getSimilarList(@PathVariable Long postId,
+                                                                                 @AuthenticationPrincipal UserDetails userDetails) {
+        List<PostSimilarResponse> response = postQueryService.getSimilarPostList(postId, userDetails);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     //

--- a/src/main/java/com/fmi/domain/post/web/dto/response/PostSimilarResponse.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/response/PostSimilarResponse.java
@@ -1,0 +1,15 @@
+package com.fmi.domain.post.web.dto.response;
+
+import java.time.LocalDateTime;
+
+public record PostSimilarResponse(
+        Long postId,
+        String title,
+        String thumbnailImageUrl,
+        String address,
+        Long favoriteCount,
+        boolean favoriteStatus,
+        Long viewCount,
+        LocalDateTime createdAt
+) {
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close #208 
- close #210 

## 🛠️ 작업 내용

- POST API 에서 비회원도 이용할수 있는 API Spring Security 에 등록
- 검색 API
- 공유하기 API
- full text index 사용하는 쿼리 alias 제거
- 비슷한 게시글 추천 리스트 5개 API
- 게시글 keyword 검색 API - LIKE 기반 검색으로 수정


## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
