### PR TITLE
fix: 프로필 수정 API 이미지 삭제 여부를 쿼리스트링에서 Request Body로 변경

### DIFF
--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -253,8 +253,9 @@ public class UserController {
             - 파일을 보내지 않으면 → 이미지 변경 없음
             - 파일을 보내면 → 기존 이미지 삭제 후 새 이미지로 업데이트
             
-            **이미지 삭제** (deleteProfileImage 파라미터):
+            **이미지 삭제** (request JSON 내 deleteProfileImage 필드):
             - true로 보내면 → 기존 이미지 삭제 (프로필 이미지 없음 상태)
+            - null 또는 필드 미포함 → 이미지 삭제 없음
             """)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 정보 수정 성공"),
@@ -282,10 +283,10 @@ public class UserController {
     public ApiResponse<UserProfileResponse> updateMyProfile(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestPart(value = "request", required = false) @Valid UserUpdateRequest request,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
-            @RequestParam(value = "deleteProfileImage", required = false, defaultValue = "false") boolean deleteProfileImage
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
         String email = userDetails.getUsername();
+        boolean deleteProfileImage = request != null && request.isDeleteProfileImage();
         UserProfileResponse response = userService.updateMyProfile(email, request, profileImage, deleteProfileImage);
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/fmi/domain/user/web/dto/UserUpdateRequest.java
+++ b/src/main/java/com/fmi/domain/user/web/dto/UserUpdateRequest.java
@@ -13,6 +13,8 @@ public class UserUpdateRequest {
     @Size(min = 2, max = 15, message = "닉네임은 2~15자 사이여야 합니다")
     private String nickname;
 
+    private Boolean deleteProfileImage;
+
     @JsonIgnore
     private boolean nicknameProvided = false;
 
@@ -20,5 +22,9 @@ public class UserUpdateRequest {
     public void setNickname(String nickname) {
         this.nicknameProvided = true;
         this.nickname = nickname;
+    }
+
+    public boolean isDeleteProfileImage() {
+        return Boolean.TRUE.equals(deleteProfileImage);
     }
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #329

## 🛠️ 작업 내용

- 프로필 수정 API 이미지 삭제 여부를 쿼리스트링에서 Request Body로 변경 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
