### PR TITLE
chore: build.gradle 의존성 취약점 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 
 ext['kotlin.version'] = '2.1.0'
 ext['spring-framework.version'] = '6.2.11'
+ext['jackson.version'] = '2.19.2'
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 }
 
 ext['kotlin.version'] = '2.1.0'
+ext['spring-framework.version'] = '6.2.11'
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -49,7 +50,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	//s3
-	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.1'
 	implementation platform('software.amazon.awssdk:bom:2.27.21')
 	implementation 'software.amazon.awssdk:s3'
 	implementation "software.amazon.awssdk:apache-client"

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	// Email


### PR DESCRIPTION
## 🧩 관련 이슈

- close #317 

## 🛠️ 작업 내용

- springdoc-openapi-starter-webmvc-ui 버전을 2.8.9 -> 2.8.14로 업그레이드 했습니다.
- io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0 -> 3.4.1로 업그레이드 했습니다.
- ext['spring-framework.version'] = '6.2.11'로 설정했습니다.
- ext['jackson.version'] = '2.19.2'로 설정했습니다.

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
