### PR TITLE
feat: 차단 유저 목록, 내 댓글 목록 커서 기반 페이지네이션 전환

### DIFF
--- a/src/main/java/com/fmi/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/fmi/domain/comment/repository/CommentRepository.java
@@ -38,13 +38,15 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("""
             SELECT c FROM Comment c JOIN FETCH c.post
             WHERE c.user = :user AND c.deleted = false
+              AND (:cursor IS NULL OR c.id < :cursor)
               AND (:startDate IS NULL OR c.createdAt >= :startDate)
               AND (:endDate IS NULL OR c.createdAt < :endDate)
               AND (:keyword IS NULL OR c.content LIKE CONCAT('%', :keyword, '%')
                    OR c.post.title LIKE CONCAT('%', :keyword, '%'))
-            ORDER BY c.createdAt DESC
+            ORDER BY c.id DESC
             """)
     Slice<Comment> searchMyCommentsLatest(@Param("user") User user,
+                                          @Param("cursor") Long cursor,
                                           @Param("startDate") LocalDateTime startDate,
                                           @Param("endDate") LocalDateTime endDate,
                                           @Param("keyword") String keyword,
@@ -53,13 +55,15 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("""
             SELECT c FROM Comment c JOIN FETCH c.post
             WHERE c.user = :user AND c.deleted = false
+              AND (:cursor IS NULL OR c.id > :cursor)
               AND (:startDate IS NULL OR c.createdAt >= :startDate)
               AND (:endDate IS NULL OR c.createdAt < :endDate)
               AND (:keyword IS NULL OR c.content LIKE CONCAT('%', :keyword, '%')
                    OR c.post.title LIKE CONCAT('%', :keyword, '%'))
-            ORDER BY c.createdAt ASC
+            ORDER BY c.id ASC
             """)
     Slice<Comment> searchMyCommentsOldest(@Param("user") User user,
+                                          @Param("cursor") Long cursor,
                                           @Param("startDate") LocalDateTime startDate,
                                           @Param("endDate") LocalDateTime endDate,
                                           @Param("keyword") String keyword,

--- a/src/main/java/com/fmi/domain/report/web/controller/BlockController.java
+++ b/src/main/java/com/fmi/domain/report/web/controller/BlockController.java
@@ -6,6 +6,7 @@ import com.fmi.domain.userblock.data.BlockedUser;
 import com.fmi.domain.userblock.service.BlockService;
 import com.fmi.domain.userblock.web.dto.response.BlockedUserResponse;
 import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.global.apiPayload.CursorPageResponse;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,8 +17,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/reports")
@@ -59,14 +58,17 @@ public class BlockController {
     }
 
     @GetMapping("/block")
-    @Operation(summary = "내가 차단한 유저 목록", description = "차단한 유저의 ID, 닉네임, 프로필 사진을 반환합니다.")
+    @Operation(summary = "내가 차단한 유저 목록", description = "차단한 유저의 ID, 닉네임, 프로필 사진을 커서 기반으로 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "차단 유저 목록 조회 성공")
     })
-    public ApiResponse<List<BlockedUserResponse>> list(@AuthenticationPrincipal UserDetails userDetails) {
+    public ApiResponse<CursorPageResponse<BlockedUserResponse>> list(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size) {
         User user = userRepository.findByEmail(userDetails.getUsername())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
-        List<BlockedUserResponse> blockedUsers = blockService.listWithUserInfo(user.getId());
+        CursorPageResponse<BlockedUserResponse> blockedUsers = blockService.listWithUserInfoCursor(user.getId(), cursor, size);
         return ApiResponse.onSuccess(blockedUsers);
     }
 }

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -200,12 +200,12 @@ public class UserService {
     }
 
     /**
-     * 내가 쓴 댓글 목록 조회 (페이지 기반 + 필터)
+     * 내가 쓴 댓글 목록 조회 (커서 기반 + 필터)
      */
     @Transactional(readOnly = true)
     public MyCommentPageResponse getMyComments(String email, SortType sortType,
                                                 LocalDate startDate, LocalDate endDate,
-                                                String keyword, int page, int size) {
+                                                String keyword, Long cursor, int size) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
@@ -213,16 +213,19 @@ public class UserService {
         LocalDateTime endDateTime = (endDate != null) ? endDate.plusDays(1).atStartOfDay() : null;
         String trimmedKeyword = (keyword != null && !keyword.isBlank()) ? keyword.trim() : null;
 
-        PageRequest pageRequest = PageRequest.of(page, size);
+        PageRequest pageRequest = PageRequest.of(0, size);
         Slice<Comment> commentSlice = (sortType == SortType.OLDEST)
-                ? commentRepository.searchMyCommentsOldest(user, startDateTime, endDateTime, trimmedKeyword, pageRequest)
-                : commentRepository.searchMyCommentsLatest(user, startDateTime, endDateTime, trimmedKeyword, pageRequest);
+                ? commentRepository.searchMyCommentsOldest(user, cursor, startDateTime, endDateTime, trimmedKeyword, pageRequest)
+                : commentRepository.searchMyCommentsLatest(user, cursor, startDateTime, endDateTime, trimmedKeyword, pageRequest);
 
         List<UserCommentSummaryResponse> comments = commentSlice.getContent().stream()
                 .map(UserConverter::toUserCommentSummaryResponse)
                 .toList();
 
-        return new MyCommentPageResponse(comments, null, commentSlice.hasNext());
+        Long nextCursor = commentSlice.hasNext()
+                ? commentSlice.getContent().get(commentSlice.getContent().size() - 1).getId()
+                : null;
+        return new MyCommentPageResponse(comments, nextCursor, commentSlice.hasNext());
     }
 
     /**

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -111,12 +111,16 @@ public class UserController {
 
     @GetMapping("/me/comments")
     @Operation(summary = "내가 쓴 댓글 목록", description = """
-            현재 로그인한 사용자가 작성한 댓글 목록을 조회합니다. 삭제된 댓글은 제외됩니다.
+            현재 로그인한 사용자가 작성한 댓글 목록을 커서 기반으로 조회합니다. 삭제된 댓글은 제외됩니다.
 
             **필터 파라미터** (모두 선택):
             - startDate, endDate: yyyy-MM-dd 형식 (예: 2024-01-01)
             - keyword: 댓글 내용 또는 게시글 제목 검색
             - sort: LATEST(최신순, 기본값) / OLDEST(오래된순)
+
+            **페이지네이션:**
+            - cursor: 다음 페이지 시작점 (이전 응답의 nextCursor 값)
+            - size: 한 페이지당 항목 수 (기본값 20)
             """)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 댓글 목록 조회 성공"),
@@ -128,11 +132,11 @@ public class UserController {
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false, defaultValue = "LATEST") SortType sort,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size
     ) {
         String email = userDetails.getUsername();
-        MyCommentPageResponse response = userService.getMyComments(email, sort, startDate, endDate, keyword, page, size);
+        MyCommentPageResponse response = userService.getMyComments(email, sort, startDate, endDate, keyword, cursor, size);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/fmi/domain/userblock/repository/BlockedUserRepository.java
+++ b/src/main/java/com/fmi/domain/userblock/repository/BlockedUserRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -15,6 +18,12 @@ public interface BlockedUserRepository extends JpaRepository<BlockedUser, Long> 
     boolean existsByBlockerAndBlocked(User blocker, User blocked);
     Optional<BlockedUser> findByBlockerAndBlocked(User blocker, User blocked);
     List<BlockedUser> findAllByBlocker(User blocker);
+
+    @Query("SELECT b FROM BlockedUser b JOIN FETCH b.blocked WHERE b.blocker = :blocker ORDER BY b.id DESC")
+    Slice<BlockedUser> findByBlockerOrderByIdDesc(@Param("blocker") User blocker, Pageable pageable);
+
+    @Query("SELECT b FROM BlockedUser b JOIN FETCH b.blocked WHERE b.blocker = :blocker AND b.id < :cursor ORDER BY b.id DESC")
+    Slice<BlockedUser> findByBlockerAndIdLessThanOrderByIdDesc(@Param("blocker") User blocker, @Param("cursor") Long cursor, Pageable pageable);
 
     @Query("SELECT b.blocked.id FROM BlockedUser b WHERE b.blocker.id = :blockerId")
     List<Long> findBlockedUserIdsByBlockerId(@Param("blockerId") Long blockerId);

--- a/src/main/java/com/fmi/domain/userblock/service/BlockService.java
+++ b/src/main/java/com/fmi/domain/userblock/service/BlockService.java
@@ -13,6 +13,10 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fmi.global.apiPayload.CursorPageResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
 import java.util.List;
 
 @Slf4j
@@ -68,6 +72,27 @@ public class BlockService {
                         bu.getBlocked().getProfile_img()
                 ))
                 .toList();
+    }
+
+    public CursorPageResponse<BlockedUserResponse> listWithUserInfoCursor(Long blockerUserId, Long cursor, int size) {
+        User blocker = userRepository.findActiveById(blockerUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        PageRequest pageRequest = PageRequest.of(0, size);
+        Slice<BlockedUser> slice = (cursor == null)
+                ? blockedUserRepository.findByBlockerOrderByIdDesc(blocker, pageRequest)
+                : blockedUserRepository.findByBlockerAndIdLessThanOrderByIdDesc(blocker, cursor, pageRequest);
+
+        List<BlockedUserResponse> content = slice.getContent().stream()
+                .map(bu -> new BlockedUserResponse(
+                        bu.getBlocked().getId(),
+                        bu.getBlocked().getNickname(),
+                        bu.getBlocked().getProfile_img()
+                ))
+                .toList();
+
+        Long nextCursor = slice.hasNext() ? slice.getContent().get(slice.getContent().size() - 1).getId() : null;
+        return new CursorPageResponse<>(content, nextCursor, slice.hasNext());
     }
 
     private void saveBlockIfNotExists(User blocker, User blocked) {


### PR DESCRIPTION
## 🧩 관련 이슈

- close #360 

## 🛠️ 작업 내용

- 차단 유저 목록, 내 댓글 목록 조회 API에 커서 기반 무한 스크롤을 적용합니다.
- 기존 차단 유저 목록은 전체 List 반환, 내 댓글 목록은 offset 기반이었으나 커서 방식으로 통일합니다.

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
