### PR TITLE
fix: 공지사항 무한스크롤 시 고정 공지 중복 노출 수정

### DIFF
--- a/src/main/java/com/fmi/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/fmi/domain/notice/repository/NoticeRepository.java
@@ -87,7 +87,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             SELECT * FROM notice n
             WHERE n.draft = false
               AND (:category IS NULL OR n.category = :category)
-              AND (:cursor IS NULL OR n.id < :cursor)
+              AND (:cursor IS NULL OR (n.id < :cursor AND n.pinned = false))
             ORDER BY n.pinned DESC, n.created_at DESC
             LIMIT :limit
             """,
@@ -101,7 +101,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             SELECT * FROM notice n
             WHERE n.draft = false
               AND (:category IS NULL OR n.category = :category)
-              AND (:cursor IS NULL OR n.id > :cursor)
+              AND (:cursor IS NULL OR (n.id > :cursor AND n.pinned = false))
             ORDER BY n.pinned DESC, n.created_at ASC
             LIMIT :limit
             """,
@@ -116,7 +116,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             WHERE n.draft = false
               AND (:category IS NULL OR n.category = :category)
               AND MATCH(n.title, n.content) AGAINST(:keyword IN BOOLEAN MODE)
-              AND (:cursor IS NULL OR n.id < :cursor)
+              AND (:cursor IS NULL OR (n.id < :cursor AND n.pinned = false))
             ORDER BY n.pinned DESC, n.created_at DESC
             LIMIT :limit
             """,
@@ -132,7 +132,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             WHERE n.draft = false
               AND (:category IS NULL OR n.category = :category)
               AND MATCH(n.title, n.content) AGAINST(:keyword IN BOOLEAN MODE)
-              AND (:cursor IS NULL OR n.id > :cursor)
+              AND (:cursor IS NULL OR (n.id > :cursor AND n.pinned = false))
             ORDER BY n.pinned DESC, n.created_at ASC
             LIMIT :limit
             """,
@@ -148,7 +148,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             WHERE n.draft = false
               AND (:category IS NULL OR n.category = :category)
               AND MATCH(n.title, n.content) AGAINST(:keyword IN BOOLEAN MODE)
-              AND (:cursor IS NULL OR n.id < :cursor)
+              AND (:cursor IS NULL OR (n.id < :cursor AND n.pinned = false))
             ORDER BY n.pinned DESC, n.view_cnt DESC, n.id DESC
             LIMIT :limit
             """,


### PR DESCRIPTION
## 🧩 관련 이슈

- close #343

## 🛠️ 작업 내용

- 공지사항 무한스크롤 시 고정 공지 중복 노출 수정

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
