### PR TITLE
fix: 채팅 목록 주소 검색 시 부분 일치 검색 가능하도록 개선

### DIFF
--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
@@ -19,9 +19,24 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 
 @Repository
 public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRepositoryCustom {
+
+    private static final Map<String, String> ADDRESS_ALIASES = Map.ofEntries(
+            Map.entry("서울시", "서울특별시"),
+            Map.entry("부산시", "부산광역시"),
+            Map.entry("대구시", "대구광역시"),
+            Map.entry("인천시", "인천광역시"),
+            Map.entry("광주시", "광주광역시"),
+            Map.entry("대전시", "대전광역시"),
+            Map.entry("울산시", "울산광역시"),
+            Map.entry("세종시", "세종특별자치시"),
+            Map.entry("강원도", "강원특별자치도"),
+            Map.entry("전라북도", "전북특별자치도"),
+            Map.entry("제주도", "제주특별자치도")
+    );
 
     private final JPAQueryFactory queryFactory;
 
@@ -108,6 +123,17 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
     }
 
     private BooleanExpression addressEq(String address) {
-        return address != null ? QPost.post.address.startsWith(address) : null;
+        if (address == null || address.isBlank()) return null;
+
+        String[] tokens = address.trim().split("\\s+");
+        BooleanExpression result = null;
+
+        for (String token : tokens) {
+            String normalized = ADDRESS_ALIASES.getOrDefault(token, token);
+            BooleanExpression contains = QPost.post.address.contains(normalized);
+            result = (result == null) ? contains : result.and(contains);
+        }
+
+        return result;
     }
 }

--- a/src/test/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImplTest.java
+++ b/src/test/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImplTest.java
@@ -1,0 +1,96 @@
+package com.fmi.domain.chatroom.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomParticipantRepositoryImplTest {
+
+    @Mock
+    private EntityManager entityManager;
+
+    private ChatRoomParticipantRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new ChatRoomParticipantRepositoryImpl(entityManager);
+    }
+
+    private BooleanExpression invokeAddressEq(String address) throws Exception {
+        Method method = ChatRoomParticipantRepositoryImpl.class
+                .getDeclaredMethod("addressEq", String.class);
+        method.setAccessible(true);
+        return (BooleanExpression) method.invoke(repository, address);
+    }
+
+    @Test
+    @DisplayName("address가 null이면 null 반환")
+    void addressEq_null() throws Exception {
+        assertThat(invokeAddressEq(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("address가 빈 문자열이면 null 반환")
+    void addressEq_blank() throws Exception {
+        assertThat(invokeAddressEq("   ")).isNull();
+    }
+
+    @Test
+    @DisplayName("단일 키워드 검색 시 해당 키워드를 포함하는 조건 생성")
+    void addressEq_singleToken() throws Exception {
+        BooleanExpression result = invokeAddressEq("강남");
+
+        assertThat(result).isNotNull();
+        assertThat(result.toString()).contains("강남");
+    }
+
+    @Test
+    @DisplayName("서울시 → 서울특별시로 정규화")
+    void addressEq_aliasNormalization_seoul() throws Exception {
+        BooleanExpression result = invokeAddressEq("서울시");
+
+        assertThat(result).isNotNull();
+        assertThat(result.toString()).contains("서울특별시");
+        assertThat(result.toString()).doesNotContain("서울시");
+    }
+
+    @Test
+    @DisplayName("별칭이 없는 키워드는 그대로 사용")
+    void addressEq_noAlias() throws Exception {
+        BooleanExpression result = invokeAddressEq("개포동");
+
+        assertThat(result).isNotNull();
+        assertThat(result.toString()).contains("개포동");
+    }
+
+    @Test
+    @DisplayName("다중 키워드 검색 시 모든 키워드를 포함하는 AND 조건 생성")
+    void addressEq_multipleTokens() throws Exception {
+        BooleanExpression result = invokeAddressEq("강남 개포");
+
+        assertThat(result).isNotNull();
+        assertThat(result.toString()).contains("강남");
+        assertThat(result.toString()).contains("개포");
+    }
+
+    @Test
+    @DisplayName("별칭 키워드와 일반 키워드 혼합 시 정규화 + AND 조건 생성")
+    void addressEq_aliasWithMultipleTokens() throws Exception {
+        BooleanExpression result = invokeAddressEq("서울시 강남");
+
+        assertThat(result).isNotNull();
+        assertThat(result.toString()).contains("서울특별시");
+        assertThat(result.toString()).contains("강남");
+        assertThat(result.toString()).doesNotContain("서울시 강남");
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close #382 

## 🛠️ 작업 내용

- 기존 주소 검색이 앞부분 일치(startsWith)만 지원해서 "서울특별시 강남구 개포동"을 검색하려면 "서울특별시"로 시작해야만 했던 문제를 개선
- `startsWith` → 공백 기준 토큰 분리 후 각 키워드 `contains` AND 조건으로 변경                                           
- 행정구역 별칭 정규화 추가 (ex) 서울시 → 서울특별시)  
- 테스트 코드 추가       

## 📢 참고 및 특이사항

- 현재 `LIKE '%keyword%'` 방식으로 인덱스 미사용입니다.                                                                                                                
- 부하/성능 테스트 후  MySQL Full-Text Search로 전환 검토 예정입니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
