### PR TITLE
feat: 채팅 신고 접수 시 상대 유저 자동 차단

### DIFF
--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -15,13 +15,14 @@ import static com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.*;
 
 public class ChatRoomConverter {
 
-    public static ChatRoomResultDTO toChatRoomResultDTO(ChatRoom chatRoom, User user, Post post, Long unreadCount, String thumbnailUrl) {
+    public static ChatRoomResultDTO toChatRoomResultDTO(ChatRoom chatRoom, User user, Post post, Long unreadCount, String thumbnailUrl, boolean isBlocked) {
 
         var opponentUser = opponentUserDTO.builder()
                 .opponentUserId(user.getId())
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfile_img() == null ? null : user.getProfile_img())
                 .emailVerified(user.isEmail_verified())
+                .blocked(isBlocked)
                 .build();
 
         var postInfo = PostInfoDTO.builder()

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
@@ -15,6 +15,7 @@ import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.post.service.PostImageService;
+import com.fmi.domain.userblock.service.BlockService;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,7 @@ public class ChatRoomService {
     private final ChatRoomParticipantRepository chatRoomParticipantRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final PostImageService postImageService;
+    private final BlockService blockService;
 
     public Pair<ChatRoomResultDTO, Boolean> createChatRoom(Long postId, Long contactUserId) {
 
@@ -62,13 +64,15 @@ public class ChatRoomService {
 
         String thumbnailImageUrl = postImageService.findThumbnailImageUrl(post);
 
+        boolean isBlocked = blockService.isBlocked(contactUserId, opponentUser.getId());
+
         // 채팅방이 이미 존재하는 경우
         if (optionalChatRoom.isPresent()) {
             ChatRoom existingRoom = optionalChatRoom.get();
 
             Long unreadCount = existingRoom.getParticipant(contactUserId).getUnreadCount();
 
-            ChatRoomResultDTO dto = ChatRoomConverter.toChatRoomResultDTO(existingRoom, opponentUser, post, unreadCount, thumbnailImageUrl);
+            ChatRoomResultDTO dto = ChatRoomConverter.toChatRoomResultDTO(existingRoom, opponentUser, post, unreadCount, thumbnailImageUrl, isBlocked);
 
             return Pair.of(dto, false);
         }
@@ -97,7 +101,7 @@ public class ChatRoomService {
 
             chatRoomRepository.save(newRoom);
 
-            ChatRoomResultDTO dto = ChatRoomConverter.toChatRoomResultDTO(newRoom, opponentUser, post, 0L, thumbnailImageUrl);
+            ChatRoomResultDTO dto = ChatRoomConverter.toChatRoomResultDTO(newRoom, opponentUser, post, 0L, thumbnailImageUrl, isBlocked);
 
             return Pair.of(dto, true);
         }
@@ -164,7 +168,9 @@ public class ChatRoomService {
 
         String thumbnailImageUrl = postImageService.findThumbnailImageUrl(post);
 
-        return ChatRoomConverter.toChatRoomResultDTO(chatRoom, opponent, post, unreadCount, thumbnailImageUrl);
+        boolean isBlocked = blockService.isBlocked(user.getId(), opponent.getId());
+
+        return ChatRoomConverter.toChatRoomResultDTO(chatRoom, opponent, post, unreadCount, thumbnailImageUrl, isBlocked);
 
     }
 

--- a/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/dto/ChatRoomResponseDTO.java
@@ -34,6 +34,7 @@ public class ChatRoomResponseDTO {
         private String nickname;
         private String profileImageUrl;
         private boolean emailVerified;
+        private boolean blocked;
     }
 
     @Builder

--- a/src/main/java/com/fmi/domain/report/service/ReportService.java
+++ b/src/main/java/com/fmi/domain/report/service/ReportService.java
@@ -3,6 +3,7 @@ package com.fmi.domain.report.service;
 import com.fmi.domain.Enum.Role;
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.domain.chatroom.data.ChatRoom;
 import com.fmi.domain.chatroom.repository.ChatRoomRepository;
 import com.fmi.domain.comment.repository.CommentRepository;
 import com.fmi.domain.notification.data.enums.NotificationType;
@@ -21,6 +22,7 @@ import com.fmi.domain.report.repository.ReportRepository;
 import com.fmi.domain.report.web.dto.request.ReportCreateRequestDTO;
 import com.fmi.domain.report.web.dto.response.ReportDetailDTO;
 import com.fmi.domain.report.web.dto.response.ReportListDTO;
+import com.fmi.domain.userblock.service.BlockService;
 import com.fmi.global.apiPayload.CursorPageResponse;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
@@ -53,6 +55,7 @@ public class ReportService {
     private final EmailService emailService;
     private final ReportAnswerImageRepository reportAnswerImageRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final BlockService blockService;
 
     /**
      * 신고하기 (통합)
@@ -87,6 +90,9 @@ public class ReportService {
                 .build();
         
         Report saved = reportRepository.save(report);
+
+        // 채팅 신고면 상대방 차단
+        autoBlockOnChatReport(request, user);
 
         eventPublisher.publishEvent(ReportEvent.from(saved, user));
 
@@ -377,6 +383,27 @@ public class ReportService {
             log.warn("피신고자 조회 실패: targetType={}, targetId={}", targetType, targetId, e);
             return null;
         }
+    }
+
+    /**
+     * 채팅 신고면 상대방 차단
+     */
+    private void autoBlockOnChatReport(ReportCreateRequestDTO request, User reporter) {
+        if (request.getTargetType() != ReportTargetType.CHAT) {
+            return;
+        }
+
+        ChatRoom room = chatRoomRepository.findById(request.getTargetId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
+
+        // 신고자가 해당 채팅방 참여자가 아니면 차단 로직 진행 안 함
+        if (!room.isParticipant(reporter)) {
+            throw new GeneralException(ErrorStatus._CHATROOM_ACCESS_DENIED);
+        }
+
+        User targetUser = room.getOtherParticipant(reporter.getId());
+
+        blockService.block(reporter.getId(), targetUser.getId());
     }
 }
 

--- a/src/main/java/com/fmi/domain/report/service/ReportService.java
+++ b/src/main/java/com/fmi/domain/report/service/ReportService.java
@@ -78,7 +78,7 @@ public class ReportService {
                 });
         
         // 신고 대상 존재 여부 확인
-        validateTargetExists(request.getTargetType(), request.getTargetId());
+        validateTargetExists(request.getTargetType(), request.getTargetId(), user);
         
         // 신고 생성
         Report report = Report.builder()
@@ -199,7 +199,7 @@ public class ReportService {
     /**
      * 신고 대상 존재 확인
      */
-    private void validateTargetExists(ReportTargetType targetType, Long targetId) {
+    private void validateTargetExists(ReportTargetType targetType, Long targetId, User reporter) {
         switch (targetType) {
             case POST:
                 postRepository.findById(targetId)
@@ -214,8 +214,11 @@ public class ReportService {
                         .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
                 break;
             case CHAT:
-                chatRoomRepository.findById(targetId)
+                ChatRoom room = chatRoomRepository.findById(targetId)
                         .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
+                if (!room.isParticipant(reporter)) {
+                    throw new GeneralException(ErrorStatus._CHATROOM_ACCESS_DENIED);
+                }
                 break;
         }
     }
@@ -395,11 +398,6 @@ public class ReportService {
 
         ChatRoom room = chatRoomRepository.findById(request.getTargetId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
-
-        // 신고자가 해당 채팅방 참여자가 아니면 차단 로직 진행 안 함
-        if (!room.isParticipant(reporter)) {
-            throw new GeneralException(ErrorStatus._CHATROOM_ACCESS_DENIED);
-        }
 
         User targetUser = room.getOtherParticipant(reporter.getId());
 

--- a/src/test/java/com/fmi/domain/chatroom/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/fmi/domain/chatroom/service/ChatRoomServiceTest.java
@@ -1,0 +1,101 @@
+package com.fmi.domain.chatroom.service;
+
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.domain.chatmessage.repository.ChatMessageRepository;
+import com.fmi.domain.chatroom.data.ChatRoom;
+import com.fmi.domain.chatroom.data.ChatRoomParticipant;
+import com.fmi.domain.chatroom.repository.ChatRoomParticipantRepository;
+import com.fmi.domain.chatroom.repository.ChatRoomRepository;
+import com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.ChatRoomResultDTO;
+import com.fmi.domain.post.data.Post;
+import com.fmi.domain.post.repository.PostRepository;
+import com.fmi.domain.post.service.PostImageService;
+import com.fmi.domain.userblock.service.BlockService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ChatRoomServiceTest {
+
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private PostRepository postRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ChatRoomParticipantRepository chatRoomParticipantRepository;
+    @Mock private ChatMessageRepository chatMessageRepository;
+    @Mock private PostImageService postImageService;
+    @Mock private BlockService blockService;
+
+    @InjectMocks
+    private ChatRoomService chatRoomService;
+
+    private User currentUser;
+    private User opponent;
+    private ChatRoom chatRoom;
+    private Post post;
+    private ChatRoomParticipant participant;
+
+    @BeforeEach
+    void setUp() {
+        currentUser = User.builder().id(1L).email("me@test.com").nickname("나").build();
+        opponent = User.builder().id(2L).email("other@test.com").nickname("상대").build();
+
+        post = mock(Post.class);
+        given(post.getId()).willReturn(99L);
+
+        chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(10L);
+        given(chatRoom.getPost()).willReturn(post);
+        given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
+
+        participant = ChatRoomParticipant.builder()
+                .user(currentUser)
+                .unreadCount(0L)
+                .build();
+        given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
+
+        given(postImageService.findThumbnailImageUrl(post)).willReturn(null);
+    }
+
+    @Test
+    @DisplayName("getChatRoomDetail - 차단 상태이면 opponentUser.blocked = true")
+    void getChatRoomDetail_blocked_returnsIsBlockedTrue() {
+        // given
+        given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+        given(blockService.isBlocked(currentUser.getId(), opponent.getId())).willReturn(true);
+
+        // when
+        ChatRoomResultDTO result = chatRoomService.getChatRoomDetail(10L, currentUser);
+
+        // then
+        assertThat(result.getOpponentUser().isBlocked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getChatRoomDetail - 차단 상태가 아니면 opponentUser.blocked = false")
+    void getChatRoomDetail_notBlocked_returnsIsBlockedFalse() {
+        // given
+        given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+        given(blockService.isBlocked(currentUser.getId(), opponent.getId())).willReturn(false);
+
+        // when
+        ChatRoomResultDTO result = chatRoomService.getChatRoomDetail(10L, currentUser);
+
+        // then
+        assertThat(result.getOpponentUser().isBlocked()).isFalse();
+    }
+}

--- a/src/test/java/com/fmi/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/com/fmi/domain/report/service/ReportServiceTest.java
@@ -1,0 +1,145 @@
+package com.fmi.domain.report.service;
+
+import com.fmi.domain.Enum.Role;
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.domain.chatroom.data.ChatRoom;
+import com.fmi.domain.chatroom.repository.ChatRoomRepository;
+import com.fmi.domain.comment.repository.CommentRepository;
+import com.fmi.domain.post.repository.PostRepository;
+import com.fmi.domain.report.converter.ReportConverter;
+import com.fmi.domain.report.data.Report;
+import com.fmi.domain.report.data.enums.ReportTargetType;
+import com.fmi.domain.report.data.enums.ReportType;
+import com.fmi.domain.report.repository.ReportAnswerImageRepository;
+import com.fmi.domain.report.repository.ReportRepository;
+import com.fmi.domain.report.web.dto.request.ReportCreateRequestDTO;
+import com.fmi.domain.notification.service.NotificationService;
+import com.fmi.domain.userblock.service.BlockService;
+import com.fmi.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ReportServiceTest {
+
+    @Mock private ReportRepository reportRepository;
+    @Mock private PostRepository postRepository;
+    @Mock private CommentRepository commentRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private ReportConverter reportConverter;
+    @Mock private NotificationService notificationService;
+    @Mock private EmailService emailService;
+    @Mock private ReportAnswerImageRepository reportAnswerImageRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private BlockService blockService;
+
+    @InjectMocks
+    private ReportService reportService;
+
+    private User reporter;
+    private User targetUser;
+    private ChatRoom chatRoom;
+    private UserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        reporter = User.builder()
+                .id(1L)
+                .email("reporter@test.com")
+                .nickname("신고자")
+                .role(Role.USER)
+                .build();
+
+        targetUser = User.builder()
+                .id(2L)
+                .email("target@test.com")
+                .nickname("피신고자")
+                .role(Role.USER)
+                .build();
+
+        chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(10L);
+        given(chatRoom.isParticipant(reporter)).willReturn(true);
+        given(chatRoom.getOtherParticipant(reporter.getId())).willReturn(targetUser);
+
+        userDetails = mock(UserDetails.class);
+        given(userDetails.getUsername()).willReturn(reporter.getEmail());
+    }
+
+    @Test
+    @DisplayName("채팅 신고 시 상대방이 자동으로 차단된다")
+    void createReport_chat_autoBlocksOpponent() {
+        // given
+        ReportCreateRequestDTO request = new ReportCreateRequestDTO(
+                ReportTargetType.CHAT, 10L, ReportType.SPAM, "스팸 메시지"
+        );
+
+        given(userRepository.findByEmail(reporter.getEmail())).willReturn(Optional.of(reporter));
+        given(reportRepository.findByReporterAndTargetTypeAndTargetId(reporter, ReportTargetType.CHAT, 10L))
+                .willReturn(Optional.empty());
+        given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+
+        Report savedReport = Report.builder()
+                .reportId(100L)
+                .reporter(reporter)
+                .targetType(ReportTargetType.CHAT)
+                .targetId(10L)
+                .reportType(ReportType.SPAM)
+                .build();
+        given(reportRepository.save(any(Report.class))).willReturn(savedReport);
+
+        // when
+        reportService.createReport(request, userDetails);
+
+        // then
+        then(blockService).should().block(reporter.getId(), targetUser.getId());
+    }
+
+    @Test
+    @DisplayName("채팅 외 신고(게시글)는 자동 차단이 발생하지 않는다")
+    void createReport_nonChat_doesNotBlock() {
+        // given
+        ReportCreateRequestDTO request = new ReportCreateRequestDTO(
+                ReportTargetType.POST, 99L, ReportType.SPAM, "스팸 게시글"
+        );
+
+        given(userRepository.findByEmail(reporter.getEmail())).willReturn(Optional.of(reporter));
+        given(reportRepository.findByReporterAndTargetTypeAndTargetId(reporter, ReportTargetType.POST, 99L))
+                .willReturn(Optional.empty());
+        given(postRepository.findById(99L)).willReturn(Optional.of(mock(com.fmi.domain.post.data.Post.class)));
+
+        Report savedReport = Report.builder()
+                .reportId(101L)
+                .reporter(reporter)
+                .targetType(ReportTargetType.POST)
+                .targetId(99L)
+                .reportType(ReportType.SPAM)
+                .build();
+        given(reportRepository.save(any(Report.class))).willReturn(savedReport);
+
+        // when
+        reportService.createReport(request, userDetails);
+
+        // then
+        then(blockService).shouldHaveNoInteractions();
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close #458 

## 🛠️ 작업 내용

- 채팅 신고 접수 시 자동으로 상대 유저를 차단하는 기능을 추가했습니다.
- 채팅 응답에서 상대 유저가 차단된 유저인지 확인하는 컬럼(blocked)을 추가했습니다. 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
