### PR TITLE
refactor: 관리자 비회원 문의 api 응답 누락 수정 및 필터 추가

### DIFF
--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   pull-requests: write
   issues: write
+  actions: write
 
 jobs:
   # 리뷰 승인 시 D-라벨 자동 제거
@@ -129,4 +130,26 @@ jobs:
               });
 
               console.log(`PR #${pr.number}: ${currentDLabel} → ${transition.next} (${diffDays}일 경과)`);
+
+              // D-0 전환 시 review-gate 재실행 (GITHUB_TOKEN 라벨은 다른 워크플로우를 트리거하지 않으므로)
+              if (transition.next === 'D-0') {
+                try {
+                  const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: 'review-gate.yml',
+                    head_sha: pr.head.sha
+                  });
+                  if (runs.total_count > 0) {
+                    await github.rest.actions.reRunWorkflow({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      run_id: runs.workflow_runs[0].id
+                    });
+                    console.log(`PR #${pr.number}: review-gate 재실행 완료`);
+                  }
+                } catch (e) {
+                  console.log(`PR #${pr.number}: review-gate 재실행 실패 — ${e.message}`);
+                }
+              }
             }

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -2,7 +2,7 @@ name: Review Gate
 
 on:
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, labeled]
   pull_request_review:
     types: [submitted]
 
@@ -35,12 +35,6 @@ jobs:
             const hasApproval = reviews.some(r => r.state === 'APPROVED');
             if (hasApproval) {
               console.log(`PR #${prNumber}: 승인된 리뷰 있음 — 머지 허용`);
-              return;
-            }
-
-            // D-0 외 라벨 이벤트는 통과 (불필요한 실패 알림 방지)
-            if (context.payload.action === 'labeled') {
-              console.log(`PR #${prNumber}: D-0 외 라벨 변경 — 스킵`);
               return;
             }
 

