### PR TITLE
fix: 콘텐츠 활용 동의 게시글 조회 API 보강 및 정렬 옵션 추가, 공지샇아 대댓글 에러 수정 

### DIFF
--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -47,9 +47,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fmi.domain.admin.dto.AdminGuestInquiryPageResponse;
 
+import com.fmi.domain.auth.data.User;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostStatus;
 import com.fmi.domain.post.converter.util.PostConverter;
+import com.fmi.domain.post.service.HotPostService;
 import com.fmi.domain.post.service.PostImageService;
 import com.fmi.domain.post.web.dto.response.PostBriefResponse;
 import com.fmi.domain.postfavorite.service.PostFavoriteService;
@@ -57,6 +59,7 @@ import com.fmi.domain.postfavorite.service.PostFavoriteService;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -77,6 +80,7 @@ public class AdminService {
     private final IpBlacklistService ipBlacklistService;
     private final PostFavoriteService postFavoriteService;
     private final PostImageService postImageService;
+    private final HotPostService hotPostService;
     private final ReportAnswerImageRepository reportAnswerImageRepository;
 
     public Page<AdminInquiryResponse> getInquiryPage(InquiryType type,
@@ -423,7 +427,8 @@ public class AdminService {
 
     public CursorPageResponse<PostBriefResponse> getContentPolicyPosts(
             String sort, Category category, PostStatus postStatus,
-            Long cursor, Long cursorViewCount, int size) {
+            String keyword, Long cursor, Long cursorViewCount, int size,
+            String adminEmail) {
 
         size = Math.max(1, Math.min(size, 50));
         int fetchSize = size + 1;
@@ -431,13 +436,14 @@ public class AdminService {
 
         String categoryStr = category != null ? category.name() : null;
         String postStatusStr = postStatus != null ? postStatus.name() : null;
+        String trimmedKeyword = (keyword != null && !keyword.isBlank()) ? keyword.trim() : null;
 
         if ("popular".equals(sort)) {
             posts = postRepository.findContentPolicyPostsByPopular(
-                    categoryStr, postStatusStr, cursorViewCount, cursor, fetchSize);
+                    categoryStr, postStatusStr, trimmedKeyword, cursorViewCount, cursor, fetchSize);
         } else {
             posts = postRepository.findContentPolicyPostsByLatest(
-                    categoryStr, postStatusStr, cursor, fetchSize);
+                    categoryStr, postStatusStr, trimmedKeyword, cursor, fetchSize);
         }
 
         boolean hasNext = posts.size() > size;
@@ -448,14 +454,35 @@ public class AdminService {
         Map<Long, String> thumbnailMap = postImageService.findThumbnailUrlByPostList(content);
         Map<Long, Integer> imageCountMap = postImageService.countImageByPostList(content);
 
+        User adminUser = userRepository.findByEmail(adminEmail).orElse(null);
+        Map<Long, Boolean> favoriteStatusMap = (adminUser != null)
+                ? postFavoriteService.getIsFavoriteMap(adminUser, content)
+                : Map.of();
+
+        Set<Long> hotPostIds = hotPostService.resolveHotPostIdsForUser(
+                null, postStatus, category, null, null, 5);
+
         List<PostBriefResponse> responseList = content.stream()
-                .map(post -> PostConverter.toPostBriefResponse(
-                        post,
-                        false,
-                        thumbnailMap.getOrDefault(post.getId(), null),
-                        favoriteCountMap.getOrDefault(post.getId(), 0L),
-                        imageCountMap.getOrDefault(post.getId(), 0)
-                ))
+                .map(post -> {
+                    Long pid = post.getId();
+                    return new PostBriefResponse(
+                            pid,
+                            post.getTitle(),
+                            post.makeSummary(),
+                            thumbnailMap.getOrDefault(pid, null),
+                            post.getAddress(),
+                            post.getPostStatus(),
+                            post.getPostType(),
+                            post.getCategory(),
+                            favoriteCountMap.getOrDefault(pid, 0L),
+                            favoriteStatusMap.getOrDefault(pid, false),
+                            post.getViewCount(),
+                            post.isNew(),
+                            hotPostIds.contains(pid),
+                            post.getCreatedAt(),
+                            imageCountMap.getOrDefault(pid, 0)
+                    );
+                })
                 .toList();
 
         return new CursorPageResponse<>(responseList, nextCursor, hasNext);

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -1,6 +1,7 @@
 package com.fmi.domain.admin.service;
 
 import com.fmi.domain.Enum.Category;
+import com.fmi.domain.Enum.SortType;
 import com.fmi.domain.Enum.WithdrawalReason;
 import com.fmi.domain.admin.dto.AdminDeletedUserResponse;
 import com.fmi.domain.admin.dto.AdminInquiryResponse;
@@ -426,8 +427,8 @@ public class AdminService {
     }
 
     public CursorPageResponse<PostBriefResponse> getContentPolicyPosts(
-            String sort, Category category, PostStatus postStatus,
-            String keyword, Long cursor, Long cursorViewCount, int size,
+            SortType sortType, Category category, PostStatus postStatus,
+            String keyword, Long cursor, Long cursorViewCount, Long cursorFavCount, int size,
             String adminEmail) {
 
         size = Math.max(1, Math.min(size, 50));
@@ -438,13 +439,16 @@ public class AdminService {
         String postStatusStr = postStatus != null ? postStatus.name() : null;
         String trimmedKeyword = (keyword != null && !keyword.isBlank()) ? keyword.trim() : null;
 
-        if ("popular".equals(sort)) {
-            posts = postRepository.findContentPolicyPostsByPopular(
-                    categoryStr, postStatusStr, trimmedKeyword, cursorViewCount, cursor, fetchSize);
-        } else {
-            posts = postRepository.findContentPolicyPostsByLatest(
+        posts = switch (sortType) {
+            case OLDEST -> postRepository.findContentPolicyPostsByOldest(
                     categoryStr, postStatusStr, trimmedKeyword, cursor, fetchSize);
-        }
+            case MOST_VIEWED -> postRepository.findContentPolicyPostsByMostViewed(
+                    categoryStr, postStatusStr, trimmedKeyword, cursorViewCount, cursor, fetchSize);
+            case MOST_FAVORITED -> postRepository.findContentPolicyPostsByMostFavorited(
+                    categoryStr, postStatusStr, trimmedKeyword, cursorFavCount, cursor, fetchSize);
+            default -> postRepository.findContentPolicyPostsByLatest(
+                    categoryStr, postStatusStr, trimmedKeyword, cursor, fetchSize);
+        };
 
         boolean hasNext = posts.size() > size;
         List<Post> content = hasNext ? posts.subList(0, size) : posts;

--- a/src/main/java/com/fmi/domain/admin/service/AdminService.java
+++ b/src/main/java/com/fmi/domain/admin/service/AdminService.java
@@ -467,26 +467,14 @@ public class AdminService {
                 null, postStatus, category, null, null, 5);
 
         List<PostBriefResponse> responseList = content.stream()
-                .map(post -> {
-                    Long pid = post.getId();
-                    return new PostBriefResponse(
-                            pid,
-                            post.getTitle(),
-                            post.makeSummary(),
-                            thumbnailMap.getOrDefault(pid, null),
-                            post.getAddress(),
-                            post.getPostStatus(),
-                            post.getPostType(),
-                            post.getCategory(),
-                            favoriteCountMap.getOrDefault(pid, 0L),
-                            favoriteStatusMap.getOrDefault(pid, false),
-                            post.getViewCount(),
-                            post.isNew(),
-                            hotPostIds.contains(pid),
-                            post.getCreatedAt(),
-                            imageCountMap.getOrDefault(pid, 0)
-                    );
-                })
+                .map(post -> PostConverter.toPostBriefResponse(
+                        post,
+                        favoriteStatusMap.getOrDefault(post.getId(), false),
+                        thumbnailMap.getOrDefault(post.getId(), null),
+                        favoriteCountMap.getOrDefault(post.getId(), 0L),
+                        imageCountMap.getOrDefault(post.getId(), 0),
+                        hotPostIds.contains(post.getId())
+                ))
                 .toList();
 
         return new CursorPageResponse<>(responseList, nextCursor, hasNext);

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -462,11 +462,11 @@ public class AdminController {
         return ApiResponse.onSuccess(AuthConverter.toSignupResponse(id));
     }
 
-    @GetMapping("/posts/marketing")
+    @GetMapping("/posts/content-policy")
     @Operation(summary = "콘텐츠 활용 동의 유저 게시글 목록 조회",
             description = """
-                콘텐츠 활용 동의한 유저들의 게시글을 조회합니다.
-                커서 기반 무한스크롤을 지원하며, 정렬/카테고리/찾음 여부 필터를 제공합니다.
+                콘텐츠 활용에 동의한 유저들의 게시글을 조회합니다.
+                커서 기반 무한스크롤을 지원하며, 정렬/카테고리/찾음 여부/키워드 필터를 제공합니다.
 
                 **정렬 (sort):**
                 - latest: 최신순 (기본값)
@@ -475,9 +475,12 @@ public class AdminController {
                 **필터:**
                 - category: 카테고리 필터 (ELECTRONICS, WALLET, ID_CARD, JEWELRY, BAG, CARD, ETC)
                 - postStatus: 찾음 여부 필터 (SEARCHING, FOUND)
+                - keyword: 제목/내용 검색
                 """)
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자만 접근할 수 있습니다")
     })
     public ApiResponse<CursorPageResponse<PostBriefResponse>> getContentPolicyPosts(
             @Parameter(description = "정렬 (latest=최신순, popular=인기순)")
@@ -486,14 +489,17 @@ public class AdminController {
             @RequestParam(required = false) Category category,
             @Parameter(description = "찾음 여부 필터 (SEARCHING=찾는중, FOUND=찾음)")
             @RequestParam(required = false) PostStatus postStatus,
+            @Parameter(description = "제목/내용 키워드 검색")
+            @RequestParam(required = false) String keyword,
             @Parameter(description = "커서 (마지막 게시글 ID)")
             @RequestParam(required = false) Long cursor,
             @Parameter(description = "인기순 정렬 시 마지막 게시글의 조회수 (popular 정렬에서만 사용)")
             @RequestParam(required = false) Long cursorViewCount,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @AuthenticationPrincipal UserDetails userDetails
     ) {
         CursorPageResponse<PostBriefResponse> response =
-                adminService.getContentPolicyPosts(sort, category, postStatus, cursor, cursorViewCount, size);
+                adminService.getContentPolicyPosts(sort, category, postStatus, keyword, cursor, cursorViewCount, size, userDetails.getUsername());
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
+++ b/src/main/java/com/fmi/domain/admin/web/controller/AdminController.java
@@ -468,14 +468,21 @@ public class AdminController {
                 콘텐츠 활용에 동의한 유저들의 게시글을 조회합니다.
                 커서 기반 무한스크롤을 지원하며, 정렬/카테고리/찾음 여부/키워드 필터를 제공합니다.
 
-                **정렬 (sort):**
-                - latest: 최신순 (기본값)
-                - popular: 인기순 (조회수)
+                **정렬 (sortType):**
+                - LATEST: 최신순 (기본값)
+                - OLDEST: 오래된순
+                - MOST_VIEWED: 조회수 많은순
+                - MOST_FAVORITED: 즐겨찾기 많은순
 
                 **필터:**
                 - category: 카테고리 필터 (ELECTRONICS, WALLET, ID_CARD, JEWELRY, BAG, CARD, ETC)
                 - postStatus: 찾음 여부 필터 (SEARCHING, FOUND)
                 - keyword: 제목/내용 검색
+
+                **커서:**
+                - cursor: 마지막 게시글 ID
+                - cursorViewCount: MOST_VIEWED 정렬 시 마지막 게시글의 조회수
+                - cursorFavCount: MOST_FAVORITED 정렬 시 마지막 게시글의 즐겨찾기 수
                 """)
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
@@ -483,8 +490,8 @@ public class AdminController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자만 접근할 수 있습니다")
     })
     public ApiResponse<CursorPageResponse<PostBriefResponse>> getContentPolicyPosts(
-            @Parameter(description = "정렬 (latest=최신순, popular=인기순)")
-            @RequestParam(defaultValue = "latest") String sort,
+            @Parameter(description = "정렬 (LATEST=최신순, OLDEST=오래된순, MOST_VIEWED=조회수순, MOST_FAVORITED=즐겨찾기순)")
+            @RequestParam(defaultValue = "LATEST") SortType sortType,
             @Parameter(description = "카테고리 필터")
             @RequestParam(required = false) Category category,
             @Parameter(description = "찾음 여부 필터 (SEARCHING=찾는중, FOUND=찾음)")
@@ -493,13 +500,15 @@ public class AdminController {
             @RequestParam(required = false) String keyword,
             @Parameter(description = "커서 (마지막 게시글 ID)")
             @RequestParam(required = false) Long cursor,
-            @Parameter(description = "인기순 정렬 시 마지막 게시글의 조회수 (popular 정렬에서만 사용)")
+            @Parameter(description = "MOST_VIEWED 정렬 시 마지막 게시글의 조회수")
             @RequestParam(required = false) Long cursorViewCount,
+            @Parameter(description = "MOST_FAVORITED 정렬 시 마지막 게시글의 즐겨찾기 수")
+            @RequestParam(required = false) Long cursorFavCount,
             @RequestParam(defaultValue = "20") int size,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
         CursorPageResponse<PostBriefResponse> response =
-                adminService.getContentPolicyPosts(sort, category, postStatus, keyword, cursor, cursorViewCount, size, userDetails.getUsername());
+                adminService.getContentPolicyPosts(sortType, category, postStatus, keyword, cursor, cursorViewCount, cursorFavCount, size, userDetails.getUsername());
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/fmi/domain/noticecomment/repository/NoticeCommentRepository.java
+++ b/src/main/java/com/fmi/domain/noticecomment/repository/NoticeCommentRepository.java
@@ -22,11 +22,11 @@ public interface NoticeCommentRepository extends JpaRepository<NoticeComment, Lo
     List<Object[]> countByParentIds(@Param("parentIds") List<Long> parentIds);
 
     @Query("select c from NoticeComment c join fetch c.user left join fetch c.parent " +
-            "where c.notice.noticeId = :noticeId order by c.id desc")
+            "where c.notice.noticeId = :noticeId and c.parent is null order by c.id desc")
     Slice<NoticeComment> findTopByNoticeIdOrderByIdDesc(@Param("noticeId") Long noticeId, Pageable pageable);
 
     @Query("select c from NoticeComment c join fetch c.user left join fetch c.parent " +
-            "where c.notice.noticeId = :noticeId and c.id < :cursor order by c.id desc")
+            "where c.notice.noticeId = :noticeId and c.parent is null and c.id < :cursor order by c.id desc")
     Slice<NoticeComment> findByNoticeIdAndIdLessThanOrderByIdDesc(@Param("noticeId") Long noticeId,
                                                                   @Param("cursor") Long cursor,
                                                                   Pageable pageable);

--- a/src/main/java/com/fmi/domain/post/converter/util/PostConverter.java
+++ b/src/main/java/com/fmi/domain/post/converter/util/PostConverter.java
@@ -59,6 +59,10 @@ public final class PostConverter {
     }
 
     public static PostBriefResponse toPostBriefResponse(Post post, boolean isFavorite, String thumbnailImageUrl, Long favoriteCount, Integer imageCount) {
+        return toPostBriefResponse(post, isFavorite, thumbnailImageUrl, favoriteCount, imageCount, false);
+    }
+
+    public static PostBriefResponse toPostBriefResponse(Post post, boolean isFavorite, String thumbnailImageUrl, Long favoriteCount, Integer imageCount, boolean isHot) {
         return new PostBriefResponse(
                 post.getId(),
                 post.getTitle(),
@@ -72,7 +76,7 @@ public final class PostConverter {
                 isFavorite,
                 post.getViewCount(),
                 post.isNew(),
-                false,
+                isHot,
                 post.getCreatedAt(),
                 imageCount
         );

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -107,7 +107,26 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
                                               @Param("cursor") Long cursor,
                                               @Param("limit") int limit);
 
-    // 콘텐츠 활용 동의 유저 게시글 - 인기순 (view_count + id 복합 커서)
+    // 콘텐츠 활용 동의 유저 게시글 - 오래된순
+    @Query(value = """
+            SELECT p.* FROM post p
+            INNER JOIN users u ON p.user_id = u.id
+            WHERE u.content_policy_agreed = true AND u.deleted = false
+              AND p.temporary_save = false AND p.deleted = false
+              AND (:category IS NULL OR p.category = :category)
+              AND (:postStatus IS NULL OR p.item_status = :postStatus)
+              AND (:keyword IS NULL OR p.title LIKE CONCAT('%', :keyword, '%') OR p.content LIKE CONCAT('%', :keyword, '%'))
+              AND (:cursor IS NULL OR p.id > :cursor)
+            ORDER BY p.id ASC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<Post> findContentPolicyPostsByOldest(@Param("category") String category,
+                                              @Param("postStatus") String postStatus,
+                                              @Param("keyword") String keyword,
+                                              @Param("cursor") Long cursor,
+                                              @Param("limit") int limit);
+
+    // 콘텐츠 활용 동의 유저 게시글 - 조회수 많은순
     @Query(value = """
             SELECT p.* FROM post p
             INNER JOIN users u ON p.user_id = u.id
@@ -120,11 +139,34 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
             ORDER BY p.view_count DESC, p.id DESC
             LIMIT :limit
             """, nativeQuery = true)
-    List<Post> findContentPolicyPostsByPopular(@Param("category") String category,
-                                               @Param("postStatus") String postStatus,
-                                               @Param("keyword") String keyword,
-                                               @Param("cursorViewCount") Long cursorViewCount,
-                                               @Param("cursorId") Long cursorId,
-                                               @Param("limit") int limit);
+    List<Post> findContentPolicyPostsByMostViewed(@Param("category") String category,
+                                                   @Param("postStatus") String postStatus,
+                                                   @Param("keyword") String keyword,
+                                                   @Param("cursorViewCount") Long cursorViewCount,
+                                                   @Param("cursorId") Long cursorId,
+                                                   @Param("limit") int limit);
+
+    // 콘텐츠 활용 동의 유저 게시글 - 즐겨찾기 많은순
+    @Query(value = """
+            SELECT p.*, COUNT(pf.favorite_id) AS fav_count FROM post p
+            INNER JOIN users u ON p.user_id = u.id
+            LEFT JOIN post_favorite pf ON pf.post_id = p.id AND pf.is_favorite = true
+            WHERE u.content_policy_agreed = true AND u.deleted = false
+              AND p.temporary_save = false AND p.deleted = false
+              AND (:category IS NULL OR p.category = :category)
+              AND (:postStatus IS NULL OR p.item_status = :postStatus)
+              AND (:keyword IS NULL OR p.title LIKE CONCAT('%', :keyword, '%') OR p.content LIKE CONCAT('%', :keyword, '%'))
+            GROUP BY p.id
+            HAVING (:cursorFavCount IS NULL OR COUNT(pf.favorite_id) < :cursorFavCount
+                    OR (COUNT(pf.favorite_id) = :cursorFavCount AND p.id < :cursorId))
+            ORDER BY fav_count DESC, p.id DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<Post> findContentPolicyPostsByMostFavorited(@Param("category") String category,
+                                                      @Param("postStatus") String postStatus,
+                                                      @Param("keyword") String keyword,
+                                                      @Param("cursorFavCount") Long cursorFavCount,
+                                                      @Param("cursorId") Long cursorId,
+                                                      @Param("limit") int limit);
 
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepository.java
@@ -96,14 +96,16 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
               AND p.temporary_save = false AND p.deleted = false
               AND (:category IS NULL OR p.category = :category)
               AND (:postStatus IS NULL OR p.item_status = :postStatus)
+              AND (:keyword IS NULL OR p.title LIKE CONCAT('%', :keyword, '%') OR p.content LIKE CONCAT('%', :keyword, '%'))
               AND (:cursor IS NULL OR p.id < :cursor)
             ORDER BY p.id DESC
             LIMIT :limit
             """, nativeQuery = true)
     List<Post> findContentPolicyPostsByLatest(@Param("category") String category,
-                                               @Param("postStatus") String postStatus,
-                                               @Param("cursor") Long cursor,
-                                               @Param("limit") int limit);
+                                              @Param("postStatus") String postStatus,
+                                              @Param("keyword") String keyword,
+                                              @Param("cursor") Long cursor,
+                                              @Param("limit") int limit);
 
     // 콘텐츠 활용 동의 유저 게시글 - 인기순 (view_count + id 복합 커서)
     @Query(value = """
@@ -113,14 +115,16 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
               AND p.temporary_save = false AND p.deleted = false
               AND (:category IS NULL OR p.category = :category)
               AND (:postStatus IS NULL OR p.item_status = :postStatus)
+              AND (:keyword IS NULL OR p.title LIKE CONCAT('%', :keyword, '%') OR p.content LIKE CONCAT('%', :keyword, '%'))
               AND (:cursorViewCount IS NULL OR (p.view_count < :cursorViewCount OR (p.view_count = :cursorViewCount AND p.id < :cursorId)))
             ORDER BY p.view_count DESC, p.id DESC
             LIMIT :limit
             """, nativeQuery = true)
     List<Post> findContentPolicyPostsByPopular(@Param("category") String category,
-                                                @Param("postStatus") String postStatus,
-                                                @Param("cursorViewCount") Long cursorViewCount,
-                                                @Param("cursorId") Long cursorId,
-                                                @Param("limit") int limit);
+                                               @Param("postStatus") String postStatus,
+                                               @Param("keyword") String keyword,
+                                               @Param("cursorViewCount") Long cursorViewCount,
+                                               @Param("cursorId") Long cursorId,
+                                               @Param("limit") int limit);
 
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #450 

## 🛠️ 작업 내용

- 콘텐츠 활용 동의 게시글 조회 API 보강 및 정렬 옵션 추가
- 공지사항 대댓글 에러 수정 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
