### PR TITLE
fix: Comment API 수정

### DIFF
--- a/src/main/java/com/fmi/domain/comment/data/Comment.java
+++ b/src/main/java/com/fmi/domain/comment/data/Comment.java
@@ -74,7 +74,7 @@ public class Comment {
         }
 
         int nextDepth = parent.getDepth() + 1;
-        if (nextDepth > 2) {
+        if (nextDepth > 3) {
             throw new GeneralException(ErrorStatus._COMMENT_DEPTH_EXCEEDED);
         }
 

--- a/src/main/java/com/fmi/domain/comment/service/CommentQueryService.java
+++ b/src/main/java/com/fmi/domain/comment/service/CommentQueryService.java
@@ -37,12 +37,13 @@ public class CommentQueryService {
     private final CommentLikeService commentLikeService;
     private final BlockedUserRepository blockedUserRepository;
 
-    private static final int PAGE_SIZE = 10;
+    private static final int PARENT_PAGE_SIZE = 10;
+    private static final int CHILD_COMMENT_PAGE_SIZE = 5;
 
     @Transactional(readOnly = true)
     public CommentPageResponse getParentComments(Long postId, int page, UserDetails userDetails) {
         User user = userQueryService.findUserIfNullReturnNull(userDetails);
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        Pageable pageable = PageRequest.of(page, PARENT_PAGE_SIZE);
 
         Set<Long> excludedUserIds = getExcludedUserIds(user);
         boolean excludedEmpty = (excludedUserIds == null || excludedUserIds.isEmpty());
@@ -54,18 +55,17 @@ public class CommentQueryService {
                 pageable
         );
 
-        boolean hasNext = fetched.size() > PAGE_SIZE;
-        if (hasNext) fetched = fetched.subList(0, PAGE_SIZE);
-
-        Integer nextPage = hasNext ? page + 1 : null;
-
         long totalCount = commentRepository.countParentComments(
                 postId,
                 excludedEmpty ? Set.of(0L) : excludedUserIds,
                 excludedEmpty
         );
 
-        long shown = ((long) page * PAGE_SIZE) + fetched.size();
+        boolean hasNext = totalCount > (long) (page + 1) * PARENT_PAGE_SIZE;
+
+        Integer nextPage = hasNext ? page + 1 : null;
+
+        long shown = ((long) page * PARENT_PAGE_SIZE) + fetched.size();
         long remainingCount = Math.max(0, totalCount - shown);
 
         List<Long> parentIds = fetched.stream()
@@ -106,7 +106,7 @@ public class CommentQueryService {
         Set<Long> excludedUserIds = getExcludedUserIds(user);
         boolean excludedEmpty = excludedUserIds == null || excludedUserIds.isEmpty();
 
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        Pageable pageable = PageRequest.of(page, CHILD_COMMENT_PAGE_SIZE);
 
         List<Comment> fetched = commentRepository.findReplies(
                 parentComment.getId(),
@@ -115,18 +115,16 @@ public class CommentQueryService {
                 pageable
         );
 
-        boolean hasNext = fetched.size() > PAGE_SIZE;
-        if (hasNext) fetched = fetched.subList(0, PAGE_SIZE);
-
-        Integer nextPage = hasNext ? page + 1 : null;
-
         long totalCount = commentRepository.countReplies(
                 parentComment.getId(),
                 excludedEmpty ? Set.of(0L) : excludedUserIds,
                 excludedEmpty
         );
 
-        long shown = (long) page * PAGE_SIZE + fetched.size();
+        boolean hasNext = totalCount > (long) (page + 1) * CHILD_COMMENT_PAGE_SIZE;
+        Integer nextPage = hasNext ? page + 1 : null;
+
+        long shown = (long) page * CHILD_COMMENT_PAGE_SIZE + fetched.size();
         long remainingCount = Math.max(0, totalCount - shown);
 
         List<Long> replyIds = fetched.stream()
@@ -146,7 +144,7 @@ public class CommentQueryService {
                             reply,
                             UserConverter.toUserCommentResponse(reply.getUser()),
                             imageMap.getOrDefault(reply.getId(), List.of()),
-                            (reply.getDepth() < 2) ? replyCountMap.getOrDefault(reply.getId(), 0L) : 0L,
+                            (reply.getDepth() < 3) ? replyCountMap.getOrDefault(reply.getId(), 0L) : 0L,
                             likeCountMap.getOrDefault(reply.getId(), 0L),
                             myLikeSet.contains(reply.getId()),
                             isAuthor

--- a/src/main/java/com/fmi/domain/commentlike/data/CommentLike.java
+++ b/src/main/java/com/fmi/domain/commentlike/data/CommentLike.java
@@ -21,9 +21,11 @@ public class CommentLike {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
     private Comment comment;
 
     @Column(name = "is_like")

--- a/src/main/java/com/fmi/domain/commentlike/web/controller/CommentLikeController.java
+++ b/src/main/java/com/fmi/domain/commentlike/web/controller/CommentLikeController.java
@@ -2,6 +2,8 @@ package com.fmi.domain.commentlike.web.controller;
 
 import com.fmi.domain.commentlike.service.CommentLikeService;
 import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.global.apiPayload.code.status.ErrorStatus;
+import com.fmi.global.apiPayload.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -15,6 +17,8 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,6 +47,10 @@ public class CommentLikeController {
     })
     public ResponseEntity<ApiResponse<Boolean>> createLike(@PathVariable Long commentId,
                                                            @AuthenticationPrincipal UserDetails userDetails) {
+        if(Objects.isNull(userDetails)){
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
         commentLikeService.createLike(commentId, userDetails);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(true));
@@ -69,6 +77,10 @@ public class CommentLikeController {
     })
     public ResponseEntity<ApiResponse<Boolean>> deleteLike(@PathVariable Long commentId,
                                                            @AuthenticationPrincipal UserDetails userDetails) {
+        if(Objects.isNull(userDetails)){
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
 
         commentLikeService.deleteLike(commentId, userDetails);
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close #327 

## 🛠️ 작업 내용

- Comment depth = 3 까지 확장

- Comment 조회 api hasNext 로직 수정

- Comment 부모 조회 api size = 10, 자식 조회 api size= 5로 변경

- CommentLike entity 연관관계 매핑 수정

## 📢 참고 및 특이사항


## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
