### PR TITLE
feat: 채팅 응답에 게시글 상태 필드 추가 및 내 채팅방 목록 노출 상태 변경

### DIFF
--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -31,6 +31,7 @@ public class ChatRoomConverter {
                 .title(post.getTitle())
                 .address(post.getAddress())
                 .thumbnailUrl(thumbnailUrl)
+                .postStatus(post.getPostStatus())
                 .build();
 
         return ChatRoomResultDTO.builder()
@@ -71,6 +72,7 @@ public class ChatRoomConverter {
                 .title(post.getTitle())
                 .address(post.getAddress())
                 .thumbnailUrl(thumbnailUrl)
+                .postStatus(post.getPostStatus())
                 .build();
 
         ChatMessage lastMessage = participant.getLastMessage();

--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.fmi.domain.chatroom.repository;
 
 import com.fmi.domain.Enum.SortType;
-import com.fmi.domain.Enum.Type;
 import com.fmi.domain.auth.data.QUser;
 import com.fmi.domain.chatmessage.data.QChatMessage;
 import com.fmi.domain.chatroom.data.ChatRoomParticipant;
@@ -44,8 +43,7 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
                 .selectFrom(pt)
                 .join(pt.chatRoom, cr).fetchJoin()
                 .join(cr.post, p).fetchJoin()
-                //todo: 추후에 이걸로 다시 변경 .join(pt.lastMessage, lm).fetchJoin()
-                .leftJoin(pt.lastMessage, lm).fetchJoin()
+                .join(pt.lastMessage, lm).fetchJoin()
                 .join(cr.participants, otherPt)
                 .join(otherPt.user, otherUser).fetchJoin()
                 .where(
@@ -53,7 +51,7 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
                         pt.user.id.eq(userId),
                         otherPt.user.id.ne(userId),
                         pt.participantState.eq(ParticipantState.ACTIVE),
-                        //todo: 추후에 주석 해제 pt.lastMessage.isNotNull(),
+                        pt.lastMessage.isNotNull(),
 
                         typeEq(type),
                         addressEq(address)

--- a/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
@@ -2,6 +2,7 @@ package com.fmi.domain.chatroom.web.dto;
 
 import com.fmi.domain.Enum.Category;
 import com.fmi.domain.chatmessage.data.enums.MessageType;
+import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.data.PostType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,6 +47,7 @@ public class ChatRoomResponseDTO {
         private String title;
         private String address;
         private String thumbnailUrl;
+        private PostStatus postStatus;
     }
 
     @Builder


### PR DESCRIPTION
## 🧩 관련 이슈

- close #223 

## 🛠️ 작업 내용

- 채팅 응답에서 게시글 상태 필드를 추가했습니다.
- 기존 구현은 채팅방에서 마지막 메시지가 존재하지 않으면, 내 채팅방 목록 조회에 포함하지 않도록 구현했습니다. 그러나 프론트 개발 편의상 이 설정을 잠시 해제해두었어서 현재는 개발완료로 다시 기존 상태로 돌렸습니다. 
- 게시글 삭제 컬럼은 현재 게시글 삭제가 하드 딜리트라서 소프트 딜리트로 구현되면 추가 예정입니다. 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
