### PR TITLE
refactor: 관리자 신고/문의 통합 목록에 answered 필드 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-ec2
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/src/main/java/com/fmi/domain/admin/dto/AdminCsDetailResponse.java
+++ b/src/main/java/com/fmi/domain/admin/dto/AdminCsDetailResponse.java
@@ -1,0 +1,73 @@
+package com.fmi.domain.admin.dto;
+
+import com.fmi.domain.inquiry.data.enums.InquiryStatus;
+import com.fmi.domain.inquiry.data.enums.InquiryType;
+import com.fmi.domain.inquirycomment.response.InquiryCommentResponse;
+import com.fmi.domain.report.data.enums.ReportStatus;
+import com.fmi.domain.report.data.enums.ReportTargetType;
+import com.fmi.domain.report.data.enums.ReportType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "관리자 신고/문의 통합 상세 응답")
+public class AdminCsDetailResponse {
+
+    @Schema(description = "유형", example = "REPORT")
+    private AdminCsType type;
+    @Schema(description = "ID")
+    private Long id;
+    @Schema(description = "생성 시간")
+    private LocalDateTime createdAt;
+
+    // --- 신고 전용 필드 ---
+    @Schema(description = "신고 대상 타입 (신고 전용)")
+    private ReportTargetType targetType;
+    @Schema(description = "신고 대상 ID (신고 전용)")
+    private Long targetId;
+    @Schema(description = "신고 유형 (신고 전용)")
+    private ReportType reportType;
+    @Schema(description = "신고 사유 (신고 전용)")
+    private String reason;
+    @Schema(description = "처리 상태 (신고 전용)")
+    private ReportStatus reportStatus;
+    @Schema(description = "관리자 메모 (신고 전용)")
+    private String adminNote;
+    @Schema(description = "처리 완료 시간 (신고 전용)")
+    private LocalDateTime resolvedAt;
+    @Schema(description = "답변 여부 (신고 전용)")
+    private Boolean answered;
+    @Schema(description = "신고자 ID (신고 전용)")
+    private Long reporterId;
+    @Schema(description = "신고자 닉네임 (신고 전용)")
+    private String reporterNickname;
+    @Schema(description = "신고자 이메일 (신고 전용)")
+    private String reporterEmail;
+
+    // --- 문의 전용 필드 ---
+    @Schema(description = "문의 제목 (문의 전용)")
+    private String title;
+    @Schema(description = "문의 내용 (문의 전용)")
+    private String content;
+    @Schema(description = "문의 유형 (문의 전용)")
+    private InquiryType inquiryType;
+    @Schema(description = "문의 처리 상태 (문의 전용)")
+    private InquiryStatus inquiryStatus;
+    @Schema(description = "작성자 ID (문의 전용)")
+    private Long userId;
+    @Schema(description = "작성자 닉네임 (문의 전용)")
+    private String userNickname;
+    @Schema(description = "작성자 이메일 (문의 전용)")
+    private String userEmail;
+    @Schema(description = "댓글 목록 (문의 전용)")
+    private List<InquiryCommentResponse> comments;
+}