--- a/src/main/java/com/fmi/domain/Enum/ActivityType.java
+++ b/src/main/java/com/fmi/domain/Enum/ActivityType.java
@@ -5,6 +5,5 @@ public enum ActivityType {
     COMMENT,
     FAVORITE,
     INQUIRY,
-    REPORT,
-    VERIFICATION
+    REPORT
 }

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -176,6 +176,7 @@ public class AdminService {
             return AdminCsDetailResponse.builder()
                     .type(AdminCsType.REPORT)
                     .id(report.getReportId())
+                    .title(report.getTargetType().getDescription() + " 신고")
                     .createdAt(report.getCreatedAt())
                     .targetType(report.getTargetType())
                     .targetId(report.getTargetId())

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -310,22 +310,41 @@ public class AdminService {
      * 관리자 비회원 문의 목록 조회 (커서 기반 무한스크롤, id 기반)
      */
     public AdminGuestInquiryPageResponse getGuestInquirySlice(InquiryStatus status,
+                                                              Boolean answered,
                                                               String keyword,
                                                               Long cursor,
                                                               int size) {
         size = Math.max(1, Math.min(size, 50));
 
+        // answered 파라미터를 status로 변환 (status가 없을 때만)
+        InquiryStatus effectiveStatus = status;
+        boolean notAnsweredFilter = false;
+        if (status == null && answered != null) {
+            if (answered) {
+                effectiveStatus = InquiryStatus.ANSWERED;
+            } else {
+                notAnsweredFilter = true;
+            }
+        }
+
         PageRequest pageRequest = PageRequest.of(0, size);
         Slice<Inquiry> inquirySlice;
 
         if (keyword != null && !keyword.isBlank()) {
-            String statusStr = status != null ? status.name() : null;
-            inquirySlice = inquiryRepository.findGuestInquiriesForAdminWithKeywordSlice(
-                    statusStr, sanitizeFulltextKeyword(keyword), cursor, pageRequest);
+            String statusStr = effectiveStatus != null ? effectiveStatus.name() : null;
+            inquirySlice = notAnsweredFilter
+                    ? inquiryRepository.findGuestInquiriesNotAnsweredWithKeywordSlice(
+                            sanitizeFulltextKeyword(keyword), cursor, pageRequest)
+                    : inquiryRepository.findGuestInquiriesForAdminWithKeywordSlice(
+                            statusStr, sanitizeFulltextKeyword(keyword), cursor, pageRequest);
+        } else if (notAnsweredFilter) {
+            inquirySlice = (cursor == null)
+                    ? inquiryRepository.findGuestInquiriesNotAnsweredOrderByIdDesc(pageRequest)
+                    : inquiryRepository.findGuestInquiriesNotAnsweredBeforeCursorOrderByIdDesc(cursor, pageRequest);
         } else {
             inquirySlice = (cursor == null)
-                    ? inquiryRepository.findGuestInquiriesOrderByIdDesc(status, pageRequest)
-                    : inquiryRepository.findGuestInquiriesBeforeCursorOrderByIdDesc(status, cursor, pageRequest);
+                    ? inquiryRepository.findGuestInquiriesOrderByIdDesc(effectiveStatus, pageRequest)
+                    : inquiryRepository.findGuestInquiriesBeforeCursorOrderByIdDesc(effectiveStatus, cursor, pageRequest);
         }
 
         List<AdminInquiryResponse> items = inquirySlice.getContent().stream()

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -142,11 +142,12 @@ public class AdminController {
     })
     public ApiResponse<AdminGuestInquiryPageResponse> getGuestInquiries(
             @RequestParam(required = false) InquiryStatus status,
+            @RequestParam(required = false) Boolean answered,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "20") int size
     ) {
-        AdminGuestInquiryPageResponse response = adminService.getGuestInquirySlice(status, keyword, cursor, size);
+        AdminGuestInquiryPageResponse response = adminService.getGuestInquirySlice(status, answered, keyword, cursor, size);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/fmi/domain/inquiry/converter/InquiryConverter.java
+++ b/src/main/java/com/fmi/domain/inquiry/converter/InquiryConverter.java
@@ -28,6 +28,8 @@ public class InquiryConverter {
                 .inquiryType(inquiry.getInquiryType())
                 .status(inquiry.getAnswerStatus())
                 .createdAt(inquiry.getCreatedAt())
+                .email(inquiry.getEmail())
+                .ip(inquiry.getIp())
                 .build();
     }
 
@@ -39,6 +41,8 @@ public class InquiryConverter {
                 .inquiryType(inquiry.getInquiryType())
                 .status(inquiry.getAnswerStatus())
                 .createdAt(inquiry.getCreatedAt())
+                .email(inquiry.getEmail())
+                .ip(inquiry.getIp())
                 .comments(comments)
                 .build();
     }

--- a/src/main/java/com/fmi/domain/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/fmi/domain/inquiry/repository/InquiryRepository.java
@@ -192,6 +192,39 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
                                                                @Param("cursor") Long cursor,
                                                                Pageable pageable);
 
+    // 관리자 비회원 문의 - answered=false (미답변)
+    @Query("""
+            SELECT i FROM Inquiry i
+            WHERE i.user IS NULL
+              AND i.answerStatus <> com.fmi.domain.inquiry.data.enums.InquiryStatus.ANSWERED
+            ORDER BY i.id DESC
+            """)
+    Slice<Inquiry> findGuestInquiriesNotAnsweredOrderByIdDesc(Pageable pageable);
+
+    @Query("""
+            SELECT i FROM Inquiry i
+            WHERE i.user IS NULL
+              AND i.answerStatus <> com.fmi.domain.inquiry.data.enums.InquiryStatus.ANSWERED
+              AND i.id < :cursor
+            ORDER BY i.id DESC
+            """)
+    Slice<Inquiry> findGuestInquiriesNotAnsweredBeforeCursorOrderByIdDesc(@Param("cursor") Long cursor,
+                                                                          Pageable pageable);
+
+    // 관리자 비회원 문의 - answered=false + keyword (FULLTEXT, Slice)
+    @Query(value = """
+            SELECT * FROM customer_inquiry i
+            WHERE i.user_id IS NULL
+              AND i.answer_status <> 'ANSWERED'
+              AND MATCH(i.title, i.content) AGAINST(:keyword IN BOOLEAN MODE)
+              AND (:cursor IS NULL OR i.id < :cursor)
+            ORDER BY i.id DESC
+            """,
+            nativeQuery = true)
+    Slice<Inquiry> findGuestInquiriesNotAnsweredWithKeywordSlice(@Param("keyword") String keyword,
+                                                                 @Param("cursor") Long cursor,
+                                                                 Pageable pageable);
+
     // 관리자 비회원 문의 커서 기반 (id 기반) - keyword 있을 때 (FULLTEXT, Slice)
     @Query(value = """
             SELECT * FROM customer_inquiry i

--- a/src/main/java/com/fmi/domain/inquiry/web/dto/response/InquiryDetailDTO.java
+++ b/src/main/java/com/fmi/domain/inquiry/web/dto/response/InquiryDetailDTO.java
@@ -30,6 +30,10 @@ public class InquiryDetailDTO {
     private InquiryStatus status;
     @Schema(description = "생성 시간", example = "2024-01-01T00:00:00")
     private LocalDateTime createdAt;
+    @Schema(description = "이메일 (비회원 문의)", example = "guest@example.com")
+    private String email;
+    @Schema(description = "IP (비회원 문의)", example = "192.0.2.1")
+    private String ip;
     @Schema(description = "댓글 목록")
     private List<InquiryCommentResponse> comments;
 }

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -162,7 +162,6 @@ public class UserController {
             - FAVORITE: 즐겨찾기한 게시글
             - INQUIRY: 문의 내역
             - REPORT: 신고 내역
-            - VERIFICATION: 인증 내역
             - 미지정 시 전체 활동 조회
 
             **날짜 필터:**


### PR DESCRIPTION
## 🧩 관련 이슈

- close #311 

## 🛠️ 작업 내용

- 비회원 문의 상세 API 응답에 `email`, `ip` 필드 누락 → 추가
- 통합 상세 API REPORT 타입에서 `title`이 null → 추가
- 비회원 문의 목록 API에 `answered`(답변 여부) Boolean 필터 미구현 → 추가
- 활동 유형 `VERIFICATION`(인증) enum 제거 (미사용, 기획에서 불필요 확정)

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
