### PR TITLE
feat: 메인페이지 Map API 수정, 추가

### DIFF
--- a/src/main/java/com/fmi/domain/map/enums/MapLevel.java
+++ b/src/main/java/com/fmi/domain/map/enums/MapLevel.java
@@ -8,10 +8,10 @@ import java.util.Arrays;
 
 public enum MapLevel {
 
-    LEVEL_1(1, 50),
-    LEVEL_2(2, 100),
-    LEVEL_3(3, 200),
-    LEVEL_4(4, 400),
+    LEVEL_1(1, 75),
+    LEVEL_2(2, 150),
+    LEVEL_3(3, 300),
+    LEVEL_4(4, 500),
     LEVEL_5(5, 800),
     LEVEL_6(6, 1_500),
     LEVEL_7(7, 3_000),

--- a/src/main/java/com/fmi/domain/map/enums/MapLevel.java
+++ b/src/main/java/com/fmi/domain/map/enums/MapLevel.java
@@ -8,17 +8,17 @@ import java.util.Arrays;
 
 public enum MapLevel {
 
-    LEVEL_1(1, 20),
-    LEVEL_2(2, 30),
-    LEVEL_3(3, 50),
-    LEVEL_4(4, 100),
-    LEVEL_5(5, 250),
-    LEVEL_6(6, 500),
-    LEVEL_7(7, 1_000),
-    LEVEL_8(8, 2_000),
-    LEVEL_9(9, 4_000),
-    LEVEL_10(10, 8_000),
-    LEVEL_11(11, 16_000);
+    LEVEL_1(1, 50),
+    LEVEL_2(2, 100),
+    LEVEL_3(3, 200),
+    LEVEL_4(4, 400),
+    LEVEL_5(5, 800),
+    LEVEL_6(6, 1_500),
+    LEVEL_7(7, 3_000),
+    LEVEL_8(8, 6_000),
+    LEVEL_9(9, 12_000),
+    LEVEL_10(10, 25_000),
+    LEVEL_11(11, 50_000);
 
     private final int level;
 

--- a/src/main/java/com/fmi/domain/map/repository/PostMapCustom.java
+++ b/src/main/java/com/fmi/domain/map/repository/PostMapCustom.java
@@ -1,6 +1,7 @@
 package com.fmi.domain.map.repository;
 
 import com.fmi.domain.Enum.Category;
+import com.fmi.domain.map.web.dto.response.MapPostPageResponse;
 import com.fmi.domain.map.web.dto.response.MapPostResponse;
 import com.fmi.domain.map.web.dto.response.PostMarkerResponse;
 import com.fmi.domain.map.web.dto.response.RecentFoundPostResponse;
@@ -19,16 +20,18 @@ public interface PostMapCustom {
             Set<Long> excludedUserIds
     );
 
-    List<MapPostResponse> findMapPosts(double lat,
-                                       double lng,
-                                       int radiusMeter,
-                                       PostType postType,
-                                       PostStatus postStatus,
-                                       Category category,
-                                       String keyword,
-                                       Long userId,
-                                       Set<Long> excludedUserIds,
-                                       Set<Long> hotPostIds
+    MapPostPageResponse findMapPosts(double lat,
+                                     double lng,
+                                     int radiusMeter,
+                                     PostType postType,
+                                     PostStatus postStatus,
+                                     Category category,
+                                     String keyword,
+                                     Long userId,
+                                     Set<Long> excludedUserIds,
+                                     Set<Long> hotPostIds,
+                                     Double lastDistance,
+                                     Long lastPostId
     );
 
     List<RecentFoundPostResponse> findRecentFoundPostList(double lat,

--- a/src/main/java/com/fmi/domain/map/repository/PostMapCustom.java
+++ b/src/main/java/com/fmi/domain/map/repository/PostMapCustom.java
@@ -1,10 +1,7 @@
 package com.fmi.domain.map.repository;
 
 import com.fmi.domain.Enum.Category;
-import com.fmi.domain.map.web.dto.response.MapPostPageResponse;
-import com.fmi.domain.map.web.dto.response.MapPostResponse;
-import com.fmi.domain.map.web.dto.response.PostMarkerResponse;
-import com.fmi.domain.map.web.dto.response.RecentFoundPostResponse;
+import com.fmi.domain.map.web.dto.response.*;
 import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.data.PostType;
 
@@ -39,4 +36,16 @@ public interface PostMapCustom {
                                                           int radiusMeter,
                                                           Set<Long> excludedUserIds
     );
+
+    LocationMapPostPageResponse searchMapPostsByLocation(double lat,
+                                                         double lng,
+                                                         int radiusMeter,
+                                                         PostType postType,
+                                                         PostStatus postStatus,
+                                                         Category category,
+                                                         Long userId,
+                                                         Set<Long> excludedUserIds,
+                                                         Set<Long> hotPostIds,
+                                                         Double lastDistance,
+                                                         Long lastPostId);
 }

--- a/src/main/java/com/fmi/domain/map/repository/PostMapCustomImpl.java
+++ b/src/main/java/com/fmi/domain/map/repository/PostMapCustomImpl.java
@@ -1,10 +1,7 @@
 package com.fmi.domain.map.repository;
 
 import com.fmi.domain.Enum.Category;
-import com.fmi.domain.map.web.dto.response.MapPostPageResponse;
-import com.fmi.domain.map.web.dto.response.MapPostResponse;
-import com.fmi.domain.map.web.dto.response.PostMarkerResponse;
-import com.fmi.domain.map.web.dto.response.RecentFoundPostResponse;
+import com.fmi.domain.map.web.dto.response.*;
 import com.fmi.domain.post.data.*;
 import com.fmi.domain.postfavorite.data.QPostFavorite;
 import com.querydsl.core.BooleanBuilder;
@@ -318,5 +315,184 @@ public class PostMapCustomImpl implements PostMapCustom {
                 .orderBy(p.createdAt.desc(), p.id.desc())
                 .limit(10)
                 .fetch();
+    }
+
+    @Override
+    public LocationMapPostPageResponse searchMapPostsByLocation(double lat,
+                                                                double lng,
+                                                                int radiusMeter,
+                                                                PostType postType,
+                                                                PostStatus postStatus,
+                                                                Category category,
+                                                                Long userId,
+                                                                Set<Long> excludedUserIds,
+                                                                Set<Long> hotPostIds,
+                                                                Double lastDistance,
+                                                                Long lastPostId) {
+
+        QPost post = QPost.post;
+        QPostFavorite postFavorite = QPostFavorite.postFavorite;
+        QPostImage postImage = QPostImage.postImage;
+
+        double latDelta = radiusMeter / 111_320.0;
+        double lngDelta = radiusMeter / (111_320.0 * Math.cos(Math.toRadians(lat)));
+
+        double minLat = lat - latDelta;
+        double maxLat = lat + latDelta;
+        double minLng = lng - lngDelta;
+        double maxLng = lng + lngDelta;
+
+        NumberExpression<Double> distanceMeter = Expressions.numberTemplate(
+                Double.class,
+                "ST_Distance_Sphere(POINT({0},{1}), POINT({2},{3}))",
+                post.longitude, post.latitude,
+                lng, lat
+        );
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(post.deleted.isFalse());
+        where.and(post.temporarySave.isFalse());
+        where.and(post.latitude.isNotNull());
+        where.and(post.longitude.isNotNull());
+        where.and(post.latitude.between(minLat, maxLat));
+        where.and(post.longitude.between(minLng, maxLng));
+        where.and(distanceMeter.loe((double) radiusMeter));
+
+        if (postType != null) {
+            where.and(post.postType.eq(postType));
+        }
+        if (postStatus != null) {
+            where.and(post.postStatus.eq(postStatus));
+        }
+        if (category != null) {
+            where.and(post.category.eq(category));
+        }
+
+        if (excludedUserIds != null && !excludedUserIds.isEmpty()) {
+            where.and(post.user.id.notIn(excludedUserIds));
+        }
+
+        if (lastDistance != null && lastPostId != null) {
+            where.and(
+                    distanceMeter.gt(lastDistance)
+                            .or(distanceMeter.eq(lastDistance).and(post.id.lt(lastPostId)))
+            );
+        }
+
+        List<Tuple> tuples = jpaQueryFactory
+                .select(post, distanceMeter)
+                .from(post)
+                .where(where)
+                .orderBy(distanceMeter.asc(), post.id.desc())
+                .limit(MAP_CARD_PAGE_SIZE + 1)
+                .fetch();
+
+        boolean hasNext = tuples.size() > MAP_CARD_PAGE_SIZE;
+        if (hasNext) {
+            tuples = tuples.subList(0, MAP_CARD_PAGE_SIZE);
+        }
+
+        List<Post> posts = tuples.stream()
+                .map(tuple -> tuple.get(post))
+                .toList();
+
+        if (posts.isEmpty()) {
+            return new LocationMapPostPageResponse(List.of(), false, null, null);
+        }
+
+        Double nextDistance = null;
+        Long nextPostId = null;
+
+        if (hasNext) {
+            Tuple lastTuple = tuples.get(tuples.size() - 1);
+            nextDistance = lastTuple.get(distanceMeter);
+            nextPostId = Objects.requireNonNull(lastTuple.get(post)).getId();
+        }
+
+        List<Long> postIdList = posts.stream()
+                .map(Post::getId)
+                .toList();
+
+        Map<Long, String> thumbnailMap = jpaQueryFactory
+                .select(postImage.post.id, postImage.imgUrl)
+                .from(postImage)
+                .where(
+                        postImage.post.id.in(postIdList),
+                        postImage.imageType.eq(ImageType.THUMBNAIL)
+                )
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> Objects.requireNonNull(t.get(postImage.post.id)),
+                        t -> Objects.requireNonNull(t.get(postImage.imgUrl)),
+                        (a, b) -> a
+                ));
+
+        Map<Long, Long> favoriteCountMap = jpaQueryFactory
+                .select(postFavorite.post.id, postFavorite.favorite_id.count())
+                .from(postFavorite)
+                .where(
+                        postFavorite.post.id.in(postIdList),
+                        postFavorite.isFavorite.isTrue()
+                )
+                .groupBy(postFavorite.post.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> Objects.requireNonNull(t.get(postFavorite.post.id)),
+                        t -> Objects.requireNonNull(t.get(postFavorite.favorite_id.count()))
+                ));
+
+        Set<Long> myFavoritePostIds = userId == null ? Set.of() :
+                new HashSet<>(
+                        jpaQueryFactory
+                                .select(postFavorite.post.id)
+                                .from(postFavorite)
+                                .where(
+                                        postFavorite.user.id.eq(userId),
+                                        postFavorite.post.id.in(postIdList),
+                                        postFavorite.isFavorite.isTrue()
+                                )
+                                .fetch()
+                );
+
+        Map<Long, Integer> imageCountMap = jpaQueryFactory
+                .select(postImage.post.id, postImage.id.count())
+                .from(postImage)
+                .where(postImage.post.id.in(postIdList))
+                .groupBy(postImage.post.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> Objects.requireNonNull(t.get(postImage.post.id)),
+                        t -> Objects.requireNonNull(t.get(postImage.id.count())).intValue()
+                ));
+
+        List<MapPostResponse> content = posts.stream()
+                .map(p -> {
+                    Long pid = p.getId();
+                    boolean isHot = hotPostIds != null && hotPostIds.contains(pid);
+
+                    return new MapPostResponse(
+                            pid,
+                            p.getTitle(),
+                            p.makeSummary(),
+                            thumbnailMap.get(pid),
+                            p.getAddress(),
+                            p.getPostStatus(),
+                            p.getPostType(),
+                            p.getCategory(),
+                            favoriteCountMap.getOrDefault(pid, 0L),
+                            myFavoritePostIds.contains(pid),
+                            p.getViewCount(),
+                            p.isNew(),
+                            isHot,
+                            p.getCreatedAt(),
+                            imageCountMap.getOrDefault(pid, 0)
+                    );
+                })
+                .toList();
+
+        return new LocationMapPostPageResponse(content, hasNext, nextDistance, nextPostId);
     }
 }

