### PR TITLE
feat: 마이페이지 즐겨찾기/내 게시글 API 페이지네이션 + 필터 통일

### DIFF
--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
@@ -22,6 +22,21 @@ public interface PostRepositoryCustom {
                                                  Long userId,
                                                  Set<Long> hotPostsIds);
 
+    PostPageResponse searchMyPosts(Long userId,
+                                    PostType postType,
+                                    PostStatus postStatus,
+                                    Category category,
+                                    SortType sortType,
+                                    Long cursor,
+                                    int size);
+
+    PostPageResponse searchMyFavorites(Long userId,
+                                        PostType postType,
+                                        PostStatus postStatus,
+                                        Category category,
+                                        SortType sortType,
+                                        Long cursor,
+                                        int size);
 
     List<Post> searchByKeywordWithCursor(String keyword, Long cursor, int size);
 

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -193,6 +193,234 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     @Override
+    public PostPageResponse searchMyPosts(Long userId,
+                                           PostType postType,
+                                           PostStatus postStatus,
+                                           Category category,
+                                           SortType sortType,
+                                           Long cursor,
+                                           int size) {
+        QPost post = QPost.post;
+        QPostFavorite postFavorite = QPostFavorite.postFavorite;
+
+        BooleanExpression baseWhere = Expressions.allOf(
+                post.user.id.eq(userId),
+                post.deleted.isFalse(),
+                post.temporarySave.isFalse(),
+                equalsPostType(post, postType),
+                equalsPostStatus(post, postStatus),
+                equalsCategory(post, category)
+        );
+
+        BooleanExpression pageWhere = Expressions.allOf(
+                baseWhere,
+                cursorCondition(post, sortType, cursor)
+        );
+
+        Long postCount = queryFactory
+                .select(post.id.count())
+                .from(post)
+                .where(baseWhere)
+                .fetchOne();
+
+        if (Objects.isNull(postCount)) postCount = 0L;
+
+        List<Post> posts;
+        if (Objects.equals(sortType, SortType.MOST_FAVORITED)) {
+            posts = queryFactory.select(post)
+                    .from(post)
+                    .leftJoin(postFavorite).on(
+                            postFavorite.post.eq(post),
+                            postFavorite.isFavorite.isTrue()
+                    )
+                    .where(pageWhere)
+                    .groupBy(post.id)
+                    .orderBy(postFavorite.favorite_id.count().desc(), post.id.desc())
+                    .limit(size + 1)
+                    .fetch();
+        } else {
+            posts = queryFactory
+                    .selectFrom(post)
+                    .where(pageWhere)
+                    .orderBy(orderBySortType(post, sortType))
+                    .limit(size + 1)
+                    .fetch();
+        }
+
+        boolean hasNext = posts.size() > size;
+        if (hasNext) {
+            posts = posts.subList(0, size);
+        }
+
+        Long nextCursor = (hasNext && !posts.isEmpty()) ? posts.get(posts.size() - 1).getId() : null;
+
+        if (posts.isEmpty()) {
+            return new PostPageResponse(List.of(), 0L, null, false);
+        }
+
+        return buildPostPageResponse(posts, postCount, nextCursor, hasNext, userId);
+    }
+
+    @Override
+    public PostPageResponse searchMyFavorites(Long userId,
+                                               PostType postType,
+                                               PostStatus postStatus,
+                                               Category category,
+                                               SortType sortType,
+                                               Long cursor,
+                                               int size) {
+        QPost post = QPost.post;
+        QPostFavorite postFavorite = QPostFavorite.postFavorite;
+
+        BooleanExpression baseWhere = Expressions.allOf(
+                postFavorite.user.id.eq(userId),
+                postFavorite.isFavorite.isTrue(),
+                post.deleted.isFalse(),
+                equalsPostType(post, postType),
+                equalsPostStatus(post, postStatus),
+                equalsCategory(post, category)
+        );
+
+        BooleanExpression pageWhere = Expressions.allOf(
+                baseWhere,
+                cursorCondition(post, sortType, cursor)
+        );
+
+        Long postCount = queryFactory
+                .select(post.id.countDistinct())
+                .from(postFavorite)
+                .join(postFavorite.post, post)
+                .where(baseWhere)
+                .fetchOne();
+
+        if (Objects.isNull(postCount)) postCount = 0L;
+
+        List<Post> posts;
+        if (Objects.equals(sortType, SortType.MOST_FAVORITED)) {
+            QPostFavorite favCount = new QPostFavorite("favCount");
+            posts = queryFactory.select(post)
+                    .from(postFavorite)
+                    .join(postFavorite.post, post)
+                    .leftJoin(favCount).on(
+                            favCount.post.eq(post),
+                            favCount.isFavorite.isTrue()
+                    )
+                    .where(pageWhere)
+                    .groupBy(post.id)
+                    .orderBy(favCount.favorite_id.count().desc(), post.id.desc())
+                    .limit(size + 1)
+                    .fetch();
+        } else {
+            posts = queryFactory.select(post)
+                    .from(postFavorite)
+                    .join(postFavorite.post, post)
+                    .where(pageWhere)
+                    .orderBy(orderBySortType(post, sortType))
+                    .limit(size + 1)
+                    .fetch();
+        }
+
+        boolean hasNext = posts.size() > size;
+        if (hasNext) {
+            posts = posts.subList(0, size);
+        }
+
+        Long nextCursor = (hasNext && !posts.isEmpty()) ? posts.get(posts.size() - 1).getId() : null;
+
+        if (posts.isEmpty()) {
+            return new PostPageResponse(List.of(), 0L, null, false);
+        }
+
+        return buildPostPageResponse(posts, postCount, nextCursor, hasNext, userId);
+    }
+
+    private PostPageResponse buildPostPageResponse(List<Post> posts, Long postCount,
+                                                    Long nextCursor, boolean hasNext, Long userId) {
+        QPostFavorite postFavorite = QPostFavorite.postFavorite;
+        List<Long> postIdList = posts.stream().map(Post::getId).toList();
+
+        Map<Long, String> thumbnailMap = queryFactory
+                .select(postImage.post.id, postImage.id, postImage.imgUrl)
+                .from(postImage)
+                .where(
+                        postImage.post.id.in(postIdList),
+                        postImage.imageType.eq(ImageType.THUMBNAIL)
+                )
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> Objects.requireNonNull(t.get(postImage.post.id)),
+                        t -> Objects.requireNonNull(t.get(postImage.imgUrl)),
+                        (a, b) -> a
+                ));
+
+        Map<Long, Long> favoriteCountMap = queryFactory
+                .select(postFavorite.post.id, postFavorite.favorite_id.count())
+                .from(postFavorite)
+                .where(
+                        postFavorite.post.id.in(postIdList),
+                        postFavorite.isFavorite.isTrue()
+                )
+                .groupBy(postFavorite.post.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> Objects.requireNonNull(t.get(postFavorite.post.id)),
+                        t -> Objects.requireNonNull(t.get(postFavorite.favorite_id.count()))
+                ));
+
+        Set<Long> myFavoritePostIds = Objects.isNull(userId) ? Set.of() :
+                new HashSet<>(
+                        queryFactory
+                                .select(postFavorite.post.id)
+                                .from(postFavorite)
+                                .where(
+                                        postFavorite.user.id.eq(userId),
+                                        postFavorite.post.id.in(postIdList),
+                                        postFavorite.isFavorite.isTrue()
+                                )
+                                .fetch()
+                );
+
+        Map<Long, Integer> imageCountMap = queryFactory
+                .select(postImage.post.id, postImage.id.count())
+                .from(postImage)
+                .where(postImage.post.id.in(postIdList))
+                .groupBy(postImage.post.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> Objects.requireNonNull(t.get(postImage.post.id)),
+                        t -> Objects.requireNonNull(t.get(postImage.id.count())).intValue()
+                ));
+
+        List<PostBriefResponse> postList = posts.stream()
+                .map(p -> {
+                    Long pid = p.getId();
+                    return new PostBriefResponse(
+                            pid,
+                            p.getTitle(),
+                            p.makeSummary(),
+                            thumbnailMap.get(pid),
+                            p.getAddress(),
+                            p.getPostStatus(),
+                            p.getPostType(),
+                            p.getCategory(),
+                            favoriteCountMap.getOrDefault(pid, 0L),
+                            myFavoritePostIds.contains(pid),
+                            p.getViewCount(),
+                            p.isNew(),
+                            false,
+                            p.getCreatedAt(),
+                            imageCountMap.getOrDefault(pid, 0)
+                    );
+                })
+                .toList();
+
+        return new PostPageResponse(postList, postCount, nextCursor, hasNext);
+    }
+
+    @Override
     public List<Post> searchByKeywordWithCursor(String keyword, Long cursor, int size) {
         QPost post = QPost.post;
 

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -270,17 +270,13 @@ public class PostQueryService {
     }
 
 
-    //즐찾 조회
     @Transactional(readOnly = true)
-    public List<PostBriefResponse> getFavoritePost(UserDetails userDetails) {
+    public PostPageResponse getFavoritePost(UserDetails userDetails, PostType postType,
+                                             PostStatus postStatus, Category category,
+                                             SortType sortType, Long cursor, int size) {
         User user = userQueryService.findUser(userDetails.getUsername());
 
-        List<PostFavorite> favorites = postFavoriteRepository.findByUserAndIsFavoriteTrue(user);
-        List<Post> posts = favorites.stream()
-                .map(PostFavorite::getPost)
-                .toList();
-
-        return getPostBriefResponseList(posts, user);
+        return postRepository.searchMyFavorites(user.getId(), postType, postStatus, category, sortType, cursor, size);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
+++ b/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
@@ -1,7 +1,11 @@
 package com.fmi.domain.postfavorite.web.controller;
 
+import com.fmi.domain.Enum.Category;
+import com.fmi.domain.Enum.SortType;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.service.PostQueryService;
-import com.fmi.domain.post.web.dto.response.PostBriefResponse;
+import com.fmi.domain.post.web.dto.response.PostPageResponse;
 import com.fmi.domain.postfavorite.response.PostFavoriteResponse;
 import com.fmi.domain.postfavorite.service.PostFavoriteService;
 import com.fmi.global.apiPayload.ApiResponse;
@@ -14,8 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,14 +55,29 @@ public class PostFavoriteController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @Operation(summary = "즐겨찾기 목록 조회", tags = {"User"})
+    @Operation(summary = "즐겨찾기 목록 조회", description = """
+            현재 로그인한 사용자의 즐겨찾기 목록을 커서 기반으로 조회합니다.
+
+            **필터 파라미터** (모두 선택):
+            - postType: LOST / FOUND
+            - postStatus: SEARCHING / FOUND
+            - category: ELECTRONICS / WALLET / ID_CARD / JEWELRY / BAG / CARD / ETC
+            """, tags = {"User"})
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "즐겨찾기 목록 조회 성공")
     })
     @GetMapping("/users/me/favorites")
