### PR TITLE
fix: Post delete API 영속성 컨텍스트 clear 되기 전에 soft delete 하기

### DIFF
--- a/src/main/java/com/fmi/domain/post/service/PostService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostService.java
@@ -49,7 +49,7 @@ public class PostService {
 
         Post savePost = postRepository.save(post);
 
-        postImageService.createPostImageAtS3AndDB(images ,savePost);
+        postImageService.createPostImageAtS3AndDB(images, savePost);
 
         notificationService.notifyCategoriesForPost(post);
 
@@ -105,9 +105,9 @@ public class PostService {
         Post post = postQueryService.findById(postId);
         checkPostAccessDenied(post, userDetails.getUsername());
 
+        post.softDelete();
         postImageService.deleteAllImageByPost(post);
         postFavoriteRepository.deleteAllByPostId(postId);
-        post.softDelete();
     }
 
     @Transactional


### PR DESCRIPTION
## 🧩 관련 이슈

- close #344 

## 🛠️ 작업 내용

- deleteAllByPostId() 실행 후 detached 상태로 인한
post 가 더 이상 JPA가 추적하는 엔티티가 아니게 되어서 dirty checking이 일어나지 않아 soft delete가 일어나지 않는 현상 으로 인한 로직 순서 변경


## 📢 참고 및 특이사항


## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
