### PR TITLE
refactor: 카카오 로그인 API 에 약관 동의 필드 추가 및 관리자 마케팅 동의 유저 게시글 목록 조회 api 추가 

### DIFF
--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -47,6 +47,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fmi.domain.admin.dto.AdminGuestInquiryPageResponse;
 
+import com.fmi.domain.post.data.Post;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.web.dto.response.PostBriefResponse;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -406,6 +410,50 @@ public class AdminService {
                         .withdrawalReason(user.getWithdrawalReason())
                         .withdrawalOtherReason(user.getWithdrawalOtherReason())
                         .build())
+                .toList();
+
+        return new CursorPageResponse<>(responseList, nextCursor, hasNext);
+    }
+
+    public CursorPageResponse<PostBriefResponse> getMarketingConsentPosts(
+            String sort, Category category, PostStatus postStatus, Long cursor, int size) {
+
+        int fetchSize = size + 1;
+        List<Post> posts;
+
+        String categoryStr = category != null ? category.name() : null;
+        String postStatusStr = postStatus != null ? postStatus.name() : null;
+
+        if ("popular".equals(sort)) {
+            posts = postRepository.findMarketingConsentPostsByPopular(
+                    categoryStr, postStatusStr, cursor, fetchSize);
+        } else {
+            posts = postRepository.findMarketingConsentPostsByLatest(
+                    categoryStr, postStatusStr, cursor, fetchSize);
+        }
+
+        boolean hasNext = posts.size() > size;
+        List<Post> content = hasNext ? posts.subList(0, size) : posts;
+        Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
+
+        List<PostBriefResponse> responseList = content.stream()
+                .map(post -> new PostBriefResponse(
+                        post.getId(),
+                        post.getTitle(),
+                        post.makeSummary(),
+                        null,
+                        post.getAddress(),
+                        post.getPostStatus(),
+                        post.getPostType(),
+                        post.getCategory(),
+                        0L,
+                        false,
+                        post.getViewCount(),
+                        post.isNew(),
+                        false,
+                        post.getCreatedAt(),
+                        0
+                ))
                 .toList();
 
         return new CursorPageResponse<>(responseList, nextCursor, hasNext);

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -49,10 +49,14 @@ import com.fmi.domain.admin.dto.AdminGuestInquiryPageResponse;
 
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.converter.util.PostConverter;
+import com.fmi.domain.post.service.PostImageService;
 import com.fmi.domain.post.web.dto.response.PostBriefResponse;
+import com.fmi.domain.postfavorite.service.PostFavoriteService;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -71,6 +75,8 @@ public class AdminService {
     private final UserCategoryRepository userCategoryRepository;
     private final InquiryCommentService inquiryCommentService;
     private final IpBlacklistService ipBlacklistService;
+    private final PostFavoriteService postFavoriteService;
+    private final PostImageService postImageService;
     private final ReportAnswerImageRepository reportAnswerImageRepository;
 
     public Page<AdminInquiryResponse> getInquiryPage(InquiryType type,
@@ -416,8 +422,10 @@ public class AdminService {
     }
 
     public CursorPageResponse<PostBriefResponse> getMarketingConsentPosts(
-            String sort, Category category, PostStatus postStatus, Long cursor, int size) {
+            String sort, Category category, PostStatus postStatus,
+            Long cursor, Long cursorViewCount, int size) {
 
+        size = Math.max(1, Math.min(size, 50));
         int fetchSize = size + 1;
         List<Post> posts;
 
@@ -426,7 +434,7 @@ public class AdminService {
 
         if ("popular".equals(sort)) {
             posts = postRepository.findMarketingConsentPostsByPopular(
-                    categoryStr, postStatusStr, cursor, fetchSize);
+                    categoryStr, postStatusStr, cursorViewCount, cursor, fetchSize);
         } else {
             posts = postRepository.findMarketingConsentPostsByLatest(
                     categoryStr, postStatusStr, cursor, fetchSize);
@@ -436,23 +444,17 @@ public class AdminService {
         List<Post> content = hasNext ? posts.subList(0, size) : posts;
         Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
 
+        Map<Long, Long> favoriteCountMap = postFavoriteService.getFavoriteCountMap(content);
+        Map<Long, String> thumbnailMap = postImageService.findThumbnailUrlByPostList(content);
+        Map<Long, Integer> imageCountMap = postImageService.countImageByPostList(content);
+
         List<PostBriefResponse> responseList = content.stream()
-                .map(post -> new PostBriefResponse(
-                        post.getId(),
-                        post.getTitle(),
-                        post.makeSummary(),
-                        null,
-                        post.getAddress(),
-                        post.getPostStatus(),
-                        post.getPostType(),
-                        post.getCategory(),
-                        0L,
+                .map(post -> PostConverter.toPostBriefResponse(
+                        post,
                         false,
-                        post.getViewCount(),
-                        post.isNew(),
-                        false,
-                        post.getCreatedAt(),
-                        0
+                        thumbnailMap.getOrDefault(post.getId(), null),
+                        favoriteCountMap.getOrDefault(post.getId(), 0L),
+                        imageCountMap.getOrDefault(post.getId(), 0)
                 ))
                 .toList();
 

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -6,6 +6,9 @@ import com.fmi.domain.admin.dto.AdminGuestInquiryReplyRequestDTO;
 import com.fmi.domain.admin.dto.AdminInquiryResponse;
 import com.fmi.domain.admin.dto.AdminReportResponse;
 import com.fmi.domain.admin.dto.AdminUserDetailResponse;
+import com.fmi.domain.Enum.Category;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.web.dto.response.PostBriefResponse;
 import com.fmi.domain.admin.service.AdminService;
 import com.fmi.domain.admin.web.dto.AdminIpBlockRequest;
 import com.fmi.domain.admin.web.dto.AdminSignupRequest;
@@ -449,6 +452,38 @@ public class AdminController {
     public ApiResponse<SignupResponse> adminSignup(@Valid @RequestBody AdminSignupRequest request) {
         Long id = authService.adminSignup(request);
         return ApiResponse.onSuccess(AuthConverter.toSignupResponse(id));
+    }
+
+    @GetMapping("/posts/marketing")
+    @Operation(summary = "마케팅 동의 유저 게시글 목록 조회",
+            description = """
+                마케팅 수신 동의한 유저들의 게시글을 조회합니다.
+                커서 기반 무한스크롤을 지원하며, 정렬/카테고리/찾음 여부 필터를 제공합니다.
+
+                **정렬 (sort):**
+                - latest: 최신순 (기본값)
+                - popular: 인기순 (조회수)
+
+                **필터:**
+                - category: 카테고리 필터 (ELECTRONICS, WALLET, ID_CARD, JEWELRY, BAG, CARD, ETC)
+                - postStatus: 찾음 여부 필터 (SEARCHING, FOUND)
+                """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공")
+    })
+    public ApiResponse<CursorPageResponse<PostBriefResponse>> getMarketingConsentPosts(
+            @Parameter(description = "정렬 (latest=최신순, popular=인기순)")
+            @RequestParam(defaultValue = "latest") String sort,
+            @Parameter(description = "카테고리 필터")
+            @RequestParam(required = false) Category category,
+            @Parameter(description = "찾음 여부 필터 (SEARCHING=찾는중, FOUND=찾음)")
+            @RequestParam(required = false) PostStatus postStatus,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        CursorPageResponse<PostBriefResponse> response =
+                adminService.getMarketingConsentPosts(sort, category, postStatus, cursor, size);
+        return ApiResponse.onSuccess(response);
     }
 
     @GetMapping("/users/deleted")

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -478,11 +478,14 @@ public class AdminController {
             @RequestParam(required = false) Category category,
             @Parameter(description = "찾음 여부 필터 (SEARCHING=찾는중, FOUND=찾음)")
             @RequestParam(required = false) PostStatus postStatus,
+            @Parameter(description = "커서 (마지막 게시글 ID)")
             @RequestParam(required = false) Long cursor,
+            @Parameter(description = "인기순 정렬 시 마지막 게시글의 조회수 (popular 정렬에서만 사용)")
+            @RequestParam(required = false) Long cursorViewCount,
             @RequestParam(defaultValue = "20") int size
     ) {
         CursorPageResponse<PostBriefResponse> response =
-                adminService.getMarketingConsentPosts(sort, category, postStatus, cursor, size);
+                adminService.getMarketingConsentPosts(sort, category, postStatus, cursor, cursorViewCount, size);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/fmi/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/fmi/domain/auth/converter/AuthConverter.java
@@ -50,7 +50,9 @@ public class AuthConverter {
     /**
      * 소셜 로그인용 User Entity 생성
      */
-    public static User toSocialUserEntity(Long providerId, String email, String nickname, String profileImageUrl, String encodedPassword) {
+    public static User toSocialUserEntity(Long providerId, String email, String nickname, String profileImageUrl, String encodedPassword,
+                                           Boolean privacyPolicyAgreed, Boolean termsOfServiceAgreed,
+                                           Boolean contentPolicyAgreed, Boolean marketingConsent) {
         String effectiveEmail = (email != null && !email.isBlank())
                 ? email
                 : ("kakao_" + providerId + "@kakao.local");
@@ -62,10 +64,10 @@ public class AuthConverter {
                 .profile_img(profileImageUrl != null ? profileImageUrl : "")
                 .role(Role.USER)
                 .email_verified(true)
-                .privacyPolicyAgreed(false)
-                .termsOfServiceAgreed(false)
-                .contentPolicyAgreed(false)
-                .marketingConsent(false)
+                .privacyPolicyAgreed(Boolean.TRUE.equals(privacyPolicyAgreed))
+                .termsOfServiceAgreed(Boolean.TRUE.equals(termsOfServiceAgreed))
+                .contentPolicyAgreed(Boolean.TRUE.equals(contentPolicyAgreed))
+                .marketingConsent(Boolean.TRUE.equals(marketingConsent))
                 .build();
     }
 

--- a/src/main/java/com/fmi/domain/auth/response/LoginResponse.java
+++ b/src/main/java/com/fmi/domain/auth/response/LoginResponse.java
@@ -9,9 +9,16 @@ import lombok.Data;
 @Schema(description = "로그인 응답")
 public class LoginResponse {
     @Schema(description = "사용자 ID", example = "1")
-    private Long userId;  // 사용자 ID
-    // accessToken 필드 제거됨 - 쿠키로 전송되므로 응답 body에 포함하지 않음
+    private Long userId;
     @Schema(description = "임시 비밀번호로 로그인했는지 여부 (비밀번호 변경 페이지 리다이렉트용)", example = "false")
-    private boolean isTemporaryPassword;  // 임시 비밀번호로 로그인했는지 여부 (비밀번호 변경 페이지 리다이렉트용)
+    private boolean isTemporaryPassword;
+    @Schema(description = "신규 가입 여부 (카카오 로그인 시 약관 동의 화면 분기용, 일반 로그인은 항상 false)", example = "false")
+    private boolean isNewUser;
+
+    public LoginResponse(Long userId, boolean isTemporaryPassword) {
+        this.userId = userId;
+        this.isTemporaryPassword = isTemporaryPassword;
+        this.isNewUser = false;
+    }
 }
 

--- a/src/main/java/com/fmi/domain/auth/service/SocialLoginService.java
+++ b/src/main/java/com/fmi/domain/auth/service/SocialLoginService.java
@@ -28,14 +28,18 @@ public class SocialLoginService {
     private final PasswordEncoder passwordEncoder;
     private final NicknameGeneratorService nicknameGeneratorService;
 
-    public User upsertUserFromKakao(Long kakaoId, String email, String nickname, String profileImageUrl) {
+    public record KakaoLoginResult(User user, boolean isNewUser) {}
+
+    public KakaoLoginResult upsertUserFromKakao(Long kakaoId, String email, String nickname, String profileImageUrl,
+                                       Boolean privacyPolicyAgreed, Boolean termsOfServiceAgreed,
+                                       Boolean contentPolicyAgreed, Boolean marketingConsent) {
         String providerId = String.valueOf(kakaoId);
 
         // 이미 존재하는 소셜 계정인지 확인
         Optional<SocialAccounts> existingAccount = socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId);
         if (existingAccount.isPresent()) {
             log.info("기존 카카오 계정 찾음: providerId={}, userId={}", providerId, existingAccount.get().getUser().getId());
-            return reloadUser(existingAccount.get().getUser());
+            return new KakaoLoginResult(reloadUser(existingAccount.get().getUser()), false);
         }
 
         log.info("새 카카오 계정 생성 시작: providerId={}", providerId);
@@ -62,7 +66,11 @@ public class SocialLoginService {
                             email,
                             effectiveNickname,
                             profileImageUrl,
-                            passwordEncoder.encode("{noop}-" + providerId)
+                            passwordEncoder.encode("{noop}-" + providerId),
+                            privacyPolicyAgreed,
+                            termsOfServiceAgreed,
+                            contentPolicyAgreed,
+                            marketingConsent
                     );
                     return userRepository.save(u);
                 });
@@ -72,7 +80,7 @@ public class SocialLoginService {
         Optional<SocialAccounts> existingAccountAfterUser = socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId);
         if (existingAccountAfterUser.isPresent()) {
             log.info("동시 요청으로 인해 이미 소셜 계정이 생성됨: providerId={}, userId={}", providerId, existingAccountAfterUser.get().getUser().getId());
-            return reloadUser(existingAccountAfterUser.get().getUser());
+            return new KakaoLoginResult(reloadUser(existingAccountAfterUser.get().getUser()), false);
         }
 
         // 소셜 계정 연결 저장
@@ -84,14 +92,14 @@ public class SocialLoginService {
                     .build();
             SocialAccounts savedAccount = socialAccountsRepository.save(account);
             log.info("소셜 계정 저장 성공: socialId={}, providerId={}, userId={}", savedAccount.getSocialId(), providerId, user.getId());
-            return reloadUser(user);
+            return new KakaoLoginResult(reloadUser(user), true);
         } catch (DataIntegrityViolationException e) {
             log.warn("소셜 계정 저장 중 중복 키 위반 발생 (동시 요청 가능성): providerId={}, error={}", providerId, e.getMessage());
             // 중복 키 위반 시 다시 조회해서 반환
             Optional<SocialAccounts> retryAccount = socialAccountsRepository.findByProviderAndProviderIdWithUser(Provider.KAKAO, providerId);
             if (retryAccount.isPresent()) {
                 log.info("중복 키 위반 후 재조회 성공: providerId={}, userId={}", providerId, retryAccount.get().getUser().getId());
-                return reloadUser(retryAccount.get().getUser());
+                return new KakaoLoginResult(reloadUser(retryAccount.get().getUser()), false);
             }
             // 재조회도 실패한 경우
             log.error("소셜 계정 저장 실패 후 재조회도 실패: providerId={}, 원본 에러: {}", providerId, e.getMessage(), e);

--- a/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
@@ -135,7 +135,11 @@ public class KakaoAuthController {
             profile = profile != null ? profile : user.getProperties().getProfile_image();
         }
 
-        var localUser = socialLoginService.upsertUserFromKakao(user.getId(), email, nickname, profile);
+        var result = socialLoginService.upsertUserFromKakao(user.getId(), email, nickname, profile,
+                req.getPrivacyPolicyAgreed(), req.getTermsOfServiceAgreed(),
+                req.getContentPolicyAgreed(), req.getMarketingConsent());
+        var localUser = result.user();
+        boolean isNewUser = result.isNewUser();
 
         var claims = new java.util.HashMap<String, Object>();
         claims.put("userId", localUser.getId());
@@ -165,7 +169,7 @@ public class KakaoAuthController {
         return ResponseEntity.ok()
                 .header("Set-Cookie", accessCookie.toString())
                 .header("Set-Cookie", refreshCookie.toString())
-                .body(ApiResponse.onSuccess(AuthConverter.toLoginResponse(localUser.getId(), false)));
+                .body(ApiResponse.onSuccess(new LoginResponse(localUser.getId(), false, isNewUser)));
     }
 
     private ResponseCookie buildCookie(String name, String value, Duration maxAge) {

--- a/src/main/java/com/fmi/domain/auth/web/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/fmi/domain/auth/web/dto/KakaoLoginRequest.java
@@ -17,12 +17,24 @@ public class KakaoLoginRequest {
     )
     @NotBlank(message = "code 필수")
     private String code;
-    
+
     @Schema(
         description = "환경 타입 (선택사항: 'dev' 또는 'prod', 없으면 기본값 'prod' 사용)",
         example = "dev",
         allowableValues = {"dev", "prod"}
     )
     private String environment;
+
+    @Schema(description = "개인정보 처리방침 동의 (신규 가입 시 필수)", example = "true")
+    private Boolean privacyPolicyAgreed;
+
+    @Schema(description = "이용약관 동의 (신규 가입 시 필수)", example = "true")
+    private Boolean termsOfServiceAgreed;
+
+    @Schema(description = "콘텐츠 활용 동의 (선택)", example = "false")
+    private Boolean contentPolicyAgreed;
+
+    @Schema(description = "마케팅 수신 동의 (선택)", example = "false")
+    private Boolean marketingConsent;
 }
 

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -70,4 +70,38 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     Optional<Post> findByUserAndTemporarySaveTrueAndDeletedFalse(User user);
 
+    // 마케팅 동의 유저 게시글 - 최신순
+    @Query(value = """
+            SELECT p.* FROM post p
+            INNER JOIN users u ON p.user_id = u.id
+            WHERE u.marketing_consent = true AND u.deleted = false
+              AND p.temporary_save = false AND p.deleted = false
+              AND (:category IS NULL OR p.category = :category)
+              AND (:postStatus IS NULL OR p.item_status = :postStatus)
+              AND (:cursor IS NULL OR p.id < :cursor)
+            ORDER BY p.id DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<Post> findMarketingConsentPostsByLatest(@Param("category") String category,
+                                                  @Param("postStatus") String postStatus,
+                                                  @Param("cursor") Long cursor,
+                                                  @Param("limit") int limit);
+
+    // 마케팅 동의 유저 게시글 - 인기순
+    @Query(value = """
+            SELECT p.* FROM post p
+            INNER JOIN users u ON p.user_id = u.id
+            WHERE u.marketing_consent = true AND u.deleted = false
+              AND p.temporary_save = false AND p.deleted = false
+              AND (:category IS NULL OR p.category = :category)
+              AND (:postStatus IS NULL OR p.item_status = :postStatus)
+              AND (:cursor IS NULL OR p.id < :cursor)
+            ORDER BY p.view_count DESC, p.id DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<Post> findMarketingConsentPostsByPopular(@Param("category") String category,
+                                                   @Param("postStatus") String postStatus,
+                                                   @Param("cursor") Long cursor,
+                                                   @Param("limit") int limit);
+
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -87,7 +87,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
                                                   @Param("cursor") Long cursor,
                                                   @Param("limit") int limit);
 
-    // 마케팅 동의 유저 게시글 - 인기순
+    // 마케팅 동의 유저 게시글 - 인기순 (view_count + id 복합 커서)
     @Query(value = """
             SELECT p.* FROM post p
             INNER JOIN users u ON p.user_id = u.id
@@ -95,13 +95,14 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
               AND p.temporary_save = false AND p.deleted = false
               AND (:category IS NULL OR p.category = :category)
               AND (:postStatus IS NULL OR p.item_status = :postStatus)
-              AND (:cursor IS NULL OR p.id < :cursor)
+              AND (:cursorViewCount IS NULL OR (p.view_count < :cursorViewCount OR (p.view_count = :cursorViewCount AND p.id < :cursorId)))
             ORDER BY p.view_count DESC, p.id DESC
             LIMIT :limit
             """, nativeQuery = true)
     List<Post> findMarketingConsentPostsByPopular(@Param("category") String category,
                                                    @Param("postStatus") String postStatus,
-                                                   @Param("cursor") Long cursor,
+                                                   @Param("cursorViewCount") Long cursorViewCount,
+                                                   @Param("cursorId") Long cursorId,
                                                    @Param("limit") int limit);
 
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #437

## 🛠️ 작업 내용

- 카카오 로그인 API 에 약관 동의 필드 추가
- 관리자 마케팅 동의 유저 게시글 목록 조회 api 추가 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