--- a/src/main/java/com/fmi/domain/map/repository/PostMapCustomImpl.java
+++ b/src/main/java/com/fmi/domain/map/repository/PostMapCustomImpl.java
@@ -1,12 +1,14 @@
 package com.fmi.domain.map.repository;
 
 import com.fmi.domain.Enum.Category;
+import com.fmi.domain.map.web.dto.response.MapPostPageResponse;
 import com.fmi.domain.map.web.dto.response.MapPostResponse;
 import com.fmi.domain.map.web.dto.response.PostMarkerResponse;
 import com.fmi.domain.map.web.dto.response.RecentFoundPostResponse;
 import com.fmi.domain.post.data.*;
 import com.fmi.domain.postfavorite.data.QPostFavorite;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
@@ -21,6 +23,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PostMapCustomImpl implements PostMapCustom {
     private final JPAQueryFactory jpaQueryFactory;
+
+    private static final int MAP_CARD_PAGE_SIZE = 10;
 
     @Override
     public List<PostMarkerResponse> findPostMaker(double lat,
@@ -72,16 +76,18 @@ public class PostMapCustomImpl implements PostMapCustom {
     }
 
     @Override
-    public List<MapPostResponse> findMapPosts(double lat,
-                                              double lng,
-                                              int radiusMeter,
-                                              PostType postType,
-                                              PostStatus postStatus,
-                                              Category category,
-                                              String keyword,
-                                              Long userId,
-                                              Set<Long> excludedUserIds,
-                                              Set<Long> hotPostIds) {
+    public MapPostPageResponse findMapPosts(double lat,
+                                            double lng,
+                                            int radiusMeter,
+                                            PostType postType,
+                                            PostStatus postStatus,
+                                            Category category,
+                                            String keyword,
+                                            Long userId,
+                                            Set<Long> excludedUserIds,
+                                            Set<Long> hotPostIds,
+                                            Double lastDistance,
+                                            Long lastPostId) {
 
         QPost post = QPost.post;
         QPostFavorite postFavorite = QPostFavorite.postFavorite;
@@ -128,21 +134,50 @@ public class PostMapCustomImpl implements PostMapCustom {
                             .or(post.content.containsIgnoreCase(keyword))
             );
         }
+
         if (excludedUserIds != null && !excludedUserIds.isEmpty()) {
             where.and(post.user.id.notIn(excludedUserIds));
         }
 
-        List<Post> posts = jpaQueryFactory
-                .selectFrom(post)
-                .where(where)
-                .orderBy(distanceMeter.asc(), post.id.desc())
-                .fetch();
-
-        if (posts.isEmpty()) {
-            return List.of();
+        if (Objects.nonNull(lastDistance) && Objects.nonNull(lastPostId)) {
+            where.and(distanceMeter.gt(lastDistance).or(distanceMeter.eq(lastDistance).and(post.id.lt(lastPostId))));
         }
 
-        List<Long> postIdList = posts.stream().map(Post::getId).toList();
+        List<Tuple> tuples = jpaQueryFactory
+                .select(post, distanceMeter)
+                .from(post)
+                .where(where)
+                .orderBy(distanceMeter.asc(), post.id.desc())
+                .limit(MAP_CARD_PAGE_SIZE + 1)
+                .fetch();
+
+        boolean hasNext = tuples.size() > MAP_CARD_PAGE_SIZE;
+
+        if (hasNext) {
+            tuples = tuples.subList(0, MAP_CARD_PAGE_SIZE);
+        }
+
+        List<Post> posts = tuples.stream()
+                .map(tuple -> tuple.get(post))
+                .toList();
+
+        if (posts.isEmpty()) {
+            return new MapPostPageResponse(List.of(), false, null, null);
+        }
+
+        Double nextDistance = null;
+        Long nextPostId = null;
+
+        if (hasNext) {
+            Tuple lastTuple = tuples.get(tuples.size() - 1);
+            nextDistance = lastTuple.get(distanceMeter);
+            nextPostId = lastTuple.get(post).getId();
+        }
+
+
+        List<Long> postIdList = posts.stream()
+                .map(Post::getId)
+                .toList();
 
         Map<Long, String> thumbnailMap = jpaQueryFactory
                 .select(postImage.post.id, postImage.imgUrl)
@@ -200,7 +235,7 @@ public class PostMapCustomImpl implements PostMapCustom {
                 ));
 
 
-        return posts.stream()
+        List<MapPostResponse> content = posts.stream()
                 .map(p -> {
                     Long pid = p.getId();
                     boolean isHot = hotPostIds != null && hotPostIds.contains(pid);
@@ -224,6 +259,8 @@ public class PostMapCustomImpl implements PostMapCustom {
                     );
                 })
                 .toList();
+
+        return new MapPostPageResponse(content, hasNext, nextDistance, nextPostId);
     }
 
     @Override

--- a/src/main/java/com/fmi/domain/map/service/PostMapService.java
+++ b/src/main/java/com/fmi/domain/map/service/PostMapService.java
@@ -2,9 +2,11 @@ package com.fmi.domain.map.service;
 
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.map.enums.MapLevel;
+import com.fmi.domain.map.web.dto.request.LocationMapPostRequest;
 import com.fmi.domain.map.web.dto.request.MapPostRequest;
 import com.fmi.domain.map.web.dto.request.PostMarkerRequest;
 import com.fmi.domain.map.web.dto.request.RecentFoundPostRequest;
+import com.fmi.domain.map.web.dto.response.MapPostPageResponse;
 import com.fmi.domain.map.web.dto.response.MapPostResponse;
 import com.fmi.domain.map.web.dto.response.PostMarkerResponse;
 import com.fmi.domain.map.web.dto.response.RecentFoundPostResponse;
@@ -12,6 +14,7 @@ import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.post.service.HotPostService;
 import com.fmi.domain.post.service.PostQueryService;
+import com.fmi.domain.post.web.dto.response.PostBriefResponse;
 import com.fmi.domain.userblock.repository.BlockedUserRepository;
 import com.fmi.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +22,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.xml.stream.Location;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -69,7 +73,11 @@ public class PostMapService {
     }
 
     @Transactional(readOnly = true)
-    public List<MapPostResponse> getPostMap(Long postId, MapPostRequest request, UserDetails userDetails) {
+    public MapPostPageResponse getPostMap(Long postId,
+                                          MapPostRequest request,
+                                          Double lastDistance,
+                                          Long lastPostId,
+                                          UserDetails userDetails) {
         MapLevel mapLevel = MapLevel.from(request.level());
         int radiusMeter = mapLevel.getRadiusMeter();
 
@@ -97,7 +105,9 @@ public class PostMapService {
                 request.keyword(),
                 Objects.nonNull(user) ? user.getId() : null,
                 excludedUserIds,
-                hotPostIds
+                hotPostIds,
+                lastDistance,
+                lastPostId
         );
     }
 

--- a/src/main/java/com/fmi/domain/map/service/PostMapService.java
+++ b/src/main/java/com/fmi/domain/map/service/PostMapService.java
@@ -6,10 +6,7 @@ import com.fmi.domain.map.web.dto.request.LocationMapPostRequest;
 import com.fmi.domain.map.web.dto.request.MapPostRequest;
 import com.fmi.domain.map.web.dto.request.PostMarkerRequest;
 import com.fmi.domain.map.web.dto.request.RecentFoundPostRequest;
-import com.fmi.domain.map.web.dto.response.MapPostPageResponse;
-import com.fmi.domain.map.web.dto.response.MapPostResponse;
-import com.fmi.domain.map.web.dto.response.PostMarkerResponse;
-import com.fmi.domain.map.web.dto.response.RecentFoundPostResponse;
+import com.fmi.domain.map.web.dto.response.*;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.post.service.HotPostService;
@@ -103,6 +100,41 @@ public class PostMapService {
                 request.postStatus(),
                 request.category(),
                 request.keyword(),
+                Objects.nonNull(user) ? user.getId() : null,
+                excludedUserIds,
+                hotPostIds,
+                lastDistance,
+                lastPostId
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public LocationMapPostPageResponse searchPostsByLocation(LocationMapPostRequest request,
+                                                             Double lastDistance,
+                                                             Long lastPostId,
+                                                             UserDetails userDetails) {
+        MapLevel mapLevel = MapLevel.from(request.level());
+        int radiusMeter = mapLevel.getRadiusMeter();
+
+        User user = userQueryService.findUserIfNullReturnNull(userDetails);
+        Set<Long> excludedUserIds = getExcludedUserIds(user);
+
+        Set<Long> hotPostIds = hotPostService.resolveHotPostIdsForUser(
+                request.postType(),
+                request.postStatus(),
+                request.category(),
+                null,
+                user != null ? user.getId() : null,
+                20
+        );
+
+        return postRepository.searchMapPostsByLocation(
+                request.latitude(),
+                request.longitude(),
+                radiusMeter,
+                request.postType(),
+                request.postStatus(),
+                request.category(),
                 Objects.nonNull(user) ? user.getId() : null,
                 excludedUserIds,
                 hotPostIds,

--- a/src/main/java/com/fmi/domain/map/web/controller/MapController.java
+++ b/src/main/java/com/fmi/domain/map/web/controller/MapController.java
@@ -4,6 +4,8 @@ import com.fmi.domain.map.service.PostMapService;
 import com.fmi.domain.map.web.dto.request.MapPostRequest;
 import com.fmi.domain.map.web.dto.request.PostMarkerRequest;
 import com.fmi.domain.map.web.dto.request.RecentFoundPostRequest;
+import com.fmi.domain.map.web.dto.request.LocationMapPostRequest;
+import com.fmi.domain.map.web.dto.response.MapPostPageResponse;
 import com.fmi.domain.map.web.dto.response.MapPostResponse;
 import com.fmi.domain.map.web.dto.response.PostMarkerResponse;
 import com.fmi.domain.map.web.dto.response.RecentFoundPostResponse;
@@ -95,7 +97,7 @@ public class MapController {
     @Operation(
             summary = "최근 습득된 분실물 조회",
             description = """
-                    지도 중심 좌표와 level을 기준으로 반경 내에서 
+                    지도 중심 좌표와 level을 기준으로 반경 내에서
                     최근 습득된 분실물 게시글 10개를 조회합니다.
                     
                     - 지도 범위내 게시글만 조회됩니다.
@@ -157,14 +159,14 @@ public class MapController {
     @Operation(
             summary = "지도 게시글 카드 리스트 조회",
             description = """
-                지도에서 특정 게시글 마커를 클릭했을 때 주변 게시글 카드 리스트를 조회합니다.
-                
-                - 기준 게시글의 위치를 중심으로 주변 게시글을 조회합니다.
-                - 지도 레벨(level)에 따라 검색 반경이 결정됩니다.
-                - 거리순으로 정렬됩니다.
-                - 필터(postType, postStatus, category, keyword)를 적용할 수 있습니다.
-                - 로그인 사용자인 경우 차단된 유저의 게시글은 제외됩니다.
-                """
+                    지도에서 특정 게시글 마커를 클릭했을 때 주변 게시글 카드 리스트를 조회합니다.
+                    
+                    - 기준 게시글의 위치를 중심으로 주변 게시글을 조회합니다.
+                    - 지도 레벨(level)에 따라 검색 반경이 결정됩니다.
+                    - 거리순으로 정렬됩니다.
+                    - 필터(postType, postStatus, category, keyword)를 적용할 수 있습니다.
+                    - 로그인 사용자인 경우 차단된 유저의 게시글은 제외됩니다.
+                    """
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -174,31 +176,31 @@ public class MapController {
                             mediaType = "application/json",
                             examples = @ExampleObject(
                                     value = """
-                                        {
-                                          "isSuccess": true,
-                                          "code": "COMMON200",
-                                          "message": "성공",
-                                          "result": [
                                             {
-                                              "id": 12,
-                                              "title": "지갑을 습득했습니다",
-                                              "summary": "검정색 지갑을 발견했습니다.",
-                                              "thumbnailImageUrl": "https://image-url.com/1.jpg",
-                                              "address": "서울시 중구 명동",
-                                              "postStatus": "SEARCHING",
-                                              "postType": "FOUND",
-                                              "category": "WALLET",
-                                              "favoriteCount": 4,
-                                              "favoriteStatus": false,
-                                              "viewCount": 120,
-                                              "isNew": true,
-                                              "isHot": false,
-                                              "createdAt": "2026-02-20T14:32:10",
-                                              "imageCount": 3
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "성공",
+                                              "result": [
+                                                {
+                                                  "id": 12,
+                                                  "title": "지갑을 습득했습니다",
+                                                  "summary": "검정색 지갑을 발견했습니다.",
+                                                  "thumbnailImageUrl": "https://image-url.com/1.jpg",
+                                                  "address": "서울시 중구 명동",
+                                                  "postStatus": "SEARCHING",
+                                                  "postType": "FOUND",
+                                                  "category": "WALLET",
+                                                  "favoriteCount": 4,
+                                                  "favoriteStatus": false,
+                                                  "viewCount": 120,
+                                                  "isNew": true,
+                                                  "isHot": false,
+                                                  "createdAt": "2026-02-20T14:32:10",
+                                                  "imageCount": 3
+                                                }
+                                              ]
                                             }
-                                          ]
-                                        }
-                                        """
+                                            """
                             )
                     )
             ),
@@ -218,12 +220,21 @@ public class MapController {
                     content = @Content
             )
     })
-    public ResponseEntity<ApiResponse<List<MapPostResponse>>> getPostsSummary(@PathVariable Long postId,
-                                                                              @ModelAttribute @Valid MapPostRequest request,
-                                                                              @AuthenticationPrincipal UserDetails userDetails) {
-        List<MapPostResponse> response = postMapService.getPostMap(postId, request, userDetails);
+    public ResponseEntity<ApiResponse<MapPostPageResponse>> getPostsSummary(@PathVariable Long postId,
+                                                                            @ModelAttribute @Valid MapPostRequest request,
+                                                                            @RequestParam(required = false) Double lastDistance,
+                                                                            @RequestParam(required = false) Long lastPostId,
+                                                                            @AuthenticationPrincipal UserDetails userDetails) {
+        MapPostPageResponse response = postMapService.getPostMap(postId, request, lastDistance, lastPostId, userDetails);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @GetMapping("/search/location")
+    public ResponseEntity<Void> searchPostsByLocation(@ModelAttribute @Valid LocationMapPostRequest request,
+                                                      @AuthenticationPrincipal UserDetails userDetails) {
+
+        return null;
     }
 
 }

--- a/src/main/java/com/fmi/domain/map/web/controller/MapController.java
+++ b/src/main/java/com/fmi/domain/map/web/controller/MapController.java
@@ -5,14 +5,13 @@ import com.fmi.domain.map.web.dto.request.MapPostRequest;
 import com.fmi.domain.map.web.dto.request.PostMarkerRequest;
 import com.fmi.domain.map.web.dto.request.RecentFoundPostRequest;
 import com.fmi.domain.map.web.dto.request.LocationMapPostRequest;
-import com.fmi.domain.map.web.dto.response.MapPostPageResponse;
-import com.fmi.domain.map.web.dto.response.MapPostResponse;
-import com.fmi.domain.map.web.dto.response.PostMarkerResponse;
-import com.fmi.domain.map.web.dto.response.RecentFoundPostResponse;
+import com.fmi.domain.map.web.dto.response.*;
 import com.fmi.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -230,11 +229,93 @@ public class MapController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @GetMapping("/search/location")
-    public ResponseEntity<Void> searchPostsByLocation(@ModelAttribute @Valid LocationMapPostRequest request,
-                                                      @AuthenticationPrincipal UserDetails userDetails) {
+    @GetMapping("/search-location")
+    @Operation(
+            summary = "위치 기반 게시글 검색 (무한 스크롤)",
+            description = """
+                    지도 중심 좌표(latitude, longitude)와 지도 레벨(level)을 기준으로
+                    반경 내 게시글을 조회합니다.
+                    
+                    - 지도 레벨(level)에 따라 검색 반경이 결정됩니다.
+                    - 거리순(distance ASC, postId DESC)으로 정렬됩니다.
+                    - 게시글 타입(postType), 게시글 상태(postStatus), 카테고리(category) 필터를 적용할 수 있습니다.
+                    - 로그인 사용자인 경우 차단 유저의 게시글은 제외됩니다.
+                    - 첫 요청은 lastDistance, lastPostId 없이 호출합니다.
+                    - 이후 응답의 nextDistance, nextPostId를 다음 요청에 전달합니다.
+                    
+                    예)
+                    - 첫 요청:
+                      /main/posts/search-location?latitude=37.5665&longitude=126.9780&level=5
+                    - 다음 요청:
+                      /main/posts/search-location?latitude=37.5665&longitude=126.9780&level=5&lastDistance=152.4&lastPostId=12
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "위치 기반 게시글 검색 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = LocationMapPostPageResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "성공",
+                                              "result": {
+                                                "posts": [
+                                                  {
+                                                    "id": 12,
+                                                    "title": "지갑을 습득했습니다",
+                                                    "summary": "검정색 지갑을 발견했습니다.",
+                                                    "thumbnailImageUrl": "https://image-url.com/1.jpg",
+                                                    "address": "서울시 중구 명동",
+                                                    "postStatus": "SEARCHING",
+                                                    "postType": "FOUND",
+                                                    "category": "WALLET",
+                                                    "favoriteCount": 4,
+                                                    "favoriteStatus": false,
+                                                    "viewCount": 120,
+                                                    "isNew": true,
+                                                    "isHot": false,
+                                                    "createdAt": "2026-02-20T14:32:10",
+                                                    "imageCount": 3
+                                                  }
+                                                ],
+                                                "hasNext": true,
+                                                "nextDistance": 152.4,
+                                                "nextPostId": 12
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "COMMON400: 잘못된 요청입니다.",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "COMMON401: 인증이 필요합니다.",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "COMMON500: 서버 에러",
+                    content = @Content
+            )
+    })
+    public ResponseEntity<ApiResponse<LocationMapPostPageResponse>> searchPostsByLocation(@ModelAttribute @Valid LocationMapPostRequest request,
+                                                                                          @Parameter(description = "이전 페이지 마지막 게시글의 거리값", example = "152.4") @RequestParam(required = false) Double lastDistance,
+                                                                                          @Parameter(description = "이전 페이지 마지막 게시글의 ID", example = "12") @RequestParam(required = false) Long lastPostId,
+                                                                                          @AuthenticationPrincipal UserDetails userDetails) {
 
-        return null;
+        LocationMapPostPageResponse response = postMapService.searchPostsByLocation(request, lastDistance, lastPostId, userDetails);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
 }

--- a/src/main/java/com/fmi/domain/map/web/dto/request/LocationMapPostRequest.java
+++ b/src/main/java/com/fmi/domain/map/web/dto/request/LocationMapPostRequest.java
@@ -1,0 +1,34 @@
+package com.fmi.domain.map.web.dto.request;
+
+import com.fmi.domain.Enum.Category;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.data.PostType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record LocationMapPostRequest(
+        @Schema(description = "지도 중심 위도", example = "37.5665")
+        @NotNull
+        Double latitude,
+
+        @Schema(description = "지도 중심 경도", example = "126.9780")
+        @NotNull
+        Double longitude,
+
+        @Schema(description = "지도 줌 레벨 (1~11)", example = "5")
+        @NotNull
+        @Min(1) @Max(11)
+        Integer level,
+
+        @Schema(description = "게시글 타입 필터", example = "FOUND")
+        PostType postType,
+
+        @Schema(description = "게시글 상태 필터", example = "SEARCHING")
+        PostStatus postStatus,
+
+        @Schema(description = "카테고리 필터", example = "WALLET")
+        Category category
+        ) {
+}

--- a/src/main/java/com/fmi/domain/map/web/dto/response/LocationMapPostPageResponse.java
+++ b/src/main/java/com/fmi/domain/map/web/dto/response/LocationMapPostPageResponse.java
@@ -1,0 +1,11 @@
+package com.fmi.domain.map.web.dto.response;
+
+import java.util.List;
+
+public record LocationMapPostPageResponse(
+        List<MapPostResponse> posts,
+        boolean hasNext,
+        Double nextDistance,
+        Long nextPostId
+) {
+}

--- a/src/main/java/com/fmi/domain/map/web/dto/response/MapPostPageResponse.java
+++ b/src/main/java/com/fmi/domain/map/web/dto/response/MapPostPageResponse.java
@@ -1,0 +1,11 @@
+package com.fmi.domain.map.web.dto.response;
+
+import java.util.List;
+
+public record MapPostPageResponse(
+        List<MapPostResponse> posts,
+        boolean hasNext,
+        Double nextDistance,
+        Long nextPostId
+) {
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close #395 

## 🛠️ 작업 내용

- 지도 게시글 카드 조회 API 무한 스크롤로 수정
- 위치기반으로 Post 검색 API
- 지도 반경 레벨 범위 수정

## 📢 참고 및 특이사항


## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
