### PR TITLE
chore: 모니터링 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ ext['spring-framework.version'] = '6.2.11'
 ext['jackson.version'] = '2.19.2'
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
+    // Actuator & Prometheus
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,12 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
     env_file:
       - .env
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
 
   fmi-dev:
     image: ${ECR_IMAGE_URL}:latest
@@ -41,6 +47,12 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
     env_file:
       - .env
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
 
 volumes:
   redis_data:

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.retention.time=15d'
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.10.0
     container_name: prometheus
     restart: unless-stopped
     ports:
@@ -13,7 +13,7 @@ services:
       - '--storage.tsdb.retention.time=15d'
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.4.2
     container_name: grafana
     restart: unless-stopped
     ports:

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'fmi-prod'
+    metrics_path: '/prod/actuator/prometheus'
+    static_configs:
+      - targets: ['<APP_SERVER_PRIVATE_IP>:80']
+
+
+  - job_name: 'fmi-dev'
+    metrics_path: '/dev/actuator/prometheus'
+    static_configs:
+      - targets: ['<APP_SERVER_PRIVATE_IP>:80']

--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
-                        .requestMatchers("/", "/actuator/health", "/actuator/info", "/ws/**", "/error", "/health", "/api/health").permitAll()
+                        .requestMatchers("/", "/actuator/health", "/actuator/info", "/actuator/prometheus", "/ws/**", "/error", "/health", "/api/health").permitAll()
                         .requestMatchers("/auth/**", "/s3/**", "/chat-test.html", "/chat-test2.html", "/posts/filter").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll()
                         // 공지사항 - 조회만 공개, 좋아요/댓글 작성은 인증 필요


### PR DESCRIPTION
## 🧩 관련 이슈

- close #436 

## 🛠️ 작업 내용

- 모니터링 설정을 위해서 actuator, prometheus 의존성을 추가했습니다.
- 기존 docker-compose.yml에 헬스체크 설정 추가했습니다.
- 모니터링 설정 파일인 prometheus.yml, docker-compose.yml 추가했습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
