### PR TITLE
feat: 즐겨찾기 조회 API에 지역/검색 필터 추가 및 postStatus 파라미터 삭제

### DIFF
--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
@@ -36,8 +36,9 @@ public interface PostRepositoryCustom {
 
     PostPageResponse searchMyFavorites(Long userId,
                                         PostType postType,
-                                        PostStatus postStatus,
                                         Category category,
+                                        String address,
+                                        String keyword,
                                         SortType sortType,
                                         Long cursor,
                                         int size);

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -270,33 +270,35 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     @Override
     public PostPageResponse searchMyFavorites(Long userId,
                                                PostType postType,
-                                               PostStatus postStatus,
                                                Category category,
+                                               String address,
+                                               String keyword,
                                                SortType sortType,
                                                Long cursor,
                                                int size) {
         QPost post = QPost.post;
         QPostFavorite postFavorite = QPostFavorite.postFavorite;
 
-        BooleanExpression baseWhere = Expressions.allOf(
-                postFavorite.user.id.eq(userId),
-                postFavorite.isFavorite.isTrue(),
-                post.deleted.isFalse(),
-                equalsPostType(post, postType),
-                equalsPostStatus(post, postStatus),
-                equalsCategory(post, category)
-        );
+        BooleanBuilder baseBuilder = new BooleanBuilder();
+        baseBuilder.and(postFavorite.user.id.eq(userId));
+        baseBuilder.and(postFavorite.isFavorite.isTrue());
+        baseBuilder.and(post.deleted.isFalse());
+        baseBuilder.and(equalsPostType(post, postType));
+        baseBuilder.and(equalsCategory(post, category));
+        baseBuilder.and(addressStartsWith(post, address));
 
-        BooleanExpression pageWhere = Expressions.allOf(
-                baseWhere,
-                cursorCondition(post, sortType, cursor)
-        );
+        if (hasText(keyword)) {
+            baseBuilder.and(buildKeywordCondition(post, keyword));
+        }
+
+        BooleanBuilder pageWhere = new BooleanBuilder(baseBuilder);
+        pageWhere.and(cursorCondition(post, sortType, cursor));
 
         Long postCount = queryFactory
                 .select(post.id.countDistinct())
                 .from(postFavorite)
                 .join(postFavorite.post, post)
-                .where(baseWhere)
+                .where(baseBuilder)
                 .fetchOne();
 
         if (Objects.isNull(postCount)) postCount = 0L;

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -272,11 +272,12 @@ public class PostQueryService {
 
     @Transactional(readOnly = true)
     public PostPageResponse getFavoritePost(UserDetails userDetails, PostType postType,
-                                             PostStatus postStatus, Category category,
-                                             SortType sortType, Long cursor, int size) {
+                                             Category category, String address,
+                                             String keyword, SortType sortType,
+                                             Long cursor, int size) {
         User user = userQueryService.findUser(userDetails.getUsername());
 
-        return postRepository.searchMyFavorites(user.getId(), postType, postStatus, category, sortType, cursor, size);
+        return postRepository.searchMyFavorites(user.getId(), postType, category, address, keyword, sortType, cursor, size);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
+++ b/src/main/java/com/fmi/domain/postfavorite/web/controller/PostFavoriteController.java
@@ -2,7 +2,6 @@ package com.fmi.domain.postfavorite.web.controller;
 
 import com.fmi.domain.Enum.Category;
 import com.fmi.domain.Enum.SortType;
-import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.service.PostQueryService;
 import com.fmi.domain.post.web.dto.response.PostPageResponse;
@@ -60,8 +59,9 @@ public class PostFavoriteController {
 
             **필터 파라미터** (모두 선택):
             - postType: LOST / FOUND
-            - postStatus: SEARCHING / FOUND
             - category: ELECTRONICS / WALLET / ID_CARD / JEWELRY / BAG / CARD / ETC
+            - address: 지역 필터 (예: 서울특별시, 서울특별시 강남구)
+            - keyword: 제목 또는 내용 검색
             """, tags = {"User"})
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "즐겨찾기 목록 조회 성공")
@@ -70,14 +70,15 @@ public class PostFavoriteController {
     public ResponseEntity<ApiResponse<PostPageResponse>> getFavoritePost(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(required = false) PostType postType,
-            @RequestParam(required = false) PostStatus postStatus,
             @RequestParam(required = false) Category category,
+            @RequestParam(required = false) String address,
+            @RequestParam(required = false) String keyword,
             @RequestParam(required = false, defaultValue = "LATEST") SortType sortType,
             @RequestParam(required = false) Long cursor,
             @RequestParam(required = false, defaultValue = "20") int size
     ) {
         PostPageResponse response = postQueryService.getFavoritePost(
-                userDetails, postType, postStatus, category, sortType, cursor, size);
+                userDetails, postType, category, address, keyword, sortType, cursor, size);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #321

## 🛠️ 작업 내용

- 즐겨찾기 조회 API에 지역/검색 필터 추가 및 postStatus 파라미터 삭제

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
