### PR TITLE
fix: 알림 설정 조회 시 readOnly 트랜잭션으로 인한 500 에러 수정

### DIFF
--- a/src/main/java/com/fmi/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fmi/domain/notification/service/NotificationService.java
@@ -149,6 +149,7 @@ public class NotificationService {
     /**
      * 알림 설정 조회
      */
+    @Transactional
     public NotificationSettingsDTO getSettings(User user) {
         NotificationSettings settings = notificationSettingsRepository.findByUser(user)
                 .orElseGet(() -> createDefaultSettings(user));


### PR DESCRIPTION
## 🧩 관련 이슈

- close #259 

## 🛠️ 작업 내용

-  알림 설정 조회 시 readOnly 트랜잭션으로 인한 500 에러 수정

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
