### PR TITLE
chore: Loki 로그 수집 환경 구성 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // Log
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
         max-file: "2"
 
   alloy:
-    image: grafana/alloy:latest
+    image: grafana/alloy:v1.15.0
     container_name: alloy
     restart: unless-stopped
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,11 @@ services:
       timeout: 10s
       retries: 5
       start_period: 60s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   fmi-dev:
     image: ${ECR_IMAGE_URL}:latest
@@ -53,6 +58,28 @@ services:
       timeout: 10s
       retries: 5
       start_period: 60s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "2"
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    restart: unless-stopped
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy
+      - /var/run/docker.sock:/var/run/docker.sock:ro # 컨테이너 로그 접근 권한
+      - alloy_data:/var/lib/alloy/data
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - /etc/alloy/config.alloy
+    depends_on:
+      - fmi-prod
+      - fmi-dev
 
 volumes:
   redis_data:
+  alloy_data:

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     ports:
       - "3100:3100"
     volumes:
-      - loki_data:/loki
+      - loki_data:/tmp/loki
     command: -config.file=/etc/loki/local-config.yaml
 
 volumes:

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -24,7 +24,19 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
     depends_on:
       - prometheus
+      - loki
+
+  loki:
+    image: grafana/loki:3.4.1
+    container_name: loki
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    volumes:
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
 
 volumes:
   prometheus_data:
   grafana_data:
+  loki_data:

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - loki
 
   loki:
-    image: grafana/loki:3.4.1
+    image: grafana/loki:3.7.0
     container_name: loki
     restart: unless-stopped
     ports:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,13 +4,15 @@
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
     <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
             <providers>
                 <timestamp/>
                 <logLevel/>
-                <mdc/> <loggerName/>
+                <mdc/>
+                <loggerName/>
                 <message/>
-                <stackTrace/> </providers>
+                <stackTrace/>
+            </providers>
         </encoder>
     </appender>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <providers>
+                <timestamp/>
+                <logLevel/>
+                <mdc/> <loggerName/>
+                <message/>
+                <stackTrace/> </providers>
+        </encoder>
+    </appender>
+
+    <springProfile name="prod,dev">
+        <root level="INFO">
+            <appender-ref ref="JSON_CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="default,local,local-mysql">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 🧩 관련 이슈

- close #456 

## 🛠️ 작업 내용

- logback-spring.xml 추가
  - prod, dev 환경에서 JSON 형식 로그 출력
  - 로컬 환경은 기존 텍스트 로그 유지
- micrometer-tracing-bridge-brave 의존성 추가
  - 모든 요청에 traceId, spanId 자동 생성 (sampling 1.0)
- logstash-logback-encoder 의존성 추가
- application.yml tracing 설정 추가


- docker-compose.yml에 Alloy 컨테이너 추가
  - Docker 소켓 마운트로 컨테이너 로그 수집
  - Loki로 로그 전송
- fmi-prod, fmi-dev 로그 드라이버 설정 추가
  - prod: 10MB × 3개
  - dev: 10MB × 2개

### 모니터링
- docker-compose.yml에 Loki 추가
- Grafana depends_on에 Loki 추가


## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