--- a/src/main/java/com/fmi/domain/admin/dto/AdminCsListResponse.java
+++ b/src/main/java/com/fmi/domain/admin/dto/AdminCsListResponse.java
@@ -14,8 +14,10 @@ public record AdminCsListResponse(
         String title,
         @Schema(description = "내용 미리보기 (100자)")
         String content,
-        @Schema(description = "처리 상태", example = "PENDING")
+        @Schema(description = "처리 상태 (신고: PENDING/REVIEWED/RESOLVED, 문의: RECEIVED/PENDING/ANSWERED)", example = "PENDING")
         String status,
+        @Schema(description = "답변 여부", example = "false")
+        Boolean answered,
         @Schema(description = "작성자 닉네임")
         String writerNickname,
         @Schema(description = "작성자 이메일")

--- a/src/main/java/com/fmi/domain/admin/dto/AdminGuestInquiryReplyRequestDTO.java
+++ b/src/main/java/com/fmi/domain/admin/dto/AdminGuestInquiryReplyRequestDTO.java
@@ -1,0 +1,12 @@
+package com.fmi.domain.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class AdminGuestInquiryReplyRequestDTO {
+    @NotBlank
+    @Schema(description = "답변 내용", example = "안녕하세요, 문의 주신 내용에 대해 답변 드립니다.")
+    private String content;
+}

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -39,6 +39,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fmi.domain.admin.dto.AdminCsDetailResponse;
 import com.fmi.domain.admin.dto.AdminCsListResponse;
 import com.fmi.domain.admin.dto.AdminCsPageResponse;
 import com.fmi.domain.admin.dto.AdminCsType;
@@ -166,6 +167,50 @@ public class AdminService {
         List<InquiryCommentResponse> comments =
                 inquiryCommentService.getCommentsForDetail(inquiry.getId(), userDetails);
         return inquiryConverter.toDetailDTO(inquiry, comments);
+    }
+
+    public AdminCsDetailResponse getCustomerServiceDetail(AdminCsType type, Long id, UserDetails userDetails) {
+        if (type == AdminCsType.REPORT) {
+            Report report = reportRepository.findById(id)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus._REPORT_NOT_FOUND));
+            return AdminCsDetailResponse.builder()
+                    .type(AdminCsType.REPORT)
+                    .id(report.getReportId())
+                    .createdAt(report.getCreatedAt())
+                    .targetType(report.getTargetType())
+                    .targetId(report.getTargetId())
+                    .reportType(report.getReportType())
+                    .reason(report.getReason())
+                    .reportStatus(report.getStatus())
+                    .adminNote(report.getAdminNote())
+                    .resolvedAt(report.getResolvedAt())
+                    .answered(report.getAnswered())
+                    .reporterId(report.getReporter() != null ? report.getReporter().getId() : null)
+                    .reporterNickname(report.getReporter() != null ? report.getReporter().getNickname() : null)
+                    .reporterEmail(report.getReporter() != null ? report.getReporter().getEmail() : null)
+                    .build();
+        }
+
+        Inquiry inquiry = inquiryRepository.findById(id)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INQUIRY_NOT_FOUND));
+
+        List<InquiryCommentResponse> comments =
+                inquiryCommentService.getCommentsForDetail(inquiry.getId(), userDetails);
+
+        return AdminCsDetailResponse.builder()
+                .type(AdminCsType.INQUIRY)
+                .id(inquiry.getId())
+                .createdAt(inquiry.getCreatedAt())
+                .title(inquiry.getTitle())
+                .content(inquiry.getContent())
+                .inquiryType(inquiry.getInquiryType())
+                .inquiryStatus(inquiry.getAnswerStatus())
+                .userId(inquiry.getUser() != null ? inquiry.getUser().getId() : null)
+                .userNickname(inquiry.getUser() != null ? inquiry.getUser().getNickname() : null)
+                .userEmail(inquiry.getEmail() != null ? inquiry.getEmail()
+                        : inquiry.getUser() != null ? inquiry.getUser().getEmail() : null)
+                .comments(comments)
+                .build();
     }
 
     public InquiryDetailDTO getGuestInquiryDetail(Long inquiryId, UserDetails userDetails) {

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -459,10 +459,11 @@ public class AdminService {
     }
 
     public CursorPageResponse<AdminDeletedUserResponse> getDeletedUsersCursorPage(
-            WithdrawalReason reason, Long cursor, int size) {
+            WithdrawalReason reason, String keyword, Long cursor, int size) {
         int fetchSize = size + 1;
         String reasonStr = reason != null ? reason.name() : null;
-        List<User> users = userRepository.findDeletedUsersCursor(reasonStr, cursor, fetchSize);
+        String keywordParam = (keyword != null && !keyword.isBlank()) ? "%" + keyword.trim() + "%" : null;
+        List<User> users = userRepository.findDeletedUsersCursorWithKeyword(reasonStr, keywordParam, cursor, fetchSize);
 
         boolean hasNext = users.size() > size;
         List<User> content = hasNext ? users.subList(0, size) : users;

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -168,6 +168,19 @@ public class AdminService {
         return inquiryConverter.toDetailDTO(inquiry, comments);
     }
 
+    public InquiryDetailDTO getGuestInquiryDetail(Long inquiryId, UserDetails userDetails) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INQUIRY_NOT_FOUND));
+
+        if (inquiry.getUser() != null) {
+            throw new GeneralException(ErrorStatus._INQUIRY_NOT_FOUND);
+        }
+
+        List<InquiryCommentResponse> comments =
+                inquiryCommentService.getCommentsForDetail(inquiry.getId(), userDetails);
+        return inquiryConverter.toDetailDTO(inquiry, comments);
+    }
+
     @Transactional
     public void blockInquiryIp(Long inquiryId, String reason) {
         Inquiry inquiry = inquiryRepository.findById(inquiryId)

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -209,6 +209,7 @@ public class AdminService {
                     r.getTargetType().getDescription() + " 신고",
                     truncate(r.getReason(), 100),
                     r.getStatus().name(),
+                    r.getAnswered(),
                     r.getReporter() != null ? r.getReporter().getNickname() : null,
                     r.getReporter() != null ? r.getReporter().getEmail() : null,
                     r.getCreatedAt()
@@ -226,6 +227,7 @@ public class AdminService {
                     i.getTitle(),
                     truncate(i.getContent(), 100),
                     i.getAnswerStatus().name(),
+                    i.getAnswerStatus() == InquiryStatus.ANSWERED,
                     i.getUser() != null ? i.getUser().getNickname() : null,
                     i.getUser() != null ? i.getUser().getEmail() : null,
                     i.getCreatedAt()

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -448,11 +448,12 @@ public class AdminController {
     })
     public ApiResponse<CursorPageResponse<AdminDeletedUserResponse>> getDeletedUsers(
             @RequestParam(required = false) WithdrawalReason reason,
+            @RequestParam(required = false) String keyword,
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "20") int size
     ) {
         CursorPageResponse<AdminDeletedUserResponse> response =
-                adminService.getDeletedUsersCursorPage(reason, cursor, size);
+                adminService.getDeletedUsersCursorPage(reason, keyword, cursor, size);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -83,6 +83,27 @@ public class AdminController {
         return ApiResponse.onSuccess(response);
     }
 
+    @GetMapping("/guest-inquiries/{inquiryId}")
+    @Operation(summary = "관리자 비회원 문의 상세 조회", description = "비회원이 작성한 문의의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비회원 문의 상세 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "INQUIRY404-NOT_FOUND: 존재하지 않는 문의입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"INQUIRY404-NOT_FOUND\", \"message\": \"존재하지 않는 문의입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ApiResponse<InquiryDetailDTO> getGuestInquiryDetail(@PathVariable Long inquiryId,
+                                                                @AuthenticationPrincipal UserDetails userDetails) {
+        InquiryDetailDTO response = adminService.getGuestInquiryDetail(inquiryId, userDetails);
+        return ApiResponse.onSuccess(response);
+    }
+
     @GetMapping("/guest-inquiries")
     @Operation(summary = "관리자 비회원 문의 목록 조회", description = """
             비회원이 작성한 문의 내역을 조회합니다. (커서 기반 무한스크롤)

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -1,5 +1,6 @@
 package com.fmi.domain.admin.web.controller;
 
+import com.fmi.domain.admin.dto.AdminCsDetailResponse;
 import com.fmi.domain.admin.dto.AdminCsPageResponse;
 import com.fmi.domain.admin.dto.AdminCsType;
 import com.fmi.domain.admin.dto.AdminDeletedUserResponse;
@@ -80,6 +81,29 @@ public class AdminController {
             @RequestParam(defaultValue = "20") int size
     ) {
         AdminCsPageResponse response = adminService.getCustomerServicePage(type, cursor, size);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/customer-service/{type}/{id}")
+    @Operation(summary = "관리자 신고/문의 통합 상세 조회", description = "통합 목록에서 선택한 항목의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "통합 상세 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "해당 항목을 찾을 수 없습니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"NOT_FOUND\", \"message\": \"해당 항목을 찾을 수 없습니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ApiResponse<AdminCsDetailResponse> getCustomerServiceDetail(
+            @PathVariable AdminCsType type,
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        AdminCsDetailResponse response = adminService.getCustomerServiceDetail(type, id, userDetails);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -5,6 +5,7 @@ import com.fmi.domain.admin.dto.AdminCsPageResponse;
 import com.fmi.domain.admin.dto.AdminCsType;
 import com.fmi.domain.admin.dto.AdminDeletedUserResponse;
 import com.fmi.domain.admin.dto.AdminGuestInquiryPageResponse;
+import com.fmi.domain.admin.dto.AdminGuestInquiryReplyRequestDTO;
 import com.fmi.domain.admin.dto.AdminInquiryResponse;
 import com.fmi.domain.admin.dto.AdminReportResponse;
 import com.fmi.domain.admin.dto.AdminUserDetailResponse;
@@ -325,6 +326,37 @@ public class AdminController {
     public ApiResponse<String> deleteNotice(@PathVariable Long noticeId) {
         noticeService.deleteNotice(noticeId);
         return ApiResponse.onSuccess("공지사항 삭제 완료");
+    }
+
+    @PostMapping("/guest-inquiries/{inquiryId}/reply")
+    @Operation(summary = "비회원 문의 답변 (이메일 발송)", description = "비회원 문의에 대해 이메일로 답변을 발송합니다. 상태가 ANSWERED로 변경됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "답변 발송 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "INQUIRY404-NOT_FOUND: 존재하지 않는 문의입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"INQUIRY404-NOT_FOUND\", \"message\": \"존재하지 않는 문의입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "회원 문의이거나 이메일이 없는 경우",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"COMMON400\", \"message\": \"잘못된 요청입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ApiResponse<String> replyToGuestInquiry(@PathVariable Long inquiryId,
+                                                    @Valid @RequestBody AdminGuestInquiryReplyRequestDTO request) {
+        inquiryService.replyToGuestInquiry(inquiryId, request.getContent());
+        return ApiResponse.onSuccess("OK");
     }
 
     @PutMapping("/inquiries/{inquiryId}/status")

--- a/src/main/java/com/fmi/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/fmi/domain/auth/repository/UserRepository.java
@@ -66,6 +66,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findDeletedUsersCursor(@Param("reason") String reason,
                                       @Param("cursor") Long cursor,
                                       @Param("limit") int limit);
+
+    @Query(value = "SELECT * FROM users u WHERE u.deleted_at IS NOT NULL " +
+           "AND (:reason IS NULL OR FIND_IN_SET(:reason, u.withdrawal_reason) > 0) " +
+           "AND (:keyword IS NULL OR u.email LIKE :keyword OR u.withdrawal_reason LIKE :keyword OR u.withdrawal_other_reason LIKE :keyword) " +
+           "AND (:cursor IS NULL OR u.id < :cursor) " +
+           "ORDER BY u.id DESC LIMIT :limit",
+           nativeQuery = true)
+    List<User> findDeletedUsersCursorWithKeyword(@Param("reason") String reason,
+                                                  @Param("keyword") String keyword,
+                                                  @Param("cursor") Long cursor,
+                                                  @Param("limit") int limit);
 }
 
 

--- a/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/fmi/domain/inquiry/service/InquiryService.java
@@ -204,6 +204,43 @@ public class InquiryService {
     }
     
     /**
+     * 비회원 문의 답변 (이메일 발송)
+     */
+    @Transactional
+    public void replyToGuestInquiry(Long inquiryId, String content) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._INQUIRY_NOT_FOUND));
+
+        if (inquiry.getUser() != null) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+
+        if (inquiry.getEmail() == null || inquiry.getEmail().isBlank()) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+
+        inquiry.markAsAnswered();
+
+        try {
+            String replyDate = java.time.format.DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")
+                    .format(java.time.LocalDateTime.now());
+
+            emailService.sendHtmlEmail(
+                inquiry.getEmail(),
+                "문의에 대한 답변이 도착했습니다",
+                "support-reply-email.html",
+                java.util.Map.of(
+                    "TITLE", inquiry.getTitle(),
+                    "DATE", replyDate,
+                    "CONTENT", content
+                )
+            );
+        } catch (Exception e) {
+            log.error("비회원 문의 답변 이메일 발송 실패: inquiryId={}, email={}", inquiry.getId(), inquiry.getEmail(), e);
+        }
+    }
+
+    /**
      * 문의 상태 변경(관리자)
      */
     @Transactional
@@ -228,7 +265,7 @@ public class InquiryService {
         // 문의자에게 상태 변경 알림 및 이메일 발송
         String statusMessage = getStatusMessage(status);
         
-        // 회원 문의인 경우 알림 및 이메일 발송
+        // 회원 문의인 경우 앱 알림 발송
         if (inquiry.getUser() != null) {
             notificationService.createNotification(
                     inquiry.getUser(),
@@ -238,44 +275,6 @@ public class InquiryService {
                     ReferenceType.INQUIRY,
                     inquiry.getId()
             );
-            
-            // 문의 상태 변경 이메일 발송
-            try {
-                String statusDate = java.time.format.DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")
-                        .format(java.time.LocalDateTime.now());
-                
-                emailService.sendHtmlEmail(
-                    inquiry.getUser().getEmail(),
-                    "문의 상태가 변경되었습니다",
-                    "inquiry-status-change-email.html",
-                    java.util.Map.of(
-                        "TITLE", inquiry.getTitle(),
-                        "STATUS", statusMessage,
-                        "DATE", statusDate
-                    )
-                );
-            } catch (Exception e) {
-                log.error("문의 상태 변경 이메일 발송 실패: inquiryId={}", inquiry.getId(), e);
-            }
-        } else if (inquiry.getEmail() != null) {
-            // 비회원 문의인 경우 이메일로만 발송
-            try {
-                String statusDate = java.time.format.DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")
-                        .format(java.time.LocalDateTime.now());
-                
-                emailService.sendHtmlEmail(
-                    inquiry.getEmail(),
-                    "문의 상태가 변경되었습니다",
-                    "inquiry-status-change-email.html",
-                    java.util.Map.of(
-                        "TITLE", inquiry.getTitle(),
-                        "STATUS", statusMessage,
-                        "DATE", statusDate
-                    )
-                );
-            } catch (Exception e) {
-                log.error("비회원 문의 상태 변경 이메일 발송 실패: inquiryId={}, email={}", inquiry.getId(), inquiry.getEmail(), e);
-            }
         }
     }
     


### PR DESCRIPTION
## 🧩 관련 이슈

- close #292

## 🛠️ 작업 내용

- 관리자 신고/문의 통합 목록에 answered 필드 추가
- deploy 에러수정
- 관리자 신고/문의 통합 상세 조회 API 추가
- 탈퇴 유저 목록 이메일/사유 키워드 검색 추가
- 관리자 비회원 문의 상세 조회 API 추가


## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
