### PR TITLE
fix: 쿠키 도메인 설정 기존으로 유지

### DIFF
--- a/src/main/java/com/fmi/domain/auth/web/controller/AuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/AuthController.java
@@ -261,7 +261,6 @@ public class AuthController {
                 .secure(cookieSecure)
                 .sameSite(cookieSameSite)
                 .path("/")
-                .domain("finditem.kr")
                 .maxAge(java.time.Duration.between(java.time.Instant.now(), expiration.toInstant()))
                 .build();
     }

--- a/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
@@ -155,7 +155,6 @@ public class KakaoAuthController {
                 .secure(cookieSecure)
                 .sameSite(cookieSameSite)
                 .path("/")
-                .domain("finditem.kr")
                 .maxAge(Duration.between(Instant.now(), accessExp.toInstant()))
                 .build();
 
@@ -165,7 +164,6 @@ public class KakaoAuthController {
                 .secure(cookieSecure)
                 .sameSite(cookieSameSite)
                 .path("/")
-                .domain("finditem.kr")
                 .maxAge(Duration.between(Instant.now(), refreshExp.toInstant()))
                 .build();
 


### PR DESCRIPTION
## 🧩 관련 이슈

- close #370 

## 🛠️ 작업 내용

- 로컬 프론트에서 테스트 안되는 문제로 쿠키 도메인 설정을 기존으로 유지합니다.

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
