### PR TITLE
fix: Post 상세 조회시 조회수 count 하는 로직 수정 

### DIFF
--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -20,7 +20,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     Optional<Post> findByIdAndDeletedFalse(Long id);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying(flushAutomatically = true)
     @Query("update Post p set p.viewCount = p.viewCount + 1 where p.id = :postId and p.deleted = false")
     void increaseViewCount(@Param("postId") Long postId);
 

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -86,7 +86,12 @@ public class PostQueryService {
             }
 
         } else {
-            canIncreaseViewCount = canIncreaseViewCount(postId, clientIp);
+            try {
+                canIncreaseViewCount = canIncreaseViewCount(postId, clientIp);
+            } catch (Exception e) {
+                log.warn("비회원 조회수 처리 실패", e);
+                canIncreaseViewCount = false;
+            }
         }
 
         long viewCount = post.getViewCount();
@@ -121,6 +126,9 @@ public class PostQueryService {
     }
 
     private boolean canIncreaseViewCount(Long postId, String clientIp) {
+        if (Objects.isNull(clientIp) || clientIp.isBlank() || "unknown".equalsIgnoreCase(clientIp)) {
+            return false;
+        }
         return isFirstToday(postId, "not-user", IpUtil.hashIp(clientIp));
     }
 
@@ -272,9 +280,9 @@ public class PostQueryService {
 
     @Transactional(readOnly = true)
     public PostPageResponse getFavoritePost(UserDetails userDetails, PostType postType,
-                                             Category category, String address,
-                                             String keyword, SortType sortType,
-                                             Long cursor, int size) {
+                                            Category category, String address,
+                                            String keyword, SortType sortType,
+                                            Long cursor, int size) {
         User user = userQueryService.findUser(userDetails.getUsername());
 
         return postRepository.searchMyFavorites(user.getId(), postType, category, address, keyword, sortType, cursor, size);


### PR DESCRIPTION
## 🧩 관련 이슈

- close #393 

## 🛠️ 작업 내용
post 상세 조회 api 에서 비회원일때 view count 하는 로직 방어 코드 추가 및 JPQL 영속성 컨텍스트 clear 하는 설정 제거

- [x] 방어 코드 추가
- [x] JPQL 설정 제거

## 📢 참고 및 특이사항



## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
