### PR TITLE
feat: SecurityConfig에 프론트 도메인 추가

### DIFF
--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -94,7 +94,12 @@ public class SecurityConfig {
 
         config.setAllowCredentials(true);
         // localhost의 모든 포트 허용 (개발 환경)
-        config.setAllowedOriginPatterns(Arrays.asList("http://localhost:*", "http://127.0.0.1:*"));
+        config.setAllowedOriginPatterns(Arrays.asList(
+                "http://localhost:*",
+                "http://127.0.0.1:*",
+                "https://finditem.kr",
+                "https://www.finditem.kr"
+                ));
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         config.setMaxAge(3600L);


### PR DESCRIPTION
## 🧩 관련 이슈

- close #238 

## 🛠️ 작업 내용

- SecurityConfig에 프론트 도메인이 설정되어있지 않아서 cors에러를 발생시킬 수 있는 문제로 프론트 도메인을 추가했습니다. 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
