### PR TITLE
fix: 게시글 수정 시 썸네일 변경이 반영되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/fmi/domain/post/service/PostImageService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostImageService.java
@@ -216,17 +216,21 @@ public class PostImageService {
     public void applyThumbnailOnUpdate(Post post, Long thumbnailId, List<PostImage> newlySaved) {
 
         if (thumbnailId != null) {
+            postImageRepository.resetThumbnailToNormal(post.getId());
+
             PostImage thumb = postImageRepository.findByIdAndPost_Id(thumbnailId, post.getId())
                     .orElseThrow(() -> new GeneralException(ErrorStatus._POST_IMAGE_NOT_FOUND));
 
-            postImageRepository.resetThumbnailToNormal(post.getId());
             thumb.setImageType(ImageType.THUMBNAIL);
             return;
         }
 
         if (newlySaved != null && !newlySaved.isEmpty()) {
-            postImageRepository.resetThumbnailToNormal(post.getId());
-            newlySaved.get(0).setImageType(ImageType.THUMBNAIL);
+            Long firstId = newlySaved.get(0).getId();
+            PostImage first = postImageRepository.findByIdAndPost_Id(firstId, post.getId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._POST_IMAGE_NOT_FOUND));
+
+            first.setImageType(ImageType.THUMBNAIL);
             return;
         }
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close #278 

## 🛠️ 작업 내용

- JPQL 벌크 업데이트(resetThumbnailToNormal) 이후 영속성 컨텍스트가 초기화되어
- detached 엔티티에 대한 dirty checking이 동작하지 않던 문제를 수정

## 📢 참고 및 특이사항


## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