-    public ResponseEntity<ApiResponse<List<PostBriefResponse>>> getFavoritePost(@AuthenticationPrincipal UserDetails userDetails) {
-
-        List<PostBriefResponse> response = postQueryService.getFavoritePost(userDetails);
+    public ResponseEntity<ApiResponse<PostPageResponse>> getFavoritePost(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) PostType postType,
+            @RequestParam(required = false) PostStatus postStatus,
+            @RequestParam(required = false) Category category,
+            @RequestParam(required = false, defaultValue = "LATEST") SortType sortType,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false, defaultValue = "20") int size
+    ) {
+        PostPageResponse response = postQueryService.getFavoritePost(
+                userDetails, postType, postStatus, category, sortType, cursor, size);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -1,14 +1,19 @@
 package com.fmi.domain.user.service;
 
+import com.fmi.domain.Enum.Category;
+import com.fmi.domain.Enum.SortType;
 import com.fmi.domain.Enum.UserOtherPageType;
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.comment.data.Comment;
 import com.fmi.domain.comment.repository.CommentRepository;
 import com.fmi.domain.post.data.Post;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.post.service.PostQueryService;
 import com.fmi.domain.post.web.dto.response.PostBriefResponse;
+import com.fmi.domain.post.web.dto.response.PostPageResponse;
 import com.fmi.domain.postfavorite.data.PostFavorite;
 import com.fmi.domain.postfavorite.repository.PostFavoriteRepository;
 import com.fmi.domain.user.converter.UserConverter;
@@ -221,27 +226,15 @@ public class UserService {
     }
 
     /**
-     * 내가 쓴 게시글 목록 조회 (커서 기반)
+     * 내가 쓴 게시글 목록 조회 (커서 기반 + 필터)
      */
     @Transactional(readOnly = true)
-    public MyPostPageResponse getMyPosts(String email, Long cursor, int size) {
+    public PostPageResponse getMyPosts(String email, PostType postType, PostStatus postStatus,
+                                        Category category, SortType sortType, Long cursor, int size) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        PageRequest pageRequest = PageRequest.of(0, size);
-        Slice<Post> postSlice = (cursor == null)
-                ? postRepository.findByUserAndTemporarySaveFalseAndDeletedFalseOrderByIdDesc(user, pageRequest)
-                : postRepository.findByUserAndTemporarySaveFalseAndDeletedFalseAndIdLessThanOrderByIdDesc(user, cursor, pageRequest);
-
-        List<Post> postList = postSlice.getContent();
-        List<PostBriefResponse> posts = postQueryService.getPostBriefResponseList(postList, user);
-
-        boolean hasNext = postSlice.hasNext();
-        Long nextCursor = (hasNext && !postList.isEmpty())
-                ? postList.get(postList.size() - 1).getId()
-                : null;
-
-        return new MyPostPageResponse(posts, nextCursor, hasNext);
+        return postRepository.searchMyPosts(user.getId(), postType, postStatus, category, sortType, cursor, size);
     }
 
     /**

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -1,9 +1,13 @@
 package com.fmi.domain.user.web.controller;
 
+import com.fmi.domain.Enum.Category;
+import com.fmi.domain.Enum.SortType;
 import com.fmi.domain.Enum.UserOtherPageType;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.data.PostType;
+import com.fmi.domain.post.web.dto.response.PostPageResponse;
 import com.fmi.domain.user.response.ImageUploadResponse;
 import com.fmi.domain.user.response.MyCommentPageResponse;
-import com.fmi.domain.user.response.MyPostPageResponse;
 import com.fmi.domain.user.response.MyActivityPageResponse;
 import com.fmi.domain.user.response.UserOtherPageResponse;
 import com.fmi.domain.user.response.UserProfileResponse;
@@ -118,18 +122,29 @@ public class UserController {
     }
 
     @GetMapping("/me/posts")
-    @Operation(summary = "내가 쓴 게시글 목록", description = "현재 로그인한 사용자가 작성한 게시글 목록을 커서 기반으로 조회합니다.")
+    @Operation(summary = "내가 쓴 게시글 목록", description = """
+            현재 로그인한 사용자가 작성한 게시글 목록을 커서 기반으로 조회합니다.
+
+            **필터 파라미터** (모두 선택):
+            - postType: LOST / FOUND
+            - postStatus: SEARCHING / FOUND
+            - category: ELECTRONICS / WALLET / ID_CARD / JEWELRY / BAG / CARD / ETC
+            """)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 게시글 목록 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USER404-NOT_FOUND: 존재하지 않는 회원입니다")
     })
-    public ApiResponse<MyPostPageResponse> getMyPosts(
+    public ApiResponse<PostPageResponse> getMyPosts(
             @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) PostType postType,
+            @RequestParam(required = false) PostStatus postStatus,
+            @RequestParam(required = false) Category category,
+            @RequestParam(required = false, defaultValue = "LATEST") SortType sortType,
             @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "20") int size
     ) {
         String email = userDetails.getUsername();
-        MyPostPageResponse response = userService.getMyPosts(email, cursor, size);
+        PostPageResponse response = userService.getMyPosts(email, postType, postStatus, category, sortType, cursor, size);
         return ApiResponse.onSuccess(response);
     }
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close #283 

## 🛠️ 작업 내용

- 마이페이지 즐겨찾기/내 게시글 API 페이지네이션 + 필터 통일

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
