### PR TITLE
fix: SSE 알림 구독 시 async dispatch 인증 실패(500) 해결

### DIFF
--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.security.CustomUserDetailsService;
 import com.fmi.security.JwtAuthenticationFilter;
 import com.fmi.security.JwtTokenProvider;
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
@@ -41,6 +42,7 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         .requestMatchers("/", "/actuator/health", "/actuator/info", "/ws/**", "/error", "/health", "/api/health").permitAll()
                         .requestMatchers("/auth/**", "/s3/**", "/chat-test.html", "/chat-test2.html", "/posts/filter").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()


### PR DESCRIPTION
## 🧩 관련 이슈

- close #318 

## 🛠️ 작업 내용

- SSE 알림 구독 시 async dispatch 인증 실패(500) 해결


## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
