### PR TITLE
fix: SSE 재연결 시 미읽은 알림 자동 전송

### DIFF
--- a/src/main/java/com/fmi/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fmi/domain/notification/service/NotificationService.java
@@ -96,6 +96,18 @@ public class NotificationService {
     public Long getUnreadCount(User user) {
         return notificationRepository.countByUserAndIsReadFalse(user);
     }
+
+    /**
+     * 읽지 않은 알림 DTO 목록 조회 (SSE 재연결 시 전송용, 최대 50건)
+     */
+    @Transactional(readOnly = true)
+    public List<NotificationListDTO> getUnreadNotificationDTOs(User user) {
+        Pageable limit = PageRequest.of(0, 50);
+        List<Notification> unread = notificationRepository.findByUserAndIsReadFalseCursor(user, null, limit);
+        return unread.stream()
+                .map(notificationConverter::toListDTO)
+                .toList();
+    }
     
     /**
      * 알림 읽음 처리

--- a/src/main/java/com/fmi/domain/notification/service/SseEmitterService.java
+++ b/src/main/java/com/fmi/domain/notification/service/SseEmitterService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -79,6 +80,31 @@ public class SseEmitterService {
             emitters.remove(userId);
             emitter.completeWithError(e);
         }
+    }
+
+    public void sendUnreadNotifications(Long userId, List<?> unreadNotifications) {
+        if (unreadNotifications == null || unreadNotifications.isEmpty()) {
+            return;
+        }
+
+        SseEmitter emitter = emitters.get(userId);
+        if (emitter == null) {
+            return;
+        }
+
+        for (Object notification : unreadNotifications) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("notification")
+                        .data(notification));
+            } catch (IOException e) {
+                log.error("SSE 미읽은 알림 전송 실패: userId={}", userId, e);
+                emitters.remove(userId);
+                emitter.completeWithError(e);
+                return;
+            }
+        }
+        log.info("SSE 미읽은 알림 {} 건 전송: userId={}", unreadNotifications.size(), userId);
     }
 
     public void disconnect(Long userId) {

--- a/src/main/java/com/fmi/domain/notification/web/controller/NotificationController.java
+++ b/src/main/java/com/fmi/domain/notification/web/controller/NotificationController.java
@@ -43,6 +43,7 @@ public class NotificationController {
     @GetMapping(value = "/subscribe", produces = "text/event-stream")
     @Operation(summary = "실시간 알림 구독 (SSE)",
                description = "Server-Sent Events를 통해 실시간으로 알림을 수신합니다. " +
+                           "연결 시 미읽은 알림을 자동으로 전송합니다. " +
                            "연결이 끊기면 클라이언트에서 자동으로 재연결해야 합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SSE 연결 성공")
@@ -50,7 +51,13 @@ public class NotificationController {
     public SseEmitter subscribe(@AuthenticationPrincipal UserDetails userDetails) {
         User user = userRepository.findByEmail(userDetails.getUsername())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
-        return sseEmitterService.subscribe(user.getId());
+        SseEmitter emitter = sseEmitterService.subscribe(user.getId());
+
+        // 재연결 시 미읽은 알림 전송
+        sseEmitterService.sendUnreadNotifications(user.getId(),
+                notificationService.getUnreadNotificationDTOs(user));
+
+        return emitter;
     }
 
     /**


### PR DESCRIPTION
## 🧩 관련 이슈

- close #373

## 🛠️ 작업 내용

- SSE 재연결 시 미읽은 알림 자동 전송

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
