### PR TITLE
feat: 쿠키 생성에 Domain 설정 추가

### DIFF
--- a/src/main/java/com/fmi/domain/auth/web/controller/AuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/AuthController.java
@@ -261,6 +261,7 @@ public class AuthController {
                 .secure(cookieSecure)
                 .sameSite(cookieSameSite)
                 .path("/")
+                .domain("finditem.kr")
                 .maxAge(java.time.Duration.between(java.time.Instant.now(), expiration.toInstant()))
                 .build();
     }

--- a/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
@@ -155,6 +155,7 @@ public class KakaoAuthController {
                 .secure(cookieSecure)
                 .sameSite(cookieSameSite)
                 .path("/")
+                .domain("finditem.kr")
                 .maxAge(Duration.between(Instant.now(), accessExp.toInstant()))
                 .build();
 
@@ -164,6 +165,7 @@ public class KakaoAuthController {
                 .secure(cookieSecure)
                 .sameSite(cookieSameSite)
                 .path("/")
+                .domain("finditem.kr")
                 .maxAge(Duration.between(Instant.now(), refreshExp.toInstant()))
                 .build();
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close #368 

## 🛠️ 작업 내용

- 쿠키 Domain을 상위 도메인으로 설정하여 모든 서브도메인에서 공유되도록 하였습니다.

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
