### PR TITLE
feat: 임시저장 api, 게시글 생성 api, 비슷한 분실물 api, 게시글 상태 변경 api 

### DIFF
--- a/src/main/java/com/fmi/domain/post/converter/util/PostConverter.java
+++ b/src/main/java/com/fmi/domain/post/converter/util/PostConverter.java
@@ -4,6 +4,7 @@ import com.fmi.domain.auth.data.User;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.web.dto.request.PostCreateRequest;
 import com.fmi.domain.post.web.dto.response.*;
+import com.fmi.domain.post.web.dto.response.image.PostImageResponse;
 import com.fmi.domain.user.web.dto.response.UserPostResponse;
 
 import java.util.List;
@@ -19,7 +20,7 @@ public final class PostConverter {
                 request.postType(),
                 request.category(),
                 request.content(),
-                request.temporarySave(),
+                false,
                 request.date(),
                 request.radius(),
                 user);

--- a/src/main/java/com/fmi/domain/post/converter/util/PostImageConverter.java
+++ b/src/main/java/com/fmi/domain/post/converter/util/PostImageConverter.java
@@ -3,7 +3,7 @@ package com.fmi.domain.post.converter.util;
 import com.fmi.domain.post.data.ImageType;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostImage;
-import com.fmi.domain.post.web.dto.response.PostImageResponse;
+import com.fmi.domain.post.web.dto.response.image.PostImageResponse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +13,7 @@ import java.util.stream.IntStream;
 public final class PostImageConverter {
     public static List<PostImage> createPostImageList(List<String> images, Post post) {
         if (Objects.isNull(images) || images.isEmpty()) {
-            return new ArrayList<>();
+            return List.of();
         }
 
         return IntStream.range(0, images.size())
@@ -35,6 +35,16 @@ public final class PostImageConverter {
 
     public static PostImageResponse toResponse(PostImage postImage) {
         return new PostImageResponse(postImage.getId(), postImage.getImgUrl(), postImage.getImageType());
+    }
+
+    public static List<PostImage> createAllNormal(List<String> images, Post post) {
+        if (Objects.isNull(images) || images.isEmpty()) {
+            return List.of();
+        }
+
+        return images.stream()
+                .map(url -> PostImage.create(url, ImageType.NORMAL, post))
+                .toList();
     }
 
     private PostImageConverter() {

--- a/src/main/java/com/fmi/domain/post/data/Post.java
+++ b/src/main/java/com/fmi/domain/post/data/Post.java
@@ -27,10 +27,10 @@ public class Post {
     private String address;
 
     @Column(name = "latitude")
-    private double latitude;
+    private Double latitude;
 
     @Column(name = "longitude")
-    private double longitude;
+    private Double longitude;
 
     @Column(name = "view_cnt")
     private long viewCount;
@@ -89,6 +89,46 @@ public class Post {
         return new Post(title, address, latitude, longitude, postType, category, content, temporarySave, date, radius, user);
     }
 
+    public static Post createTemporary(User user) {
+        Post post = new Post();
+        post.user = user;
+        post.temporarySave = true;
+        post.title = "";
+        post.address = "";
+        post.content = "";
+        post.postStatus = PostStatus.SEARCHING;
+        post.createdAt = LocalDateTime.now();
+        post.viewCount = 0;
+
+        return post;
+    }
+
+    public void updateTemporary(PostType postType,
+                                Category category,
+                                Radius radius,
+                                LocalDateTime date,
+                                String title,
+                                String address,
+                                String content,
+                                Double latitude,
+                                Double longitude) {
+
+        applyIfNotNull(postType, this::setPostType);
+        applyIfNotNull(category, this::setCategory);
+        applyIfNotNull(radius, this::setRadius);
+        applyIfNotNull(date, this::setDate);
+
+        applyIfNotBlank(title, this::setTitle);
+        applyIfNotBlank(address, this::setAddress);
+        applyIfNotBlank(content, this::setContent);
+
+        applyIfNotNull(latitude, this::setLatitude);
+        applyIfNotNull(longitude, this::setLongitude);
+
+        this.temporarySave = true;
+        this.updatedAt = LocalDateTime.now();
+    }
+
     public boolean isNew() {
         return this.createdAt.isAfter(LocalDateTime.now().minusHours(24));
     }
@@ -98,7 +138,7 @@ public class Post {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void updatePostStatus(PostStatus postStatus){
+    public void updatePostStatus(PostStatus postStatus) {
         applyIfNotNull(postStatus, this::setPostStatus);
         this.updatedAt = LocalDateTime.now();
     }
@@ -139,5 +179,9 @@ public class Post {
 
     private <T> void applyIfNotNull(T value, Consumer<T> setter) {
         if (Objects.nonNull(value)) setter.accept(value);
+    }
+
+    private void applyIfNotBlank(String value, Consumer<String> setter) {
+        if (Objects.nonNull(value) && !value.isBlank()) setter.accept(value);
     }
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostImageRepository.java
@@ -33,4 +33,23 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long>, Pos
 
     List<PostImage> findByPostIdInAndImageType(List<Long> postIds, ImageType imageType);
 
+    @Query("""
+                select pi
+                from PostImage pi
+                where pi.post.id = :postId
+                and pi.id not in :keepIds
+            """)
+    List<PostImage> findImagesToDelete(@Param("postId") Long postId,
+                                       @Param("keepIds") List<Long> keepIds);
+
+    void deleteAllByPost_Id(Long postId);
+
+    List<PostImage> findByPost_Id(Long postId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update PostImage pi set pi.imageType = 'NORMAL' where pi.post.id = :postId and pi.imageType = 'THUMBNAIL'")
+    void resetThumbnailToNormal(@Param("postId") Long postId);
+
+    Optional<PostImage> findByIdAndPost_Id(Long id, Long postId);
+
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
@@ -63,5 +64,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 //    List<Post> findHotPost(Pageable pageable);
 
     Long countByUserAndTemporarySaveFalse(User user);
+
+    Optional<Post> findByUserAndTemporarySaveTrue(User user);
 
 }

--- a/src/main/java/com/fmi/domain/post/service/PostImageService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostImageService.java
@@ -15,12 +15,60 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class PostImageService {
     private final S3Service s3Service;
     private final PostImageRepository postImageRepository;
 
-    @Transactional
+    public void applyThumbNail(List<MultipartFile> imageList, Post post, Long thumbnailId, List<Long> keepImageIdList) {
+        postImageRepository.resetThumbnailToNormal(post.getId());
+
+        PostImage thumb = null;
+
+        if (Objects.nonNull(thumbnailId)) {
+            thumb = postImageRepository.findByIdAndPost_Id(thumbnailId, post.getId()).orElse(null);
+
+            if (Objects.nonNull(thumb) && Objects.nonNull(keepImageIdList) && !keepImageIdList.isEmpty() && !keepImageIdList.contains(thumbnailId)) {
+                thumb = null;
+            }
+
+        }
+
+        List<PostImage> newlySaved = createPostImageNormalAtS3AndDB(imageList, post);
+
+        if (Objects.nonNull(thumb)) {
+            thumb.setImageType(ImageType.THUMBNAIL);
+            return;
+        }
+
+        if (!newlySaved.isEmpty()) {
+            newlySaved.get(0).setImageType(ImageType.THUMBNAIL);
+            return;
+        }
+
+        postImageRepository.flush();
+
+        List<PostImage> remain = postImageRepository.findByPost(post);
+
+        if (Objects.nonNull(keepImageIdList) && !keepImageIdList.isEmpty()) {
+            Map<Long, PostImage> remainMap = remain.stream()
+                    .collect(Collectors.toMap(PostImage::getId, i -> i, (a, b) -> a));
+
+            for (Long keepId : keepImageIdList) {
+                PostImage kept = remainMap.get(keepId);
+                if (kept != null) {
+                    kept.setImageType(ImageType.THUMBNAIL);
+                    return;
+                }
+            }
+        }
+
+        if (!remain.isEmpty()) {
+            remain.get(0).setImageType(ImageType.THUMBNAIL);
+        }
+    }
+
     public void createPostImageAtS3AndDB(List<MultipartFile> imageList, Post post) {
         List<PostImage> postImageList = new ArrayList<>();
         if (Objects.nonNull(imageList)) {
@@ -30,7 +78,15 @@ public class PostImageService {
         postImageRepository.saveAll(postImageList);
     }
 
-    @Transactional
+    public List<PostImage> createPostImageNormalAtS3AndDB(List<MultipartFile> imageList, Post post) {
+        List<PostImage> postImageList = new ArrayList<>();
+        if (Objects.nonNull(imageList)) {
+            postImageList = PostImageConverter.createAllNormal(s3Service.upload(imageList), post);
+        }
+
+        return postImageRepository.saveAll(postImageList);
+    }
+
     public void deleteAllImageByPost(Post post) {
         List<PostImage> postImageList = postImageRepository.findByPost(post);
 
@@ -41,13 +97,11 @@ public class PostImageService {
         postImageRepository.deleteAllByPost(post);
     }
 
-    @Transactional
     public void deleteImageAtS3(List<PostImage> imageList) {
         List<String> imageUrlList = imageList.stream().map(PostImage::getImgUrl).toList();
         s3Service.delete(imageUrlList);
     }
 
-    @Transactional
     public void deleteImageAtDB(List<PostImage> imageList) {
         imageList.forEach(postImageRepository::delete);
     }
@@ -114,5 +168,46 @@ public class PostImageService {
                         PostImage::getImgUrl
                 ));
     }
+
+    public void deleteImagesNotIn(Long postId, List<Long> keepImageIdList) {
+
+        if (Objects.isNull(keepImageIdList) || keepImageIdList.isEmpty()) {
+            deleteAllImages(postId);
+            return;
+        }
+
+        List<PostImage> imagesToDelete =
+                postImageRepository.findImagesToDelete(postId, keepImageIdList);
+
+        if (imagesToDelete.isEmpty()) {
+            return;
+        }
+
+        deleteFromS3(imagesToDelete);
+        deleteFromDatabase(imagesToDelete);
+    }
+
+    public void deleteAllImages(Long postId) {
+        List<PostImage> images =
+                postImageRepository.findByPost_Id(postId);
+
+        if (images.isEmpty()) return;
+
+        deleteFromS3(images);
+        postImageRepository.deleteAllByPost_Id(postId);
+    }
+
+    private void deleteFromS3(List<PostImage> images) {
+        List<String> urls = images.stream()
+                .map(PostImage::getImgUrl)
+                .toList();
+
+        s3Service.delete(urls);
+    }
+
+    private void deleteFromDatabase(List<PostImage> images) {
+        postImageRepository.deleteAll(images);
+    }
+
 
 }

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -13,6 +13,7 @@ import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.repository.PostImageRepository;
 import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.post.web.dto.response.*;
+import com.fmi.domain.post.web.dto.response.image.PostImageResponse;
 import com.fmi.domain.postfavorite.data.PostFavorite;
 import com.fmi.domain.postfavorite.repository.PostFavoriteRepository;
 import com.fmi.domain.postfavorite.service.PostFavoriteService;
@@ -35,7 +36,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -290,7 +290,8 @@ public class PostQueryService {
                                 favoriteCountMap.getOrDefault(p.getId(), 0L),
                                 isFavoriteByPostId.getOrDefault(p.getId(), false),
                                 p.getViewCount(),
-                                p.getCreatedAt()
+                                p.getCreatedAt(),
+                                p.getCategory()
                         )
                 )
                 .toList();

--- a/src/main/java/com/fmi/domain/post/service/PostService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostService.java
@@ -10,6 +10,7 @@ import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.post.web.dto.request.PostCreateRequest;
 import com.fmi.domain.post.web.dto.request.PostRadiusUpdateRequest;
+import com.fmi.domain.post.web.dto.request.PostStatusUpdateRequest;
 import com.fmi.domain.post.web.dto.request.PostUpdateRequest;
 import com.fmi.domain.post.web.dto.response.PostCreateResponse;
 import com.fmi.domain.post.web.dto.response.PostUpdateResponse;
@@ -43,15 +44,44 @@ public class PostService {
     public PostCreateResponse createPost(PostCreateRequest request, UserDetails userDetails, List<MultipartFile> images) {
         User user = userQueryService.findUser(userDetails.getUsername());
 
-        Post post = PostConverter.toEntity(request, user);
+        boolean fromTemp = Objects.nonNull(request.tempPostId());
+
+        Post post;
+        if (fromTemp) {
+            post = postRepository.findById(request.tempPostId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._TEMP_POST_NOT_FOUND));
+
+            checkPostAccessDenied(post, userDetails.getUsername());
+
+            if (!post.isTemporarySave()) {
+                throw new GeneralException(ErrorStatus._TEMP_POST_NOT_FOUND);
+            }
+
+            post.update(
+                    request.postType(),
+                    request.title(),
+                    PostStatus.SEARCHING,
+                    request.date(),
+                    request.address(),
+                    request.latitude(),
+                    request.longitude(),
+                    request.content(),
+                    false,
+                    request.radius(),
+                    request.category()
+            );
+
+            postImageService.deleteImagesNotIn(post.getId(), request.keepImageIdList());
+        } else {
+            post = PostConverter.toEntity(request, user);
+        }
+
         post = postRepository.save(post);
 
-        postImageService.createPostImageAtS3AndDB(images, post);
+        postImageService.applyThumbNail(images, post, request.thumbnailImageId(), request.keepImageIdList());
 
-        // 임시 저장이 아닌 경우에만 카테고리 알림 트리거
-        if (!post.isTemporarySave()) {
-            notificationService.notifyCategoriesForPost(post);
-        }
+        notificationService.notifyCategoriesForPost(post);
+
         return PostConverter.toCreateResponse(post);
     }
 
@@ -159,19 +189,17 @@ public class PostService {
     }
 
     @Transactional
-    public void markToFound(Long postId, UserDetails userDetails) {
+    public void updatePostStatus(Long postId, PostStatusUpdateRequest request, UserDetails userDetails) {
         User user = userQueryService.findUser(userDetails.getUsername());
         Post post = postQueryService.findById(postId);
 
         checkPostAccessDenied(post, user.getEmail());
 
-        if (post.getPostStatus() == PostStatus.FOUND) {
-            return;
+        if (Objects.equals(request.postStatus(), PostStatus.FOUND)) {
+            notifyFavoriteUsers(post, PostStatus.FOUND);
         }
 
-        notifyFavoriteUsers(post, PostStatus.FOUND);
-
-        post.updatePostStatus(PostStatus.FOUND);
+        post.updatePostStatus(request.postStatus());
     }
 
 //    @Transactional

--- a/src/main/java/com/fmi/domain/post/service/TemporaryPostService.java
+++ b/src/main/java/com/fmi/domain/post/service/TemporaryPostService.java
@@ -1,0 +1,107 @@
+package com.fmi.domain.post.service;
+
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.post.data.Post;
+import com.fmi.domain.post.data.PostImage;
+import com.fmi.domain.post.repository.PostRepository;
+import com.fmi.domain.post.web.dto.request.TemporaryPostCreateRequest;
+import com.fmi.domain.post.web.dto.response.image.PostImageResponse;
+import com.fmi.domain.post.web.dto.response.temp.TemporaryPostResponse;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
+import com.fmi.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class TemporaryPostService {
+    private final PostRepository postRepository;
+    private final UserQueryService userQueryService;
+    private final PostImageService postImageService;
+
+    @Transactional
+    public void create(TemporaryPostCreateRequest request, UserDetails userDetails, List<MultipartFile> newImageList) {
+        User user = userQueryService.findUser(userDetails.getUsername());
+
+        Post post = postRepository.findByUserAndTemporarySaveTrue(user)
+                .orElseGet(() -> Post.createTemporary(user));
+
+        post.updateTemporary(request.postType(),
+                request.category(),
+                request.radius(),
+                request.date(),
+                request.title(),
+                request.address(),
+                request.content(),
+                request.latitude(),
+                request.longitude());
+
+        boolean isNewTemp = Objects.isNull(post.getId());
+
+        Post savePost = postRepository.save(post);
+
+        if (!isNewTemp) {
+            postImageService.deleteImagesNotIn(savePost.getId(), request.keepImageIdList());
+        }
+
+
+        if (Objects.nonNull(newImageList) && !newImageList.isEmpty()) {
+            postImageService.createPostImageNormalAtS3AndDB(newImageList, savePost);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public TemporaryPostResponse getMyTemporaryPost(UserDetails userDetails) {
+        User user = userQueryService.findUser(userDetails.getUsername());
+        Post post = postRepository.findByUserAndTemporarySaveTrue(user).orElse(null);
+
+        if (Objects.isNull(post)) {
+            return null;
+        }
+
+        List<PostImage> imageList = postImageService.findAllByPost(post);
+
+        List<PostImageResponse> images = imageList.stream()
+                .map(image -> new PostImageResponse(
+                        image.getId(),
+                        image.getImgUrl(),
+                        image.getImageType()
+                ))
+                .toList();
+
+        return new TemporaryPostResponse(
+                post.getId(),
+                post.getPostType(),
+                post.getCategory(),
+                post.getRadius(),
+                post.getDate(),
+                post.getTitle(),
+                post.getAddress(),
+                post.getLatitude(),
+                post.getLongitude(),
+                post.getContent(),
+                images,
+                post.getUpdatedAt(),
+                post.getCreatedAt()
+        );
+    }
+
+    @Transactional
+    public void deleteTemporaryPost(UserDetails userDetails) {
+        User user = userQueryService.findUser(userDetails.getUsername());
+        Post post = postRepository.findByUserAndTemporarySaveTrue(user)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._TEMP_POST_NOT_FOUND));
+
+        postImageService.deleteAllImageByPost(post);
+        postRepository.delete(post);
+    }
+
+
+}

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -6,16 +6,15 @@ import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.service.PostQueryService;
 import com.fmi.domain.post.service.PostService;
-import com.fmi.domain.post.web.dto.request.PostCreateRequest;
-import com.fmi.domain.post.web.dto.request.PostRadiusUpdateRequest;
-import com.fmi.domain.post.web.dto.request.PostUpdateRequest;
+import com.fmi.domain.post.service.TemporaryPostService;
+import com.fmi.domain.post.web.dto.request.*;
 import com.fmi.domain.post.web.dto.response.*;
+import com.fmi.domain.post.web.dto.response.temp.TemporaryPostResponse;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.utils.IpUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -41,6 +40,7 @@ public class PostController {
 
     private final PostService postService;
     private final PostQueryService postQueryService;
+    private final TemporaryPostService temporaryPostService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "게시글 생성")
@@ -284,7 +284,8 @@ public class PostController {
                                                   "favoriteCount": 12,
                                                   "favoriteStatus": true,
                                                   "viewCount": 104,
-                                                  "createdAt": "2026-02-15T10:30:00"
+                                                  "createdAt": "2026-02-15T10:30:00",
+                                                  "category":"ELECTRONICS"
                                                 },
                                                 {
                                                   "postId": 24,
@@ -294,7 +295,8 @@ public class PostController {
                                                   "favoriteCount": 2,
                                                   "favoriteStatus": false,
                                                   "viewCount": 33,
-                                                  "createdAt": "2026-02-14T18:10:00"
+                                                  "createdAt": "2026-02-14T18:10:00",
+                                                  "category":"ELECTRONICS"
                                                 }
                                               ]
                                             }
@@ -312,50 +314,167 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    //
-//    @PostMapping("/draft")
-//    @Operation(summary = "게시글 임시 저장")
-//    @ApiResponses({
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 임시 저장 성공"),
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "FILE400-EXT_MISSING: 확장자가 존재하지 않습니다"),
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "415", description = "FILE415-EXT_UNSUPPORTED: 허용되지 않는 확장자입니다"),
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "FILE500-UPLOAD_IO: 업로드 중 오류가 발생했습니다")
-//    })
-//    public ResponseEntity<ApiResponse<Void>> saveTemporaryPost(
-//
-//            @RequestPart("request") TemporaryPostDto request,
-//            @AuthenticationPrincipal UserDetails userDetails,
-//            @RequestPart(value = "images", required = false) List<MultipartFile> images
-//    ) {
-//        postService.saveTemporaryPost(request, userDetails, images);
-//        return ResponseEntity.ok(ApiResponse.onSuccess(null));
-//    }
-//
-//    @GetMapping("/draft")
-//    @Operation(summary = "임시 저장 조회")
-//    @ApiResponses({
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "임시 저장 조회 성공")
-//    })
-//    public ResponseEntity<ApiResponse<PostResponse>> getTemporaryPost(
-//            @AuthenticationPrincipal UserDetails userDetails
-//    ) {
-//        PostResponse post = postService.getTemporaryPost(userDetails);
-//        return ResponseEntity.ok(ApiResponse.onSuccess(post));
-//    }
-//
-//    @DeleteMapping("/draft")
-//    @Operation(summary = "임시 저장 삭제")
-//    @ApiResponses({
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "임시 저장 삭제 성공")
-//    })
-//    public ResponseEntity<ApiResponse<String>> deleteTemporaryPost(
-//            @AuthenticationPrincipal UserDetails userDetails
-//    ) {
-//        postService.deleteTemporaryPost(userDetails);
-//
-//        return ResponseEntity.ok(ApiResponse.onSuccess("임시 게시글 삭제 완료"));
-//    }
-//
+    @PostMapping(value = "/temp", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "임시 저장 게시글 생성/수정",
+            description = """
+                    임시 저장 게시글을 생성하거나(없으면 생성) 기존 임시 저장 게시글을 업데이트합니다.
+                    
+                    - 회원당 임시 저장 게시글은 1개만 존재합니다.
+                    - request 파트(JSON)로 임시 저장 데이터를 전달합니다. (필드는 모두 nullable)
+                    - images 파트(파일)는 선택이며, 신규 업로드 이미지입니다.
+                    - keepImageIdList: 기존 임시 저장에 이미 저장되어 있던 이미지 중 '유지할 이미지 ID' 목록입니다.
+                      - 기존 임시 저장이 있는 경우에만 적용됩니다.
+                      - keepImageIdList에 포함되지 않은 기존 이미지는 S3/DB에서 삭제됩니다.
+                    
+                    요청 예)
+                    - 신규 임시저장 생성: request만 전송 또는 request + images 전송
+                    - 임시저장 수정(기존 이미지 유지 + 새 이미지 추가):
+                      - request.keepImageIdList=[1,2]
+                      - images에 신규 파일 추가
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "임시 저장 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "COMMON200",
+                                      "message": "성공",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (multipart 형식 오류/파라미터 오류)", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    public ResponseEntity<ApiResponse<Void>> saveTemporaryPost(@RequestPart("request") TemporaryPostCreateRequest request,
+                                                               @AuthenticationPrincipal UserDetails userDetails,
+                                                               @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+        temporaryPostService.create(request, userDetails, images);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+
+    @GetMapping("/temp")
+    @Operation(
+            summary = "내 임시 저장 게시글 조회",
+            description = """
+                    로그인한 사용자의 임시 저장 게시글(temporarySave=true)을 조회합니다.
+                    
+                    - 임시 저장 게시글이 없으면 result는 null로 반환됩니다.
+                    - images에는 임시 저장 게시글에 연결된 이미지 목록이 포함됩니다. (id/imgUrl/imageType)
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "임시 저장 존재",
+                                            value = """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "code": "COMMON200",
+                                                      "message": "성공",
+                                                      "result": {
+                                                        "postId": 24,
+                                                        "postType": "LOST",
+                                                        "category": "WALLET",
+                                                        "radius": "RADIUS_1000",
+                                                        "date": "2026-02-20T10:30:00",
+                                                        "title": "지갑을 잃어버렸어요",
+                                                        "address": "서울 강남구",
+                                                        "latitude": 37.4979,
+                                                        "longitude": 127.0276,
+                                                        "content": "강남역 근처에서 검정 지갑 분실했습니다.",
+                                                        "images": [
+                                                          {
+                                                            "id": 12,
+                                                            "imgUrl": "https://example.com/image1.png",
+                                                            "imageType": "THUMBNAIL"
+                                                          },
+                                                          {
+                                                            "id": 13,
+                                                            "imgUrl": "https://example.com/image2.png",
+                                                            "imageType": "NORMAL"
+                                                          }
+                                                        ],
+                                                        "updatedAt": "2026-02-20T12:00:00",
+                                                        "createdAt": "2026-02-20T10:00:00"
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "임시 저장 없음",
+                                            value = """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "code": "COMMON200",
+                                                      "message": "성공",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    })
+    public ResponseEntity<ApiResponse<TemporaryPostResponse>> getTemporaryPost(@AuthenticationPrincipal UserDetails userDetails) {
+        TemporaryPostResponse response = temporaryPostService.getMyTemporaryPost(userDetails);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @DeleteMapping("/temp")
+    @Operation(
+            summary = "내 임시 저장 게시글 삭제",
+            description = """
+                    로그인한 사용자의 임시 저장 게시글(temporarySave=true)을 삭제합니다.
+                    
+                    - 임시 저장 게시글이 존재하면: 연결된 이미지(S3 + DB) 삭제 후 게시글을 삭제합니다.
+                    - 임시 저장 게시글이 없으면: _TEMP_POST_NOT_FOUND 예외를 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "성공",
+                                              "result": null
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    })
+    public ResponseEntity<ApiResponse<Void>> deleteTemporaryPost(@AuthenticationPrincipal UserDetails userDetails) {
+        temporaryPostService.deleteTemporaryPost(userDetails);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+
     @GetMapping("/{postId}/share")
     @Operation(summary = "메타 데이터용 api")
     @ApiResponses({
@@ -369,17 +488,23 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.onSuccess(shareResponse));
     }
 
-    @PutMapping("/{postId}/found")
+    @PutMapping("/{postId}/status")
     @Operation(
-            summary = "게시글 상태를 '찾았음(FOUND)'으로 변경",
+            summary = "게시글 상태 변경",
             description = """
-                게시글을 '찾았음(FOUND)' 상태로 변경합니다.
+                게시글의 상태를 변경합니다.
                 
                 - 본인 게시글만 변경 가능
                 - 인증 필요 (JWT)
+                - 요청 Body에 변경할 상태 값을 전달
                 
                 예)
-                - PUT /posts/{postId}/found
+                PUT /posts/{postId}/status
+                
+                요청 예시:
+                {
+                  "status": "FOUND"
+                }
                 """
     )
     @ApiResponses({
@@ -399,14 +524,15 @@ public class PostController {
                                         """
                             )
                     )
-            ),
+            ), @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 상태 값 전달", content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음 (본인 게시글 아님)", content = @Content),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음", content = @Content)
     })
     public ResponseEntity<ApiResponse<Void>> updateFound(@PathVariable Long postId,
+                                                         @RequestBody @Valid PostStatusUpdateRequest request,
                                                          @AuthenticationPrincipal UserDetails userDetails) {
-        postService.markToFound(postId, userDetails);
+        postService.updatePostStatus(postId, request, userDetails);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(null));
     }

