### PR TITLE
feat: 알림 설정에 전체 브라우저 알림 및 카테고리별 키워드 알림 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,8 +13,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-ec2
-  cancel-in-progress: true
+  group: deploy-ec2-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request' }}
 
 jobs:
   ci:

--- a/src/main/java/com/fmi/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/fmi/domain/notification/converter/NotificationConverter.java
@@ -31,6 +31,8 @@ public class NotificationConverter {
                 .favoriteEnabled(settings.getFavoriteEnabled())
                 .noticeEnabled(settings.getNoticeEnabled())
                 .categoryEnabled(settings.getCategoryEnabled())
+                .enabledCategories(settings.getEnabledCategories())
+                .browserNotificationEnabled(settings.getBrowserNotificationEnabled())
                 .marketingConsent(user.isMarketingConsent())
                 .build();
     }

--- a/src/main/java/com/fmi/domain/notification/data/NotificationSettings.java
+++ b/src/main/java/com/fmi/domain/notification/data/NotificationSettings.java
@@ -1,10 +1,13 @@
 package com.fmi.domain.notification.data;
 
+import com.fmi.domain.Enum.Category;
 import com.fmi.domain.auth.data.User;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.EnumSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "notification_settings")
@@ -58,6 +61,19 @@ public class NotificationSettings {
     @Builder.Default
     private Boolean categoryEnabled = true;
 
+    // 전체 브라우저 알림
+    @Column(name = "browser_notification_enabled")
+    @Builder.Default
+    private Boolean browserNotificationEnabled = true;
+
+    // 카테고리별 키워드 알림 (활성화된 카테고리 목록)
+    @ElementCollection(targetClass = Category.class, fetch = FetchType.EAGER)
+    @CollectionTable(name = "notification_category_keywords", joinColumns = @JoinColumn(name = "settings_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category")
+    @Builder.Default
+    private Set<Category> enabledCategories = EnumSet.allOf(Category.class);
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -76,10 +92,10 @@ public class NotificationSettings {
     }
 
     // 설정 업데이트
-    public void updateSettings(Boolean commentEnabled, Boolean chatEnabled, 
+    public void updateSettings(Boolean commentEnabled, Boolean chatEnabled,
                                Boolean inquiryReplyEnabled, Boolean reportResultEnabled,
                                Boolean favoriteEnabled, Boolean noticeEnabled,
-                               Boolean categoryEnabled) {
+                               Boolean categoryEnabled, Boolean browserNotificationEnabled) {
         if (commentEnabled != null) this.commentEnabled = commentEnabled;
         if (chatEnabled != null) this.chatEnabled = chatEnabled;
         if (inquiryReplyEnabled != null) this.inquiryReplyEnabled = inquiryReplyEnabled;
@@ -87,6 +103,7 @@ public class NotificationSettings {
         if (favoriteEnabled != null) this.favoriteEnabled = favoriteEnabled;
         if (noticeEnabled != null) this.noticeEnabled = noticeEnabled;
         if (categoryEnabled != null) this.categoryEnabled = categoryEnabled;
+        if (browserNotificationEnabled != null) this.browserNotificationEnabled = browserNotificationEnabled;
     }
 }
 

--- a/src/main/java/com/fmi/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fmi/domain/notification/service/NotificationService.java
@@ -217,9 +217,15 @@ public class NotificationService {
                 request.getReportResultEnabled(),
                 request.getFavoriteEnabled(),
                 request.getNoticeEnabled(),
-                request.getCategoryEnabled()
+                request.getCategoryEnabled(),
+                request.getBrowserNotificationEnabled()
         );
-        
+
+        if (request.getEnabledCategories() != null) {
+            settings.getEnabledCategories().clear();
+            settings.getEnabledCategories().addAll(request.getEnabledCategories());
+        }
+
         NotificationSettings saved = notificationSettingsRepository.save(settings);
         
         // User.marketingConsent 업데이트 (요청에 값이 있는 경우에만)
@@ -244,7 +250,7 @@ public class NotificationService {
         
         NotificationSettings settings = notificationSettingsRepository.findByUser(freshUser)
                 .orElseGet(() -> createDefaultSettings(freshUser));
-        settings.updateSettings(commentEnabled, chatEnabled, null, null, null, null, categoryEnabled);
+        settings.updateSettings(commentEnabled, chatEnabled, null, null, null, null, categoryEnabled, null);
         NotificationSettings saved = notificationSettingsRepository.save(settings);
         return notificationConverter.toSettingsDTO(saved, freshUser);
     }

--- a/src/main/java/com/fmi/domain/notification/web/dto/request/NotificationSettingsUpdateDTO.java
+++ b/src/main/java/com/fmi/domain/notification/web/dto/request/NotificationSettingsUpdateDTO.java
@@ -1,8 +1,11 @@
 package com.fmi.domain.notification.web.dto.request;
 
+import com.fmi.domain.Enum.Category;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor
@@ -14,7 +17,9 @@ public class NotificationSettingsUpdateDTO {
     private Boolean reportResultEnabled;     // 신고 처리 결과 알림
     private Boolean favoriteEnabled;         // 좋아요 알림
     private Boolean noticeEnabled;           // 공지사항 알림
-    private Boolean categoryEnabled;         // 카테고리 알림
+    private Boolean categoryEnabled;         // 카테고리 키워드 알림 전체
+    private Set<Category> enabledCategories; // 활성화된 카테고리 키워드 목록
+    private Boolean browserNotificationEnabled; // 전체 브라우저 알림
     private Boolean marketingConsent;        // 마케팅 이메일 수신 동의
 }
 

--- a/src/main/java/com/fmi/domain/notification/web/dto/response/NotificationSettingsDTO.java
+++ b/src/main/java/com/fmi/domain/notification/web/dto/response/NotificationSettingsDTO.java
@@ -1,10 +1,13 @@
 package com.fmi.domain.notification.web.dto.response;
 
+import com.fmi.domain.Enum.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Set;
 
 @Getter
 @Builder
@@ -24,8 +27,12 @@ public class NotificationSettingsDTO {
     private Boolean favoriteEnabled;
     @Schema(description = "공지사항 알림 활성화 여부", example = "true")
     private Boolean noticeEnabled;
-    @Schema(description = "카테고리 알림 활성화 여부", example = "true")
+    @Schema(description = "카테고리 키워드 알림 전체 활성화 여부", example = "true")
     private Boolean categoryEnabled;
+    @Schema(description = "활성화된 카테고리 키워드 목록", example = "[\"ELECTRONICS\", \"WALLET\"]")
+    private Set<Category> enabledCategories;
+    @Schema(description = "전체 브라우저 알림 활성화 여부", example = "true")
+    private Boolean browserNotificationEnabled;
     @Schema(description = "마케팅 이메일 수신 동의", example = "false")
     private Boolean marketingConsent;
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #323 

## 🛠️ 작업 내용

- 알림 설정에 전체 브라우저 알림 및 카테고리별 키워드 알림 추가


## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
