### PR TITLE
fix: GitHub Actions 수동 실행 시 deploy job 미실행 수정 및 Docker 포트 바인딩 localhost 제한

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew clean build -x test
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/develop'
     needs: ci
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       MYSQL_USER: fmi
       MYSQL_PASSWORD: fmi
     ports:
-      - "${MYSQL_PORT:-3306}:3306"
+      - "127.0.0.1:${MYSQL_PORT:-3306}:3306"
     volumes:
       - mysql_data:/var/lib/mysql
     command: ["--default-authentication-plugin=mysql_native_password", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--max_allowed_packet=64M"]
@@ -22,7 +22,7 @@ services:
     image: redis:7
     container_name: fmi-redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     command: ["redis-server", "--appendonly", "yes"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -36,7 +36,7 @@ services:
     environment:
       - REDIS_HOSTS=local:fmi-redis:6379
     ports:
-      - "8081:8081"
+      - "127.0.0.1:8081:8081"
     depends_on:
       - redis
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close #257 

## 🛠️ 작업 내용

- deploy job 미실행 수정
- Docker 포트 바인딩 localhost 제한

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
