### PR TITLE
feat: 마케팅 수신 동의 사용자 게시글 조회 API 구현

### DIFF
--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -1,5 +1,7 @@
 package com.fmi.domain.admin.web.controller;
 
+import com.fmi.domain.Enum.Category;
+import com.fmi.domain.Enum.SortType;
 import com.fmi.domain.admin.dto.AdminDeletedUserResponse;
 import com.fmi.domain.admin.dto.AdminGuestInquiryPageResponse;
 import com.fmi.domain.admin.dto.AdminGuestInquiryReplyRequestDTO;
@@ -22,6 +24,9 @@ import com.fmi.domain.notice.service.NoticeService;
 import com.fmi.domain.notice.web.dto.NoticeCreateRequestDTO;
 import com.fmi.domain.notice.web.dto.NoticeUpdateRequestDTO;
 import com.fmi.domain.notice.web.dto.NoticeResponseDTO;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.service.PostQueryService;
+import com.fmi.domain.post.web.dto.response.MarketingConsentPostPageResponse;
 import com.fmi.domain.report.data.enums.ReportStatus;
 import com.fmi.domain.report.data.enums.ReportTargetType;
 import com.fmi.domain.report.service.ReportService;
@@ -30,6 +35,7 @@ import com.fmi.domain.report.web.dto.request.ReportAnswerRequestDTO;
 import com.fmi.domain.report.web.dto.response.ReportResponseDTO;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.global.apiPayload.CursorPageResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,6 +44,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -61,6 +68,7 @@ public class AdminController {
     private final InquiryService inquiryService;
     private final ReportService reportService;
     private final AuthService authService;
+    private final PostQueryService postQueryService;
 
     @GetMapping("/guest-inquiries/{inquiryId}")
     @Operation(summary = "관리자 비회원 문의 상세 조회", description = "비회원이 작성한 문의의 상세 정보를 조회합니다.")
@@ -465,6 +473,114 @@ public class AdminController {
         CursorPageResponse<AdminDeletedUserResponse> response =
                 adminService.getDeletedUsersCursorPage(reason, keyword, cursor, size);
         return ApiResponse.onSuccess(response);
+    }
+
+
+    @GetMapping("/marketing-consent/posts")
+    @Operation(
+            summary = "마케팅 수신 동의 사용자 게시글 조회 (관리자 전용)",
+            description = """
+                    마케팅 수신에 동의한 사용자가 작성한 게시글 목록을 조회합니다.
+                    
+                    - 관리자만 접근할 수 있습니다.
+                    - 무한스크롤 방식으로 조회합니다.
+                    - 첫 요청은 cursor 없이 호출하고, 이후 응답의 nextCursor 값을 다음 요청의 cursor로 전달합니다.
+                    - 정렬(sortType), 카테고리(category), 게시글 상태(postStatus), 키워드(keyword) 필터를 지원합니다.
+                    - keyword는 제목(title), 내용(content)을 기준으로 검색합니다.
+                    
+                    예)
+                    - 첫 요청:
+                      /posts/marketing-consent?sortType=LATEST&size=20
+                    - 다음 요청:
+                      /posts/marketing-consent?sortType=LATEST&cursor=120&size=20
+                    - 키워드 검색:
+                      /posts/marketing-consent?keyword=지갑&sortType=LATEST
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MarketingConsentPostPageResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "성공",
+                                              "result": {
+                                                "postList": [
+                                                  {
+                                                    "id": 101,
+                                                    "title": "지갑을 습득했습니다",
+                                                    "summary": "강남역 근처에서 검정색 지갑을 주웠습니다.",
+                                                    "thumbnailImageUrl": "https://example.com/thumb.jpg",
+                                                    "address": "서울 강남구",
+                                                    "postStatus": "SEARCHING",
+                                                    "postType": "FOUND",
+                                                    "category": "WALLET",
+                                                    "favoriteCount": 12,
+                                                    "favoriteStatus": false,
+                                                    "viewCount": 104,
+                                                    "isNew": true,
+                                                    "isHot": false,
+                                                    "createdAt": "2026-04-01T12:30:00",
+                                                    "imageCount": 2
+                                                  },
+                                                  {
+                                                    "id": 99,
+                                                    "title": "휴대폰을 찾습니다",
+                                                    "summary": "버스 안에서 휴대폰을 잃어버렸습니다.",
+                                                    "thumbnailImageUrl": null,
+                                                    "address": "서울 서초구",
+                                                    "postStatus": "FOUND",
+                                                    "postType": "LOST",
+                                                    "category": "ELECTRONICS",
+                                                    "favoriteCount": 5,
+                                                    "favoriteStatus": true,
+                                                    "viewCount": 87,
+                                                    "isNew": false,
+                                                    "isHot": true,
+                                                    "createdAt": "2026-03-31T18:10:00",
+                                                    "imageCount": 1
+                                                  }
+                                                ],
+                                                "nextCursor": 99,
+                                                "hasNext": true
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 파라미터",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증이 필요합니다",
+                    content = @Content
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "관리자만 접근할 수 있습니다",
+                    content = @Content
+            )
+    })
+    public ResponseEntity<ApiResponse<MarketingConsentPostPageResponse>> getMarketingConsentPosts(@RequestParam(required = false) Long cursor,
+                                                                                                  @RequestParam(defaultValue = "20") int size,
+                                                                                                  @RequestParam(defaultValue = "LATEST") SortType sortType,
+                                                                                                  @RequestParam(required = false) Category category,
+                                                                                                  @RequestParam(required = false) PostStatus postStatus,
+                                                                                                  @RequestParam(required = false) String keyword,
+                                                                                                  @AuthenticationPrincipal UserDetails userDetails) {
+        MarketingConsentPostPageResponse response = postQueryService.getMarketingConsentPosts(cursor, size, sortType, category, postStatus, keyword, userDetails);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 }
 

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
@@ -56,5 +56,6 @@ public interface PostRepositoryCustom {
                                                                SortType sortType,
                                                                Category category,
                                                                PostStatus postStatus,
+                                                               String keyword,
                                                                Set<Long> hotPostsIds);
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryCustom.java
@@ -6,6 +6,7 @@ import com.fmi.domain.Enum.SortType;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.data.PostType;
+import com.fmi.domain.post.web.dto.response.MarketingConsentPostPageResponse;
 import com.fmi.domain.post.web.dto.response.PostPageResponse;
 
 import java.time.LocalDate;
@@ -24,28 +25,36 @@ public interface PostRepositoryCustom {
                                                  Set<Long> hotPostsIds);
 
     PostPageResponse searchMyPosts(Long userId,
-                                    PostType postType,
-                                    PostStatus postStatus,
-                                    Category category,
-                                    SortType sortType,
-                                    LocalDate startDate,
-                                    LocalDate endDate,
-                                    String keyword,
-                                    Long cursor,
-                                    int size);
+                                   PostType postType,
+                                   PostStatus postStatus,
+                                   Category category,
+                                   SortType sortType,
+                                   LocalDate startDate,
+                                   LocalDate endDate,
+                                   String keyword,
+                                   Long cursor,
+                                   int size);
 
     PostPageResponse searchMyFavorites(Long userId,
-                                        PostType postType,
-                                        Category category,
-                                        String address,
-                                        String keyword,
-                                        SortType sortType,
-                                        Long cursor,
-                                        int size);
+                                       PostType postType,
+                                       Category category,
+                                       String address,
+                                       String keyword,
+                                       SortType sortType,
+                                       Long cursor,
+                                       int size);
 
     List<Post> searchByKeywordWithCursor(String keyword, Long cursor, int size);
 
     long countByKeyword(String keyword);
 
     List<Post> findSimilarPosts(Long postId, int limit);
+
+    MarketingConsentPostPageResponse findMarketingConsentPosts(Long userId,
+                                                               Long cursor,
+                                                               int size,
+                                                               SortType sortType,
+                                                               Category category,
+                                                               PostStatus postStatus,
+                                                               Set<Long> hotPostsIds);
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.fmi.domain.Enum.Category;
 import com.fmi.domain.Enum.SortType;
 import com.fmi.domain.comment.data.QComment;
 import com.fmi.domain.post.data.*;
+import com.fmi.domain.post.web.dto.response.MarketingConsentPostPageResponse;
 import com.fmi.domain.post.web.dto.response.PostBriefResponse;
 import com.fmi.domain.post.web.dto.response.PostPageResponse;
 import com.fmi.domain.postfavorite.data.QPostFavorite;
@@ -195,15 +196,15 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
     @Override
     public PostPageResponse searchMyPosts(Long userId,
-                                           PostType postType,
-                                           PostStatus postStatus,
-                                           Category category,
-                                           SortType sortType,
-                                           LocalDate startDate,
-                                           LocalDate endDate,
-                                           String keyword,
-                                           Long cursor,
-                                           int size) {
+                                          PostType postType,
+                                          PostStatus postStatus,
+                                          Category category,
+                                          SortType sortType,
+                                          LocalDate startDate,
+                                          LocalDate endDate,
+                                          String keyword,
+                                          Long cursor,
+                                          int size) {
         QPost post = QPost.post;
         QPostFavorite postFavorite = QPostFavorite.postFavorite;
 
@@ -269,13 +270,13 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
     @Override
     public PostPageResponse searchMyFavorites(Long userId,
-                                               PostType postType,
-                                               Category category,
-                                               String address,
-                                               String keyword,
-                                               SortType sortType,
-                                               Long cursor,
-                                               int size) {
+                                              PostType postType,
+                                              Category category,
+                                              String address,
+                                              String keyword,
+                                              SortType sortType,
+                                              Long cursor,
+                                              int size) {
         QPost post = QPost.post;
         QPostFavorite postFavorite = QPostFavorite.postFavorite;
 
@@ -343,7 +344,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     private PostPageResponse buildPostPageResponse(List<Post> posts, Long postCount,
-                                                    Long nextCursor, boolean hasNext, Long userId) {
+                                                   Long nextCursor, boolean hasNext, Long userId) {
         QPostFavorite postFavorite = QPostFavorite.postFavorite;
         List<Long> postIdList = posts.stream().map(Post::getId).toList();
 
@@ -531,6 +532,155 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .orderBy(post.createdAt.desc(), post.id.desc())
                 .limit(limit)
                 .fetch();
+    }
+
+    @Override
+    public MarketingConsentPostPageResponse findMarketingConsentPosts(Long userId,
+                                                                      Long cursor,
+                                                                      int size,
+                                                                      SortType sortType,
+                                                                      Category category,
+                                                                      PostStatus postStatus,
+                                                                      Set<Long> hotPostsIds) {
+        QPost post = QPost.post;
+        QPostFavorite postFavorite = QPostFavorite.postFavorite;
+
+        BooleanExpression baseWhere = Expressions.allOf(
+                post.deleted.isFalse(),
+                post.temporarySave.isFalse(),
+                post.user.marketingConsent.isTrue(),
+                equalsCategory(post, category),
+                equalsPostStatus(post, postStatus),
+                excludeBlockedUsers(post, userId)
+        );
+
+        BooleanExpression pageWhere = Expressions.allOf(
+                baseWhere,
+                cursorCondition(post, sortType, cursor)
+        );
+
+
+        List<Post> posts;
+        if (Objects.equals(sortType, SortType.MOST_FAVORITED)) {
+            posts = queryFactory
+                    .select(post)
+                    .from(post)
+                    .leftJoin(postFavorite).on(
+                            postFavorite.post.eq(post),
+                            postFavorite.isFavorite.isTrue()
+                    )
+                    .where(pageWhere)
+                    .groupBy(post.id)
+                    .orderBy(postFavorite.favorite_id.count().desc(), post.id.desc())
+                    .limit(size + 1)
+                    .fetch();
+        } else {
+            posts = queryFactory
+                    .selectFrom(post)
+                    .where(pageWhere)
+                    .orderBy(orderBySortType(post, sortType))
+                    .limit(size + 1)
+                    .fetch();
+        }
+
+        boolean hasNext = posts.size() > size;
+        if (hasNext) {
+            posts = posts.subList(0, size);
+        }
+
+        Long nextCursor = (hasNext && !posts.isEmpty())
+                ? posts.get(posts.size() - 1).getId()
+                : null;
+
+        if (posts.isEmpty()) {
+            return new MarketingConsentPostPageResponse(List.of(), null, false);
+        }
+
+        List<Long> postIdList = posts.stream()
+                .map(Post::getId)
+                .toList();
+
+        Map<Long, String> thumbnailMap = queryFactory
+                .select(postImage.post.id, postImage.imgUrl)
+                .from(postImage)
+                .where(
+                        postImage.post.id.in(postIdList),
+                        postImage.imageType.eq(ImageType.THUMBNAIL)
+                )
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> Objects.requireNonNull(t.get(postImage.post.id)),
+                        t -> Objects.requireNonNull(t.get(postImage.imgUrl)),
+                        (a, b) -> a
+                ));
+
+        Map<Long, Long> favoriteCountMap = queryFactory
+                .select(postFavorite.post.id, postFavorite.favorite_id.count())
+                .from(postFavorite)
+                .where(
+                        postFavorite.post.id.in(postIdList),
+                        postFavorite.isFavorite.isTrue()
+                )
+                .groupBy(postFavorite.post.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> Objects.requireNonNull(t.get(postFavorite.post.id)),
+                        t -> Objects.requireNonNull(t.get(postFavorite.favorite_id.count()))
+                ));
+
+        Set<Long> myFavoritePostIds = Objects.isNull(userId) ? Set.of()
+                : new HashSet<>(
+                queryFactory
+                        .select(postFavorite.post.id)
+                        .from(postFavorite)
+                        .where(
+                                postFavorite.user.id.eq(userId),
+                                postFavorite.post.id.in(postIdList),
+                                postFavorite.isFavorite.isTrue()
+                        )
+                        .fetch()
+        );
+
+        Map<Long, Integer> imageCountMap = queryFactory
+                .select(postImage.post.id, postImage.id.count())
+                .from(postImage)
+                .where(postImage.post.id.in(postIdList))
+                .groupBy(postImage.post.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        t -> Objects.requireNonNull(t.get(postImage.post.id)),
+                        t -> Objects.requireNonNull(t.get(postImage.id.count())).intValue()
+                ));
+
+        List<PostBriefResponse> postList = posts.stream()
+                .map(p -> {
+                    Long pid = p.getId();
+                    boolean isHot = hotPostsIds != null && hotPostsIds.contains(pid);
+
+                    return new PostBriefResponse(
+                            pid,
+                            p.getTitle(),
+                            p.makeSummary(),
+                            thumbnailMap.get(pid),
+                            p.getAddress(),
+                            p.getPostStatus(),
+                            p.getPostType(),
+                            p.getCategory(),
+                            favoriteCountMap.getOrDefault(pid, 0L),
+                            myFavoritePostIds.contains(pid),
+                            p.getViewCount(),
+                            p.isNew(),
+                            isHot,
+                            p.getCreatedAt(),
+                            imageCountMap.getOrDefault(pid, 0)
+                    );
+                })
+                .toList();
+
+        return new MarketingConsentPostPageResponse(postList, nextCursor, hasNext);
     }
 
     private BooleanExpression dateRange(QPost post, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -541,6 +541,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                                                                       SortType sortType,
                                                                       Category category,
                                                                       PostStatus postStatus,
+                                                                      String keyword,
                                                                       Set<Long> hotPostsIds) {
         QPost post = QPost.post;
         QPostFavorite postFavorite = QPostFavorite.postFavorite;
@@ -550,9 +551,12 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 post.temporarySave.isFalse(),
                 post.user.marketingConsent.isTrue(),
                 equalsCategory(post, category),
-                equalsPostStatus(post, postStatus),
-                excludeBlockedUsers(post, userId)
+                equalsPostStatus(post, postStatus)
         );
+
+        if (hasText(keyword)) {
+            baseWhere = baseWhere.and(buildKeywordCondition(post, keyword));
+        }
 
         BooleanExpression pageWhere = Expressions.allOf(
                 baseWhere,

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -328,12 +328,13 @@ public class PostQueryService {
                                                                      SortType sortType,
                                                                      Category category,
                                                                      PostStatus postStatus,
+                                                                     String keyword,
                                                                      UserDetails userDetails) {
         User user = userQueryService.findUser(userDetails.getUsername());
 
         Set<Long> hotIds = hotPostService.resolveHotPostIdsForUser(
-                null, postStatus, category, null, user.getId(), 5);
+                null, postStatus, category, null, null, 5);
 
-        return postRepository.findMarketingConsentPosts(user.getId(), cursor, size, sortType, category, postStatus, hotIds);
+        return postRepository.findMarketingConsentPosts(user.getId(), cursor, size, sortType, category, postStatus, keyword, hotIds);
     }
 }

--- a/src/main/java/com/fmi/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostQueryService.java
@@ -321,4 +321,19 @@ public class PostQueryService {
                 )
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public MarketingConsentPostPageResponse getMarketingConsentPosts(Long cursor,
+                                                                     int size,
+                                                                     SortType sortType,
+                                                                     Category category,
+                                                                     PostStatus postStatus,
+                                                                     UserDetails userDetails) {
+        User user = userQueryService.findUser(userDetails.getUsername());
+
+        Set<Long> hotIds = hotPostService.resolveHotPostIdsForUser(
+                null, postStatus, category, null, user.getId(), 5);
+
+        return postRepository.findMarketingConsentPosts(user.getId(), cursor, size, sortType, category, postStatus, hotIds);
+    }
 }

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -597,4 +597,16 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.onSuccess(null));
     }
 
+    @GetMapping("/marketing-consent")
+    public ResponseEntity<ApiResponse<MarketingConsentPostPageResponse>> getMarketingConsentPosts(@RequestParam(required = false) Long cursor,
+                                                                                                  @RequestParam(defaultValue = "20") int size,
+                                                                                                  @RequestParam(defaultValue = "LATEST") SortType sortType,
+                                                                                                  @RequestParam(required = false) Category category,
+                                                                                                  @RequestParam(required = false) PostStatus postStatus,
+                                                                                                  @AuthenticationPrincipal UserDetails userDetails) {
+        MarketingConsentPostPageResponse response = postQueryService.getMarketingConsentPosts(cursor, size, sortType, category, postStatus, userDetails);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
 }

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -597,16 +597,4 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.onSuccess(null));
     }
 
-    @GetMapping("/marketing-consent")
-    public ResponseEntity<ApiResponse<MarketingConsentPostPageResponse>> getMarketingConsentPosts(@RequestParam(required = false) Long cursor,
-                                                                                                  @RequestParam(defaultValue = "20") int size,
-                                                                                                  @RequestParam(defaultValue = "LATEST") SortType sortType,
-                                                                                                  @RequestParam(required = false) Category category,
-                                                                                                  @RequestParam(required = false) PostStatus postStatus,
-                                                                                                  @AuthenticationPrincipal UserDetails userDetails) {
-        MarketingConsentPostPageResponse response = postQueryService.getMarketingConsentPosts(cursor, size, sortType, category, postStatus, userDetails);
-
-        return ResponseEntity.ok(ApiResponse.onSuccess(response));
-    }
-
 }

--- a/src/main/java/com/fmi/domain/post/web/dto/response/MarketingConsentPostPageResponse.java
+++ b/src/main/java/com/fmi/domain/post/web/dto/response/MarketingConsentPostPageResponse.java
@@ -1,0 +1,10 @@
+package com.fmi.domain.post.web.dto.response;
+
+import java.util.List;
+
+public record MarketingConsentPostPageResponse(
+        List<PostBriefResponse> postList,
+        Long nextCursor,
+        boolean hasNext
+) {
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close #440 

## 🛠️ 작업 내용

- 마케팅 수신 동의 사용자 게시글 조회 API 구현 

## 📢 참고 및 특이사항



## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
