### PR TITLE
feat: 채팅방 응답에서 게시글 정보에 deleted 컬럼 추가

### DIFF
--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -32,6 +32,7 @@ public class ChatRoomConverter {
                 .address(post.getAddress())
                 .thumbnailUrl(thumbnailUrl)
                 .postStatus(post.getPostStatus())
+                .deleted(post.isDeleted())
                 .build();
 
         return ChatRoomResultDTO.builder()
@@ -73,6 +74,7 @@ public class ChatRoomConverter {
                 .address(post.getAddress())
                 .thumbnailUrl(thumbnailUrl)
                 .postStatus(post.getPostStatus())
+                .deleted(post.isDeleted())
                 .build();
 
         ChatMessage lastMessage = participant.getLastMessage();

--- a/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
@@ -48,6 +48,7 @@ public class ChatRoomResponseDTO {
         private String address;
         private String thumbnailUrl;
         private PostStatus postStatus;
+        private boolean deleted;
     }
 
     @Builder


### PR DESCRIPTION
## 🧩 관련 이슈

- close #280 

## 🛠️ 작업 내용

- 채팅방 응답에서 게시글 정보 관련 응답에 deleted 컬럼을 추가했습니다. 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
