### PR TITLE
feat: 소셜 회원가입 시 랜덤 닉네임 자동 부여

### DIFF
--- a/src/main/java/com/fmi/domain/auth/service/NicknameGeneratorService.java
+++ b/src/main/java/com/fmi/domain/auth/service/NicknameGeneratorService.java
@@ -16,17 +16,11 @@ public class NicknameGeneratorService {
     private final SecureRandom random = new SecureRandom();
 
     private static final List<String> ADJECTIVES = Arrays.asList(
-            "귀여운", "멋진", "빠른", "느긋한", "용감한",
-            "똑똑한", "친절한", "활발한", "조용한", "밝은",
-            "차분한", "씩씩한", "당당한", "신나는", "상냥한",
-            "재빠른", "튼튼한", "영리한", "즐거운", "행복한"
+            "길찾는", "지도보는", "탐색하는", "이동중인", "확인중인", "대기중인"
     );
 
     private static final List<String> ANIMALS = Arrays.asList(
-            "고양이", "강아지", "토끼", "여우", "사슴",
-            "판다", "코알라", "햄스터", "다람쥐", "펭귄",
-            "돌고래", "고래", "거북이", "수달", "미어캣",
-            "알파카", "라쿤", "늑대", "호랑이", "사자"
+            "토끼", "판다", "오리", "펭귄", "사슴", "라쿤", "곰"
     );
 
     public String generateRandomNickname() {

--- a/src/main/java/com/fmi/domain/auth/service/NicknameGeneratorService.java
+++ b/src/main/java/com/fmi/domain/auth/service/NicknameGeneratorService.java
@@ -1,0 +1,86 @@
+package com.fmi.domain.auth.service;
+
+import com.fmi.domain.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NicknameGeneratorService {
+
+    private final UserRepository userRepository;
+    private final SecureRandom random = new SecureRandom();
+
+    private static final List<String> ADJECTIVES = Arrays.asList(
+            "귀여운", "멋진", "빠른", "느긋한", "용감한",
+            "똑똑한", "친절한", "활발한", "조용한", "밝은",
+            "차분한", "씩씩한", "당당한", "신나는", "상냥한",
+            "재빠른", "튼튼한", "영리한", "즐거운", "행복한"
+    );
+
+    private static final List<String> ANIMALS = Arrays.asList(
+            "고양이", "강아지", "토끼", "여우", "사슴",
+            "판다", "코알라", "햄스터", "다람쥐", "펭귄",
+            "돌고래", "고래", "거북이", "수달", "미어캣",
+            "알파카", "라쿤", "늑대", "호랑이", "사자"
+    );
+
+    public String generateRandomNickname() {
+        String nickname;
+        int attempts = 0;
+        int maxAttempts = 50;
+
+        do {
+            nickname = generateNickname();
+            attempts++;
+
+            if (attempts >= maxAttempts) {
+                nickname = generateFallbackNickname();
+                break;
+            }
+        } while (userRepository.existsByNickname(nickname));
+
+        return nickname;
+    }
+
+    private String generateNickname() {
+        String adjective = ADJECTIVES.get(random.nextInt(ADJECTIVES.size()));
+        String animal = ANIMALS.get(random.nextInt(ANIMALS.size()));
+        int number = random.nextInt(999) + 1; // 1~999
+        return adjective + animal + number;
+    }
+
+    private String generateFallbackNickname() {
+        String base = "찾아줘";
+        String randomCode;
+        int attempts = 0;
+        int maxAttempts = 100;
+
+        do {
+            randomCode = generateRandomCode(6);
+            attempts++;
+
+            if (attempts >= maxAttempts) {
+                randomCode = generateRandomCode(8) + System.currentTimeMillis() % 1000;
+                break;
+            }
+        } while (userRepository.existsByNickname(base + "_" + randomCode));
+
+        return base + "_" + randomCode;
+    }
+
+    private String generateRandomCode(int length) {
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        StringBuilder code = new StringBuilder();
+
+        for (int i = 0; i < length; i++) {
+            code.append(chars.charAt(random.nextInt(chars.length())));
+        }
+
+        return code.toString();
+    }
+}

--- a/src/main/java/com/fmi/domain/auth/service/SocialLoginService.java
+++ b/src/main/java/com/fmi/domain/auth/service/SocialLoginService.java
@@ -26,6 +26,7 @@ public class SocialLoginService {
     private final SocialAccountsRepository socialAccountsRepository;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final NicknameGeneratorService nicknameGeneratorService;
 
     public User upsertUserFromKakao(Long kakaoId, String email, String nickname, String profileImageUrl) {
         String providerId = String.valueOf(kakaoId);
@@ -48,10 +49,18 @@ public class SocialLoginService {
         User user = userRepository.findByEmail(effectiveEmail)
                 .orElseGet(() -> {
                     log.info("새 사용자 생성: email={}", effectiveEmail);
+
+                    // 닉네임이 없으면 랜덤 닉네임 생성
+                    String effectiveNickname = (nickname != null && !nickname.isBlank())
+                            ? nickname
+                            : nicknameGeneratorService.generateRandomNickname();
+
+                    log.info("소셜 로그인 닉네임: 원본={}, 사용={}", nickname, effectiveNickname);
+
                     User u = AuthConverter.toSocialUserEntity(
                             kakaoId,
                             email,
-                            nickname,
+                            effectiveNickname,
                             profileImageUrl,
                             passwordEncoder.encode("{noop}-" + providerId)
                     );


### PR DESCRIPTION
## 🧩 관련 이슈

- close feat/#204

## 🛠️ 작업 내용

- 소셜 회원가입 시 랜덤 닉네임 자동 부여
- 형용사 + 동물 + 숫자 조합

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
