### PR TITLE
fix: 공지사항 목록 조회 500 에러 수정

### DIFF
--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -29,6 +29,7 @@ import com.fmi.domain.report.web.dto.response.ReportResponseDTO;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.global.apiPayload.CursorPageResponse;
 import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;

--- a/src/main/java/com/fmi/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/fmi/domain/notice/repository/NoticeRepository.java
@@ -162,7 +162,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             SELECT n.id FROM notice n
             LEFT JOIN notice_comment nc ON nc.notice_id = n.id
             WHERE n.draft = false
-            GROUP BY n.id
+            GROUP BY n.id, n.view_cnt, n.like_count
             HAVING COUNT(nc.comment_id) >= 1 OR n.view_cnt >= 10
             ORDER BY COUNT(nc.comment_id) DESC, n.view_cnt DESC, n.like_count DESC
             LIMIT :limit


### PR DESCRIPTION
## 🧩 관련 이슈

- close #341

## 🛠️ 작업 내용

- 공지사항 목록 조회 500 에러 수정


## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
