### PR TITLE
refactor: 활동 내역 swagger ui 누락 내용 수정, 신고 내역 조회 keyword 파라미터 추가, 비밀번호 재발급 시 미등록 사용자 에러코드 400 -> 404로 수정 

### DIFF
--- a/src/main/java/com/fmi/domain/auth/service/PasswordResetService.java
+++ b/src/main/java/com/fmi/domain/auth/service/PasswordResetService.java
@@ -32,7 +32,7 @@ public class PasswordResetService {
     @Transactional
     public void issueTemporaryPassword(String email) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST));
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         
         if (socialAccountsRepository.findByUser(user).isPresent()) {
             throw new GeneralException(ErrorStatus._SOCIAL_ACCOUNT);

--- a/src/main/java/com/fmi/domain/auth/web/controller/PasswordResetController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/PasswordResetController.java
@@ -35,6 +35,16 @@ public class PasswordResetController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "임시 비밀번호 발급 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "USER404-NOT_FOUND: 존재하지 않는 회원입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"USER404-NOT_FOUND\", \"message\": \"존재하지 않는 회원입니다.\"}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
                     description = "AUTH400-SOCIAL_ACCOUNT: 소셜 로그인 계정입니다",
                     content = @Content(

--- a/src/main/java/com/fmi/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/fmi/domain/report/repository/ReportRepository.java
@@ -73,6 +73,25 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
                                             @Param("keyword") String keyword,
                                             Pageable pageable);
 
+    // 사용자별 커서 기반 조회 - keyword 검색 (FULLTEXT + ngram)
+    @Query(value = """
+            SELECT * FROM report r
+            WHERE r.reporter_user_id = :reporterId
+              AND (:status IS NULL OR r.status = :status)
+              AND (:answered IS NULL OR r.answered = :answered)
+              AND (:cursor IS NULL OR r.report_id < :cursor)
+              AND MATCH(r.reason) AGAINST(:keyword IN BOOLEAN MODE)
+            ORDER BY r.report_id DESC
+            LIMIT :limit
+            """,
+            nativeQuery = true)
+    List<Report> findByReporterWithKeywordCursor(@Param("reporterId") Long reporterId,
+                                                  @Param("status") String status,
+                                                  @Param("answered") Boolean answered,
+                                                  @Param("keyword") String keyword,
+                                                  @Param("cursor") Long cursor,
+                                                  @Param("limit") int limit);
+
     // 사용자별 커서 기반 조회 - 전체
     @Query("""
             SELECT r FROM Report r

--- a/src/main/java/com/fmi/domain/report/service/ReportService.java
+++ b/src/main/java/com/fmi/domain/report/service/ReportService.java
@@ -142,12 +142,16 @@ public class ReportService {
     /**
      * 내 신고 내역 조회 (커서 기반)
      */
-    public CursorPageResponse<ReportListDTO> getMyReportsCursor(User user, ReportStatus status, Boolean answered, Long cursor, int size) {
+    public CursorPageResponse<ReportListDTO> getMyReportsCursor(User user, ReportStatus status, Boolean answered, String keyword, Long cursor, int size) {
         int fetchSize = size + 1;
         Pageable limit = PageRequest.of(0, fetchSize);
         List<Report> reports;
 
-        if (status != null && answered != null) {
+        if (keyword != null && !keyword.isBlank()) {
+            reports = reportRepository.findByReporterWithKeywordCursor(
+                    user.getId(), status != null ? status.name() : null,
+                    answered, keyword, cursor, fetchSize);
+        } else if (status != null && answered != null) {
             reports = reportRepository.findByReporterAndStatusAndAnsweredCursor(user, status, answered, cursor, limit);
         } else if (status != null) {
             reports = reportRepository.findByReporterAndStatusCursor(user, status, cursor, limit);

--- a/src/main/java/com/fmi/domain/report/web/controller/ReportController.java
+++ b/src/main/java/com/fmi/domain/report/web/controller/ReportController.java
@@ -100,12 +100,14 @@ public class ReportController {
             @RequestParam(required = false) ReportStatus status,
             @Parameter(description = "답변 여부 필터 (true=답변완료, false=미답변)")
             @RequestParam(required = false) Boolean answered,
+            @Parameter(description = "신고 사유 키워드 검색")
+            @RequestParam(required = false) String keyword,
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "10") int size) {
 
         User user = userRepository.findByEmail(userDetails.getUsername())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
-        CursorPageResponse<ReportListDTO> reports = reportService.getMyReportsCursor(user, status, answered, cursor, size);
+        CursorPageResponse<ReportListDTO> reports = reportService.getMyReportsCursor(user, status, answered, keyword, cursor, size);
         return ApiResponse.onSuccess(reports);
     }
 }

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -183,8 +183,12 @@ public class UserController {
             - POST: 작성한 게시글
             - COMMENT: 작성한 댓글
             - FAVORITE: 즐겨찾기한 게시글
-            - INQUIRY: 문의 내역
-            - REPORT: 신고 내역
+            - INQUIRY: 문의 내역 (전체)
+            - INQUIRY_RECEIVED: 접수된 문의 (미답변)
+            - INQUIRY_ANSWERED: 답변 완료된 문의
+            - REPORT: 신고 내역 (전체)
+            - REPORT_RECEIVED: 접수된 신고 (미답변)
+            - REPORT_ANSWERED: 답변 완료된 신고
             - 미지정 시 전체 활동 조회
 
             **날짜 필터:**


### PR DESCRIPTION
## 🧩 관련 이슈

- close #434

## 🛠️ 작업 내용

-  활동 내역 swagger ui 누락 내용 수정
- 신고 내역 조회 keyword 파라미터 추가
- 비밀번호 재발급 시 미등록 사용자 에러코드 400 -> 404로 수정 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
