### PR TITLE
fix: 내 댓글 조회 응답에 likeCount, isLike, imageList 누락 필드 추가

### DIFF
--- a/src/main/java/com/fmi/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/fmi/domain/user/converter/UserConverter.java
@@ -2,6 +2,7 @@ package com.fmi.domain.user.converter;
 
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.comment.data.Comment;
+import com.fmi.domain.comment.web.dto.response.CommentImageResponse;
 import com.fmi.domain.post.web.dto.response.PostBriefResponse;
 import com.fmi.domain.user.response.ImageUploadResponse;
 import com.fmi.domain.user.response.UserCommentSummaryResponse;
@@ -39,12 +40,16 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserCommentSummaryResponse toUserCommentSummaryResponse(Comment comment) {
+    public static UserCommentSummaryResponse toUserCommentSummaryResponse(
+            Comment comment, long likeCount, boolean isLike, List<CommentImageResponse> imageList) {
         return UserCommentSummaryResponse.builder()
                 .commentId(comment.getId())
                 .postId(comment.getPost().getId())
                 .postTitle(comment.getPost().getTitle())
                 .content(comment.getContent())
+                .likeCount(likeCount)
+                .isLike(isLike)
+                .imageList(imageList)
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/fmi/domain/user/response/UserCommentSummaryResponse.java
+++ b/src/main/java/com/fmi/domain/user/response/UserCommentSummaryResponse.java
@@ -1,11 +1,13 @@
 package com.fmi.domain.user.response;
 
+import com.fmi.domain.comment.web.dto.response.CommentImageResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -17,6 +19,9 @@ public class UserCommentSummaryResponse {
     private Long postId;
     private String postTitle;
     private String content;
+    private long likeCount;
+    private boolean isLike;
+    private List<CommentImageResponse> imageList;
     private LocalDateTime createdAt;
 }
 

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -8,6 +8,9 @@ import com.fmi.domain.auth.data.User;
 import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.comment.data.Comment;
 import com.fmi.domain.comment.repository.CommentRepository;
+import com.fmi.domain.comment.service.CommentImageService;
+import com.fmi.domain.comment.web.dto.response.CommentImageResponse;
+import com.fmi.domain.commentlike.service.CommentLikeService;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.data.PostType;
@@ -79,6 +82,8 @@ public class UserService {
     private final RefreshTokenStore refreshTokenStore;
     private final InquiryRepository inquiryRepository;
     private final ReportRepository reportRepository;
+    private final CommentLikeService commentLikeService;
+    private final CommentImageService commentImageService;
 
     /**
      * 내 정보 조회
@@ -148,8 +153,18 @@ public class UserService {
                             .toList();
                 }
 
+                List<Long> commentIds = commentList.stream().map(Comment::getId).toList();
+                Map<Long, Long> likeCountMap = commentLikeService.buildLikeCountMap(commentIds);
+                Set<Long> myLikeSet = commentLikeService.buildMyLikeSet(commentIds, me);
+                Map<Long, List<CommentImageResponse>> imageMap = commentImageService.buildImageMap(commentIds);
+
                 comments = commentList.stream()
-                        .map(UserConverter::toUserCommentSummaryResponse)
+                        .map(comment -> UserConverter.toUserCommentSummaryResponse(
+                                comment,
+                                likeCountMap.getOrDefault(comment.getId(), 0L),
+                                myLikeSet.contains(comment.getId()),
+                                imageMap.getOrDefault(comment.getId(), List.of())
+                        ))
                         .toList();
 
                 hasNext = commentSlice.hasNext();
@@ -218,12 +233,24 @@ public class UserService {
                 ? commentRepository.searchMyCommentsOldest(user, cursor, startDateTime, endDateTime, trimmedKeyword, pageRequest)
                 : commentRepository.searchMyCommentsLatest(user, cursor, startDateTime, endDateTime, trimmedKeyword, pageRequest);
 
-        List<UserCommentSummaryResponse> comments = commentSlice.getContent().stream()
-                .map(UserConverter::toUserCommentSummaryResponse)
+        List<Comment> commentList = commentSlice.getContent();
+        List<Long> commentIds = commentList.stream().map(Comment::getId).toList();
+
+        Map<Long, Long> likeCountMap = commentLikeService.buildLikeCountMap(commentIds);
+        Set<Long> myLikeSet = commentLikeService.buildMyLikeSet(commentIds, user);
+        Map<Long, List<CommentImageResponse>> imageMap = commentImageService.buildImageMap(commentIds);
+
+        List<UserCommentSummaryResponse> comments = commentList.stream()
+                .map(comment -> UserConverter.toUserCommentSummaryResponse(
+                        comment,
+                        likeCountMap.getOrDefault(comment.getId(), 0L),
+                        myLikeSet.contains(comment.getId()),
+                        imageMap.getOrDefault(comment.getId(), List.of())
+                ))
                 .toList();
 
         Long nextCursor = commentSlice.hasNext()
-                ? commentSlice.getContent().get(commentSlice.getContent().size() - 1).getId()
+                ? commentList.get(commentList.size() - 1).getId()
                 : null;
         return new MyCommentPageResponse(comments, nextCursor, commentSlice.hasNext());
     }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #372

## 🛠️ 작업 내용

- 내 댓글 조회 응답에 likeCount, isLike, imageList 누락 필드 추가

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