--- a/src/main/java/com/fmi/domain/post/web/dto/request/PostStatusUpdateRequest.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/request/PostStatusUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.fmi.domain.post.web.dto.request;
+
+import com.fmi.domain.post.data.PostStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record PostStatusUpdateRequest(
+        @NotNull
+        PostStatus postStatus
+) {
+}

--- a/src/main/java/com/fmi/domain/post/web/dto/request/TemporaryPostCreateRequest.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/request/TemporaryPostCreateRequest.java
@@ -3,44 +3,21 @@ package com.fmi.domain.post.web.dto.request;
 import com.fmi.domain.Enum.Category;
 import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.data.Radius;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record PostCreateRequest(
-        @NotNull
+public record TemporaryPostCreateRequest(
         PostType postType,
-
-        @NotBlank
         String title,
-
-        @NotNull
         LocalDateTime date,
-
-        @NotBlank
         String address,
-
-        @NotNull
         Double latitude,
-
-        @NotNull
         Double longitude,
-
-        @NotBlank
         String content,
-
-        @NotNull
         Radius radius,
-
-        @NotNull
         Category category,
 
-        Long tempPostId,
-
-        List<Long> keepImageIdList,
-
-        Long thumbnailImageId
+        List<Long> keepImageIdList
 ) {
 }

--- a/src/main/java/com/fmi/domain/post/web/dto/response/PostGetResponse.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/response/PostGetResponse.java
@@ -4,6 +4,7 @@ import com.fmi.domain.Enum.Category;
 import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.data.Radius;
+import com.fmi.domain.post.web.dto.response.image.PostImageResponse;
 import com.fmi.domain.user.web.dto.response.UserPostResponse;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/fmi/domain/post/web/dto/response/PostSimilarResponse.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/response/PostSimilarResponse.java
@@ -1,5 +1,7 @@
 package com.fmi.domain.post.web.dto.response;
 
+import com.fmi.domain.Enum.Category;
+
 import java.time.LocalDateTime;
 
 public record PostSimilarResponse(
@@ -10,6 +12,7 @@ public record PostSimilarResponse(
         Long favoriteCount,
         boolean favoriteStatus,
         Long viewCount,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        Category category
 ) {
 }

--- a/src/main/java/com/fmi/domain/post/web/dto/response/image/PostImageResponse.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/response/image/PostImageResponse.java
@@ -1,4 +1,4 @@
-package com.fmi.domain.post.web.dto.response;
+package com.fmi.domain.post.web.dto.response.image;
 
 import com.fmi.domain.post.data.ImageType;
 

--- a/src/main/java/com/fmi/domain/post/web/dto/response/temp/TemporaryPostResponse.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/response/temp/TemporaryPostResponse.java
@@ -1,0 +1,26 @@
+package com.fmi.domain.post.web.dto.response.temp;
+
+import com.fmi.domain.Enum.Category;
+import com.fmi.domain.post.data.PostType;
+import com.fmi.domain.post.data.Radius;
+import com.fmi.domain.post.web.dto.response.image.PostImageResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TemporaryPostResponse(
+        Long postId,
+        PostType postType,
+        Category category,
+        Radius radius,
+        LocalDateTime date,
+        String title,
+        String address,
+        Double latitude,
+        Double longitude,
+        String content,
+        List<PostImageResponse> images,
+        LocalDateTime updatedAt,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/fmi/global/apiPayload/code/status/ErrorStatus.java
@@ -58,6 +58,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _POST_FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-FAVORITE-NOT_FOUND", "해당 게시글에 대한 즐겨찾기를 하지 않았습니다."),
     _POST_RADIUS_NOT_MATCH(HttpStatus.BAD_REQUEST, "POST-RADIUS-NOT_MATCH", "유효하지 않는 Radius 값입니다."),
 
+    _TEMP_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "TEMP-POST404-NOT_FOUND", "임시저장글이 존재하지 않습니다."),
+
     // 댓글 관련 응답
     _COMMENT_PARENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404_PARENT-NOT_FOUND", "존재하지 않는 부모 댓글입니다."),
     _COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404-NOT_FOUND", "존재하지 않는 댓글입니다."),


### PR DESCRIPTION
## 🧩 관련 이슈

- close #234 

## 🛠️ 작업 내용

- 임시저장 조회

- 임시저장 생성

- 임시저장 삭제

- post 게시글 저장 api 수정

- 비슷한 분실물 category 추가

- 게시글 상태 찾았음 변경 -> 분리

## 📢 참고 및 특이사항


## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
