### PR TITLE
refactor: 게시글 삭제 후 채팅방 게시글 정보 스냅샷 유지 

### DIFF
--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatMessageService.java
@@ -132,7 +132,9 @@ public class ChatMessageService {
         List<ChatRoomParticipant> allParticipants = chatRoomParticipantRepository.findAllByChatRoom_Id(roomId);
         User sender = newMessage.getUser();
         Long senderId = sender.getId();
-        Long postId = newMessage.getChatRoom().getPost().getId();
+        Long postId = newMessage.getChatRoom().isSourcePostDeleted() || newMessage.getChatRoom().getPost() == null
+                ? newMessage.getChatRoom().getSourcePostId()
+                : newMessage.getChatRoom().getPost().getId();
 
         for (ChatRoomParticipant pt : allParticipants) {
             // 메시지 갱신 및 ACTIVE 설정

--- a/src/main/java/com/fmi/domain/chatmessage/service/ChatNotificationService.java
+++ b/src/main/java/com/fmi/domain/chatmessage/service/ChatNotificationService.java
@@ -5,6 +5,9 @@ import com.fmi.domain.notification.data.Notification;
 import com.fmi.domain.notification.data.NotificationSettings;
 import com.fmi.domain.notification.data.enums.NotificationType;
 import com.fmi.domain.notification.data.enums.ReferenceType;
+import com.fmi.domain.chatroom.data.ChatRoom;
+import com.fmi.domain.chatroom.repository.ChatRoomRepository;
+import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.notification.repository.NotificationRepository;
 import com.fmi.domain.notification.repository.NotificationSettingsRepository;
 import com.fmi.domain.notification.service.NotificationService;
@@ -12,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -21,6 +25,8 @@ public class ChatNotificationService {
     private final NotificationRepository notificationRepository;
     private final NotificationSettingsRepository notificationSettingsRepository;
     private final NotificationService notificationService;
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
 
     /**
      * 채팅 알림을 갱신하거나 새로 생성합니다.
@@ -59,6 +65,18 @@ public class ChatNotificationService {
                     roomId
             );
         }
+    }
+
+    public void markAsReadOnEnter(Long roomId, Long userId) {
+        chatRoomRepository.findById(roomId).ifPresent(chatRoom -> {
+            Long postId = chatRoom.isSourcePostDeleted() || chatRoom.getPost() == null
+                    ? chatRoom.getSourcePostId()
+                    : chatRoom.getPost().getId();
+            userRepository.findById(userId).ifPresent(user ->
+                    notificationService.markNotificationsAsReadByReference(user, postId,
+                            List.of(NotificationType.CHAT, NotificationType.CHAT_REMINDER))
+            );
+        });
     }
 
 }

--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -55,13 +55,13 @@ public class ChatRoomConverter {
                 .build();
 
         var postInfo = PostInfoDTO.builder()
-                .postId(chatRoom.getSource_post_id())
-                .postType(chatRoom.getSource_post_type())
-                .category(chatRoom.getSource_category())
-                .title(chatRoom.getSource_title())
-                .address(chatRoom.getSource_address())
-                .thumbnailUrl(chatRoom.getSource_thumbnail_url())
-                .postStatus(chatRoom.getSource_postStatus())
+                .postId(chatRoom.getSourcePostId())
+                .postType(chatRoom.getSourcePostType())
+                .category(chatRoom.getSourceCategory())
+                .title(chatRoom.getSourceTitle())
+                .address(chatRoom.getSourceAddress())
+                .thumbnailUrl(chatRoom.getSourceThumbnailUrl())
+                .postStatus(chatRoom.getSourcePostStatus())
                 .deleted(true)
                 .build();
 
@@ -95,7 +95,7 @@ public class ChatRoomConverter {
         ChatRoom room = participant.getChatRoom();
 
         PostInfoDTO postInfoDTO;
-        if (!room.isSource_post_deleted()) {
+        if (!room.isSourcePostDeleted()) {
             Post post = room.getPost();
             postInfoDTO = PostInfoDTO.builder()
                     .postId(post.getId())
@@ -109,13 +109,13 @@ public class ChatRoomConverter {
                     .build();
         } else {
             postInfoDTO = PostInfoDTO.builder()
-                    .postId(room.getSource_post_id())
-                    .postType(room.getSource_post_type())
-                    .category(room.getSource_category())
-                    .title(room.getSource_title())
-                    .address(room.getSource_address())
-                    .thumbnailUrl(room.getSource_thumbnail_url())
-                    .postStatus(room.getSource_postStatus())
+                    .postId(room.getSourcePostId())
+                    .postType(room.getSourcePostType())
+                    .category(room.getSourceCategory())
+                    .title(room.getSourceTitle())
+                    .address(room.getSourceAddress())
+                    .thumbnailUrl(room.getSourceThumbnailUrl())
+                    .postStatus(room.getSourcePostStatus())
                     .deleted(true)
                     .build();
         }

--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -44,6 +44,35 @@ public class ChatRoomConverter {
                 .build();
     }
 
+    public static ChatRoomResultDTO toChatRoomResultDTOFromSnapshot(ChatRoom chatRoom, User opponent, Long unreadCount, boolean isBlocked) {
+
+        var opponentUser = opponentUserDTO.builder()
+                .opponentUserId(opponent.getId())
+                .nickname(opponent.getNickname())
+                .profileImageUrl(opponent.getProfile_img())
+                .emailVerified(opponent.isEmail_verified())
+                .blocked(isBlocked)
+                .build();
+
+        var postInfo = PostInfoDTO.builder()
+                .postId(chatRoom.getSource_post_id())
+                .postType(chatRoom.getSource_post_type())
+                .category(chatRoom.getSource_category())
+                .title(chatRoom.getSource_title())
+                .address(chatRoom.getSource_address())
+                .thumbnailUrl(chatRoom.getSource_thumbnail_url())
+                .postStatus(chatRoom.getSource_postStatus())
+                .deleted(true)
+                .build();
+
+        return ChatRoomResultDTO.builder()
+                .roomId(chatRoom.getId())
+                .unreadCount(unreadCount)
+                .opponentUser(opponentUser)
+                .postInfo(postInfo)
+                .build();
+    }
+
     public static List<ChatRoomSummaryDTO> toChatRoomSummaryListDTO(List<ChatRoomParticipant> participants, User currentUser, Map<Long, String> thumbnailMap) {
         return participants.stream()
                 .map(pt -> {
@@ -63,20 +92,33 @@ public class ChatRoomConverter {
                 .profileImageUrl(contactUser.getProfile_img())
                 .build();
 
-        Post post = participant.getChatRoom().getPost();
+        ChatRoom room = participant.getChatRoom();
 
-        String thumbnailUrl = thumbnailMap.get(post.getId());
-
-        PostInfoDTO postInfoDTO = PostInfoDTO.builder()
-                .postId(post.getId())
-                .postType(post.getPostType())
-                .category(post.getCategory())
-                .title(post.getTitle())
-                .address(post.getAddress())
-                .thumbnailUrl(thumbnailUrl)
-                .postStatus(post.getPostStatus())
-                .deleted(post.isDeleted())
-                .build();
+        PostInfoDTO postInfoDTO;
+        if (!room.isSource_post_deleted()) {
+            Post post = room.getPost();
+            postInfoDTO = PostInfoDTO.builder()
+                    .postId(post.getId())
+                    .postType(post.getPostType())
+                    .category(post.getCategory())
+                    .title(post.getTitle())
+                    .address(post.getAddress())
+                    .thumbnailUrl(thumbnailMap.get(post.getId()))
+                    .postStatus(post.getPostStatus())
+                    .deleted(false)
+                    .build();
+        } else {
+            postInfoDTO = PostInfoDTO.builder()
+                    .postId(room.getSource_post_id())
+                    .postType(room.getSource_post_type())
+                    .category(room.getSource_category())
+                    .title(room.getSource_title())
+                    .address(room.getSource_address())
+                    .thumbnailUrl(room.getSource_thumbnail_url())
+                    .postStatus(room.getSource_postStatus())
+                    .deleted(true)
+                    .build();
+        }
 
         ChatMessage lastMessage = participant.getLastMessage();
         String content = null;

--- a/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
+++ b/src/main/java/com/fmi/domain/chatroom/converter/ChatRoomConverter.java
@@ -95,7 +95,7 @@ public class ChatRoomConverter {
         ChatRoom room = participant.getChatRoom();
 
         PostInfoDTO postInfoDTO;
-        if (!room.isSourcePostDeleted()) {
+        if (!room.isSourcePostDeleted() && room.getPost() != null) {
             Post post = room.getPost();
             postInfoDTO = PostInfoDTO.builder()
                     .postId(post.getId())

--- a/src/main/java/com/fmi/domain/chatroom/data/ChatRoom.java
+++ b/src/main/java/com/fmi/domain/chatroom/data/ChatRoom.java
@@ -36,24 +36,24 @@ public class ChatRoom {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    private Long source_post_id;
+    private Long sourcePostId;
 
-    private String source_address;
+    private String sourceAddress;
 
-    private String source_title;
-
-    @Enumerated(EnumType.STRING)
-    private PostType source_post_type;
+    private String sourceTitle;
 
     @Enumerated(EnumType.STRING)
-    private PostStatus source_postStatus;
-
-    private String source_thumbnail_url;
-
-    private boolean source_post_deleted;
+    private PostType sourcePostType;
 
     @Enumerated(EnumType.STRING)
-    private Category source_category;
+    private PostStatus sourcePostStatus;
+
+    private String sourceThumbnailUrl;
+
+    private boolean sourcePostDeleted;
+
+    @Enumerated(EnumType.STRING)
+    private Category sourceCategory;
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -65,23 +65,23 @@ public class ChatRoom {
     }
 
     public void initFromPost(Post post) {
-        this.source_post_id = post.getId();
-        this.source_title = post.getTitle();
-        this.source_address = post.getAddress();
-        this.source_post_type = post.getPostType();
-        this.source_category = post.getCategory();
-        this.source_postStatus = post.getPostStatus();
+        this.sourcePostId = post.getId();
+        this.sourceTitle = post.getTitle();
+        this.sourceAddress = post.getAddress();
+        this.sourcePostType = post.getPostType();
+        this.sourceCategory = post.getCategory();
+        this.sourcePostStatus = post.getPostStatus();
     }
 
     public void snapshotFromPost(Post post, String thumbnailUrl) {
-        this.source_post_id = post.getId();
-        this.source_title = post.getTitle();
-        this.source_address = post.getAddress();
-        this.source_post_type = post.getPostType();
-        this.source_category = post.getCategory();
-        this.source_postStatus = post.getPostStatus();
-        this.source_thumbnail_url = thumbnailUrl;
-        this.source_post_deleted = true;
+        this.sourcePostId = post.getId();
+        this.sourceTitle = post.getTitle();
+        this.sourceAddress = post.getAddress();
+        this.sourcePostType = post.getPostType();
+        this.sourceCategory = post.getCategory();
+        this.sourcePostStatus = post.getPostStatus();
+        this.sourceThumbnailUrl = thumbnailUrl;
+        this.sourcePostDeleted = true;
     }
 
     public void clearPostReference() {

--- a/src/main/java/com/fmi/domain/chatroom/data/ChatRoom.java
+++ b/src/main/java/com/fmi/domain/chatroom/data/ChatRoom.java
@@ -1,7 +1,10 @@
 package com.fmi.domain.chatroom.data;
 
+import com.fmi.domain.Enum.Category;
 import com.fmi.domain.auth.data.User;
 import com.fmi.domain.post.data.Post;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.data.PostType;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import jakarta.persistence.*;
@@ -26,12 +29,31 @@ public class ChatRoom {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id", nullable = false)
+    @JoinColumn(name = "post_id", nullable = true)
     private Post post;
 
     // 채팅방 생성 시간
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    private Long source_post_id;
+
+    private String source_address;
+
+    private String source_title;
+
+    @Enumerated(EnumType.STRING)
+    private PostType source_post_type;
+
+    @Enumerated(EnumType.STRING)
+    private PostStatus source_postStatus;
+
+    private String source_thumbnail_url;
+
+    private boolean source_post_deleted;
+
+    @Enumerated(EnumType.STRING)
+    private Category source_category;
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -40,6 +62,30 @@ public class ChatRoom {
     public void addParticipant(ChatRoomParticipant participant) {
         this.participants.add(participant);
         participant.setChatRoom(this);
+    }
+
+    public void initFromPost(Post post) {
+        this.source_post_id = post.getId();
+        this.source_title = post.getTitle();
+        this.source_address = post.getAddress();
+        this.source_post_type = post.getPostType();
+        this.source_category = post.getCategory();
+        this.source_postStatus = post.getPostStatus();
+    }
+
+    public void snapshotFromPost(Post post, String thumbnailUrl) {
+        this.source_post_id = post.getId();
+        this.source_title = post.getTitle();
+        this.source_address = post.getAddress();
+        this.source_post_type = post.getPostType();
+        this.source_category = post.getCategory();
+        this.source_postStatus = post.getPostStatus();
+        this.source_thumbnail_url = thumbnailUrl;
+        this.source_post_deleted = true;
+    }
+
+    public void clearPostReference() {
+        this.post = null;
     }
 
     //나를 제외한 다른 참여자를 찾기

--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
@@ -119,7 +119,7 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
     }
 
     private BooleanExpression typeEq(PostType type) {
-        return type != null ? QChatRoom.chatRoom.source_post_type.eq(type) : null;
+        return type != null ? QChatRoom.chatRoom.sourcePostType.eq(type) : null;
     }
 
     private BooleanExpression addressEq(String address) {
@@ -130,7 +130,7 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
 
         for (String token : tokens) {
             String normalized = ADDRESS_ALIASES.getOrDefault(token, token);
-            BooleanExpression contains = QChatRoom.chatRoom.source_address.contains(normalized);
+            BooleanExpression contains = QChatRoom.chatRoom.sourceAddress.contains(normalized);
             result = (result == null) ? contains : result.and(contains);
         }
 

--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
@@ -68,8 +68,8 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
                         pt.participantState.eq(ParticipantState.ACTIVE),
                         pt.lastMessage.isNotNull(),
 
-                        typeEq(type),
-                        addressEq(address)
+                        typeEq(type, p, cr),
+                        addressEq(address, p, cr)
                 );
 
         ChatRoomParticipant cursor = null;
@@ -118,11 +118,14 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
         return new SliceImpl<>(participants, pageable, hasNext);
     }
 
-    private BooleanExpression typeEq(PostType type) {
-        return type != null ? QChatRoom.chatRoom.sourcePostType.eq(type) : null;
+    private BooleanExpression typeEq(PostType type, QPost p, QChatRoom cr) {
+        if (type == null) return null;
+        return cr.sourcePostDeleted.isFalse().and(p.postType.eq(type))
+                .or(cr.sourcePostDeleted.isTrue().or(p.id.isNull())
+                        .and(cr.sourcePostType.eq(type)));
     }
 
-    private BooleanExpression addressEq(String address) {
+    private BooleanExpression addressEq(String address, QPost p, QChatRoom cr) {
         if (address == null || address.isBlank()) return null;
 
         String[] tokens = address.trim().split("\\s+");
@@ -130,8 +133,10 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
 
         for (String token : tokens) {
             String normalized = ADDRESS_ALIASES.getOrDefault(token, token);
-            BooleanExpression contains = QChatRoom.chatRoom.sourceAddress.contains(normalized);
-            result = (result == null) ? contains : result.and(contains);
+            BooleanExpression oneToken = cr.sourcePostDeleted.isFalse().and(p.address.contains(normalized))
+                    .or(cr.sourcePostDeleted.isTrue().or(p.id.isNull())
+                            .and(cr.sourceAddress.contains(normalized)));
+            result = (result == null) ? oneToken : result.and(oneToken);
         }
 
         return result;

--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImpl.java
@@ -57,7 +57,7 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
         JPAQuery<ChatRoomParticipant> query = queryFactory
                 .selectFrom(pt)
                 .join(pt.chatRoom, cr).fetchJoin()
-                .join(cr.post, p).fetchJoin()
+                .leftJoin(cr.post, p).fetchJoin()
                 .join(pt.lastMessage, lm).fetchJoin()
                 .join(cr.participants, otherPt)
                 .join(otherPt.user, otherUser).fetchJoin()
@@ -119,7 +119,7 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
     }
 
     private BooleanExpression typeEq(PostType type) {
-        return type != null ? QPost.post.postType.eq(type) : null;
+        return type != null ? QChatRoom.chatRoom.source_post_type.eq(type) : null;
     }
 
     private BooleanExpression addressEq(String address) {
@@ -130,7 +130,7 @@ public class ChatRoomParticipantRepositoryImpl implements ChatRoomParticipantRep
 
         for (String token : tokens) {
             String normalized = ADDRESS_ALIASES.getOrDefault(token, token);
-            BooleanExpression contains = QPost.post.address.contains(normalized);
+            BooleanExpression contains = QChatRoom.chatRoom.source_address.contains(normalized);
             result = (result == null) ? contains : result.and(contains);
         }
 

--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -22,4 +23,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 
     long countByPostId(Long postId);
+
+    List<ChatRoom> findAllByPost(Post post);
 }

--- a/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/fmi/domain/chatroom/repository/ChatRoomRepository.java
@@ -25,4 +25,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     long countByPostId(Long postId);
 
     List<ChatRoom> findAllByPost(Post post);
+
 }

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatReminderService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatReminderService.java
@@ -43,7 +43,9 @@ public class ChatReminderService {
         for (ChatRoomParticipant pt : targets) {
             try {
                 User receiver = pt.getUser();
-                Long postId = pt.getChatRoom().getPost().getId();
+                Long postId = pt.getChatRoom().isSourcePostDeleted() || pt.getChatRoom().getPost() == null
+                        ? pt.getChatRoom().getSourcePostId()
+                        : pt.getChatRoom().getPost().getId();
                 Long roomId = pt.getChatRoom().getId();
                 String content = pt.getLastMessage().getContent();
 

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
@@ -130,7 +130,7 @@ public class ChatRoomService {
         List<ChatRoomParticipant> participants = participantSlice.getContent();
 
         List<Long> postIds = participants.stream()
-                .filter(p -> !p.getChatRoom().isSource_post_deleted())
+                .filter(p -> !p.getChatRoom().isSourcePostDeleted())
                 .map(p -> p.getChatRoom().getPost().getId())
                 .distinct()
                 .collect(Collectors.toList());
@@ -173,7 +173,7 @@ public class ChatRoomService {
         boolean isBlocked = blockService.isBlocked(user.getId(), opponent.getId());
 
         // 게시글 완전 삭제 아닐 경우 -> fk로 최신 데이터
-        if(!chatRoom.isSource_post_deleted()) {
+        if(!chatRoom.isSourcePostDeleted()) {
             Post post = chatRoom.getPost();
             String thumbnailImageUrl = postImageService.findThumbnailImageUrl(post);
             return ChatRoomConverter.toChatRoomResultDTO(chatRoom, opponent, post, unreadCount, thumbnailImageUrl, isBlocked);

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
@@ -51,6 +51,10 @@ public class ChatRoomService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._POST_NOT_FOUND));
 
+        if (post.isDeleted()) {
+            throw new GeneralException(ErrorStatus._POST_NOT_FOUND);
+        }
+
         // 게시글 작성자의 ID와 채팅을 요청한 사용자의 ID가 같은지 확인
         if (post.getUser().getId().equals(contactUserId)) {
             // 같다면, 본인 글에 대한 채팅 시도이므로 예외 발생
@@ -86,6 +90,7 @@ public class ChatRoomService {
                     .post(post)
                     .createdAt(LocalDateTime.now())
                     .build();
+            newRoom.initFromPost(post);
 
             // 두 명의 참여자(게시글 작성자, 연락한 사람)에 대한 ChatRoomParticipant 엔티티를 생성
             ChatRoomParticipant authorParticipant = ChatRoomParticipant.builder()
@@ -125,6 +130,7 @@ public class ChatRoomService {
         List<ChatRoomParticipant> participants = participantSlice.getContent();
 
         List<Long> postIds = participants.stream()
+                .filter(p -> !p.getChatRoom().isSource_post_deleted())
                 .map(p -> p.getChatRoom().getPost().getId())
                 .distinct()
                 .collect(Collectors.toList());
@@ -164,13 +170,17 @@ public class ChatRoomService {
 
         User opponent = chatRoom.getOtherParticipant(user.getId());
 
-        Post post = chatRoom.getPost();
-
-        String thumbnailImageUrl = postImageService.findThumbnailImageUrl(post);
-
         boolean isBlocked = blockService.isBlocked(user.getId(), opponent.getId());
 
-        return ChatRoomConverter.toChatRoomResultDTO(chatRoom, opponent, post, unreadCount, thumbnailImageUrl, isBlocked);
+        // 게시글 완전 삭제 아닐 경우 -> fk로 최신 데이터
+        if(!chatRoom.isSource_post_deleted()) {
+            Post post = chatRoom.getPost();
+            String thumbnailImageUrl = postImageService.findThumbnailImageUrl(post);
+            return ChatRoomConverter.toChatRoomResultDTO(chatRoom, opponent, post, unreadCount, thumbnailImageUrl, isBlocked);
+        }
+
+        // 게시글 완전 삭제 -> 스냅샷 사용
+        return ChatRoomConverter.toChatRoomResultDTOFromSnapshot(chatRoom, opponent, unreadCount, isBlocked);
 
     }
 

--- a/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/fmi/domain/chatroom/service/ChatRoomService.java
@@ -130,7 +130,7 @@ public class ChatRoomService {
         List<ChatRoomParticipant> participants = participantSlice.getContent();
 
         List<Long> postIds = participants.stream()
-                .filter(p -> !p.getChatRoom().isSourcePostDeleted())
+                .filter(p -> !p.getChatRoom().isSourcePostDeleted() && p.getChatRoom().getPost() != null)
                 .map(p -> p.getChatRoom().getPost().getId())
                 .distinct()
                 .collect(Collectors.toList());
@@ -173,7 +173,7 @@ public class ChatRoomService {
         boolean isBlocked = blockService.isBlocked(user.getId(), opponent.getId());
 
         // 게시글 완전 삭제 아닐 경우 -> fk로 최신 데이터
-        if(!chatRoom.isSourcePostDeleted()) {
+        if(!chatRoom.isSourcePostDeleted() && chatRoom.getPost() != null) {
             Post post = chatRoom.getPost();
             String thumbnailImageUrl = postImageService.findThumbnailImageUrl(post);
             return ChatRoomConverter.toChatRoomResultDTO(chatRoom, opponent, post, unreadCount, thumbnailImageUrl, isBlocked);

--- a/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
+++ b/src/main/java/com/fmi/domain/chatroom/web/controller/ChatRoomController.java
@@ -1,18 +1,13 @@
 package com.fmi.domain.chatroom.web.controller;
 
 import com.fmi.domain.Enum.SortType;
-import com.fmi.domain.Enum.Type;
 import com.fmi.domain.auth.data.User;
-import com.fmi.domain.chatroom.data.ChatRoom;
-import com.fmi.domain.chatroom.repository.ChatRoomRepository;
+import com.fmi.domain.chatmessage.service.ChatNotificationService;
 import com.fmi.domain.chatroom.service.ChatRoomPresenceService;
 import com.fmi.domain.chatroom.service.ChatRoomService;
 import com.fmi.domain.post.data.PostType;
-import com.fmi.domain.notification.data.enums.NotificationType;
-import com.fmi.domain.notification.service.NotificationService;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.global.apiPayload.code.status.SuccessStatus;
-import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.service.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,7 +26,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
-import java.util.List;
 
 import static com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.ChatRoomResultDTO;
 import static com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.MyChatListDTO;
@@ -44,9 +38,7 @@ public class ChatRoomController {
     private final UserQueryService userService;
     private final ChatRoomService chatRoomService;
     private final ChatRoomPresenceService presenceService;
-    private final NotificationService notificationService;
-    private final ChatRoomRepository chatRoomRepository;
-    private final UserRepository userRepository;
+    private final ChatNotificationService chatNotificationService;
 
     @Operation(summary = "채팅방 생성/조회", description = "특정 게시글에 대해 1:1 채팅방을 생성하거나 기존 채팅방을 조회합니다.")
     @ApiResponses({
@@ -139,14 +131,7 @@ public class ChatRoomController {
         Long userId = Long.parseLong(p.getName());
         presenceService.enter(roomId, userId, acc.getSessionId());
 
-        // 채팅방 입장 시 해당 채팅 알림 자동 읽음처리
-        chatRoomRepository.findById(roomId).ifPresent(chatRoom -> {
-            Long postId = chatRoom.getPost().getId();
-            userRepository.findById(userId).ifPresent(user ->
-                    notificationService.markNotificationsAsReadByReference(user, postId,
-                            List.of(NotificationType.CHAT, NotificationType.CHAT_REMINDER))
-            );
-        });
+        chatNotificationService.markAsReadOnEnter(roomId, userId);
     }
 
     @MessageMapping("/rooms/{roomId}/ping")

--- a/src/main/java/com/fmi/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/fmi/domain/notice/service/NoticeService.java
@@ -16,6 +16,7 @@ import com.fmi.domain.notice.web.dto.NoticeMetaResponse;
 import com.fmi.domain.notice.web.dto.NoticeResponseDTO;
 import com.fmi.domain.notice.web.dto.NoticeCreateRequestDTO;
 import com.fmi.domain.notice.web.dto.NoticeUpdateRequestDTO;
+import com.fmi.domain.noticecomment.repository.NoticeCommentImageRepository;
 import com.fmi.domain.noticecomment.repository.NoticeCommentRepository;
 import com.fmi.domain.noticecommentlike.repository.NoticeCommentLikeRepository;
 import com.fmi.domain.notification.service.NotificationService;
@@ -48,6 +49,7 @@ public class NoticeService {
     private final UserRepository userRepository;
     private final NoticeConverter noticeConverter;
     private final NotificationService notificationService;
+    private final NoticeCommentImageRepository noticeCommentImageRepository;
     private final NoticeCommentRepository noticeCommentRepository;
     private final NoticeCommentLikeRepository noticeCommentLikeRepository;
     private final StringRedisTemplate stringRedisTemplate;
@@ -350,6 +352,7 @@ public class NoticeService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._NOTICE_NOT_FOUND));
 
         noticeCommentLikeRepository.deleteAllByNoticeId(noticeId);
+        noticeCommentImageRepository.deleteAllByNoticeId(noticeId);
         noticeLikeRepository.deleteByNoticeNoticeId(noticeId);
         noticeImageRepository.deleteAllByNotice(notice);
         noticeCommentRepository.deleteByNoticeNoticeId(noticeId);

--- a/src/main/java/com/fmi/domain/noticecomment/repository/NoticeCommentImageRepository.java
+++ b/src/main/java/com/fmi/domain/noticecomment/repository/NoticeCommentImageRepository.java
@@ -19,4 +19,8 @@ public interface NoticeCommentImageRepository extends JpaRepository<NoticeCommen
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM NoticeCommentImage i WHERE i.comment.id = :commentId")
     void deleteAllByCommentId(@Param("commentId") Long commentId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM NoticeCommentImage i WHERE i.comment.id IN (SELECT c.id FROM NoticeComment c WHERE c.notice.noticeId = :noticeId)")
+    void deleteAllByNoticeId(@Param("noticeId") Long noticeId);
 }

--- a/src/main/java/com/fmi/domain/post/service/PostService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostService.java
@@ -1,9 +1,11 @@
 package com.fmi.domain.post.service;
 
 import com.fmi.domain.auth.data.User;
-import com.fmi.domain.comment.service.CommentService;
+import com.fmi.domain.chatroom.data.ChatRoom;
+import com.fmi.domain.chatroom.repository.ChatRoomRepository;
 import com.fmi.domain.notification.data.enums.NotificationType;
 import com.fmi.domain.notification.data.enums.ReferenceType;
+import com.fmi.domain.notification.service.NotificationService;
 import com.fmi.domain.post.converter.util.PostConverter;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostImage;
@@ -20,14 +22,14 @@ import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import com.fmi.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
-import com.fmi.domain.notification.service.NotificationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -39,6 +41,7 @@ public class PostService {
     private final UserQueryService userQueryService;
     private final PostImageService postImageService;
     private final PostQueryService postQueryService;
+    private final ChatRoomRepository chatRoomRepository;
 
     // 게시글 생성
     @Transactional
@@ -104,6 +107,10 @@ public class PostService {
     public void deletePost(Long postId, UserDetails userDetails) {
         Post post = postQueryService.findById(postId);
         checkPostAccessDenied(post, userDetails.getUsername());
+
+        String thumbnailImageUrl = postImageService.findThumbnailImageUrl(post);
+        List<ChatRoom> chatRooms = chatRoomRepository.findAllByPost(post);
+        chatRooms.forEach(room -> room.snapshotFromPost(post, thumbnailImageUrl));
 
         post.softDelete();
         postImageService.deleteAllImageByPost(post);

--- a/src/main/java/com/fmi/domain/post/web/controller/PostController.java
+++ b/src/main/java/com/fmi/domain/post/web/controller/PostController.java
@@ -2,11 +2,11 @@ package com.fmi.domain.post.web.controller;
 
 import com.fmi.domain.Enum.Category;
 import com.fmi.domain.Enum.SortType;
-import com.fmi.domain.post.data.PostStatus;
-import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.auth.repository.UserRepository;
 import com.fmi.domain.notification.data.enums.NotificationType;
 import com.fmi.domain.notification.service.NotificationService;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.data.PostType;
 import com.fmi.domain.post.service.PostQueryService;
 import com.fmi.domain.post.service.PostService;
 import com.fmi.domain.post.service.TemporaryPostService;
@@ -15,9 +15,6 @@ import com.fmi.domain.post.web.dto.response.*;
 import com.fmi.domain.post.web.dto.response.temp.TemporaryPostResponse;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.utils.IpUtil;
-
-import java.util.List;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -36,6 +33,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Objects;
 
 @Slf4j

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -350,7 +350,7 @@ public class UserService {
                     user, startDateTime, endDateTime, trimmedKeyword, cursorTime, pageRequest);
             anySliceHasNext = anySliceHasNext || commentSlice.hasNext();
             commentSlice.getContent().forEach(c -> allActivities.add(new ActivityResponse(
-                    "INQUIRY_ANSWERED", c.getInquiry().getId(), c.getInquiry().getTitle(), truncate(c.getContent(), 100), c.getCreatedAt())));
+                    "INQUIRY_ANSWERED", c.getId(), c.getInquiry().getTitle(), truncate(c.getContent(), 100), c.getCreatedAt())));
         }
 
         if (type == null || type == ActivityType.REPORT || type == ActivityType.REPORT_RECEIVED || type == ActivityType.REPORT_ANSWERED) {

--- a/src/main/resources/db/migration/V3__add_post_deleted_at.sql
+++ b/src/main/resources/db/migration/V3__add_post_deleted_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE post ADD COLUMN deleted_at DATETIME(6);

--- a/src/main/resources/db/migration/V4__add_chatroom_snapshot_columns.sql
+++ b/src/main/resources/db/migration/V4__add_chatroom_snapshot_columns.sql
@@ -6,7 +6,7 @@ ALTER TABLE `chat_room`
     ADD COLUMN `source_title`        varchar(255)                                                        NULL,
     ADD COLUMN `source_address`      varchar(255)                                                        NULL,
     ADD COLUMN `source_post_type`    enum('LOST','FOUND')                                                NULL,
-    ADD COLUMN `source_postStatus`   enum('SEARCHING','FOUND')                                           NULL,
+    ADD COLUMN `source_post_status`   enum('SEARCHING','FOUND')                                           NULL,
     ADD COLUMN `source_category`     enum('ELECTRONICS','WALLET','ID_CARD','JEWELRY','BAG','CARD','ETC') NULL,
     ADD COLUMN `source_thumbnail_url` varchar(512)                                                       NULL,
     ADD COLUMN `source_post_deleted` bit(1)                                                              NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V4__add_chatroom_snapshot_columns.sql
+++ b/src/main/resources/db/migration/V4__add_chatroom_snapshot_columns.sql
@@ -1,0 +1,12 @@
+-- chat_room 테이블에 게시글 스냅샷 컬럼 추가 및 post_id nullable 변경
+
+ALTER TABLE `chat_room`
+    MODIFY COLUMN `post_id` bigint NULL,
+    ADD COLUMN `source_post_id`      bigint                                                              NULL,
+    ADD COLUMN `source_title`        varchar(255)                                                        NULL,
+    ADD COLUMN `source_address`      varchar(255)                                                        NULL,
+    ADD COLUMN `source_post_type`    enum('LOST','FOUND')                                                NULL,
+    ADD COLUMN `source_postStatus`   enum('SEARCHING','FOUND')                                           NULL,
+    ADD COLUMN `source_category`     enum('ELECTRONICS','WALLET','ID_CARD','JEWELRY','BAG','CARD','ETC') NULL,
+    ADD COLUMN `source_thumbnail_url` varchar(512)                                                       NULL,
+    ADD COLUMN `source_post_deleted` bit(1)                                                              NOT NULL DEFAULT 0;

--- a/src/test/java/com/fmi/domain/chatroom/converter/ChatRoomConverterSummaryTest.java
+++ b/src/test/java/com/fmi/domain/chatroom/converter/ChatRoomConverterSummaryTest.java
@@ -46,7 +46,7 @@ class ChatRoomConverterSummaryTest {
 
         ChatRoom room = mock(ChatRoom.class);
         given(room.getId()).willReturn(10L);
-        given(room.isSource_post_deleted()).willReturn(false);
+        given(room.isSourcePostDeleted()).willReturn(false);
         given(room.getPost()).willReturn(post);
 
         participant = mock(ChatRoomParticipant.class);
@@ -70,14 +70,14 @@ class ChatRoomConverterSummaryTest {
     void toChatRoomSummaryDTO_postDeleted_usesSnapshotData() {
         ChatRoom room = mock(ChatRoom.class);
         given(room.getId()).willReturn(10L);
-        given(room.isSource_post_deleted()).willReturn(true);
-        given(room.getSource_post_id()).willReturn(99L);
-        given(room.getSource_title()).willReturn("삭제 전 제목");
-        given(room.getSource_post_type()).willReturn(PostType.LOST);
-        given(room.getSource_category()).willReturn(Category.WALLET);
-        given(room.getSource_address()).willReturn("서울특별시");
-        given(room.getSource_thumbnail_url()).willReturn("https://s3.example.com/snapshot-thumb.jpg");
-        given(room.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(room.isSourcePostDeleted()).willReturn(true);
+        given(room.getSourcePostId()).willReturn(99L);
+        given(room.getSourceTitle()).willReturn("삭제 전 제목");
+        given(room.getSourcePostType()).willReturn(PostType.LOST);
+        given(room.getSourceCategory()).willReturn(Category.WALLET);
+        given(room.getSourceAddress()).willReturn("서울특별시");
+        given(room.getSourceThumbnailUrl()).willReturn("https://s3.example.com/snapshot-thumb.jpg");
+        given(room.getSourcePostStatus()).willReturn(PostStatus.SEARCHING);
 
         participant = mock(ChatRoomParticipant.class);
         given(participant.getChatRoom()).willReturn(room);
@@ -98,14 +98,14 @@ class ChatRoomConverterSummaryTest {
     void toChatRoomSummaryDTO_postDeleted_emptyThumbnailMapNoNpe() {
         ChatRoom room = mock(ChatRoom.class);
         given(room.getId()).willReturn(10L);
-        given(room.isSource_post_deleted()).willReturn(true);
-        given(room.getSource_post_id()).willReturn(99L);
-        given(room.getSource_title()).willReturn("제목");
-        given(room.getSource_post_type()).willReturn(PostType.LOST);
-        given(room.getSource_category()).willReturn(Category.WALLET);
-        given(room.getSource_address()).willReturn("서울");
-        given(room.getSource_thumbnail_url()).willReturn(null);
-        given(room.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(room.isSourcePostDeleted()).willReturn(true);
+        given(room.getSourcePostId()).willReturn(99L);
+        given(room.getSourceTitle()).willReturn("제목");
+        given(room.getSourcePostType()).willReturn(PostType.LOST);
+        given(room.getSourceCategory()).willReturn(Category.WALLET);
+        given(room.getSourceAddress()).willReturn("서울");
+        given(room.getSourceThumbnailUrl()).willReturn(null);
+        given(room.getSourcePostStatus()).willReturn(PostStatus.SEARCHING);
 
         participant = mock(ChatRoomParticipant.class);
         given(participant.getChatRoom()).willReturn(room);
@@ -133,9 +133,9 @@ class ChatRoomConverterSummaryTest {
 
         ChatRoom room = mock(ChatRoom.class);
         given(room.getId()).willReturn(10L);
-        given(room.isSource_post_deleted()).willReturn(false);
+        given(room.isSourcePostDeleted()).willReturn(false);
         given(room.getPost()).willReturn(post);
-        given(room.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(room.getSourcePostStatus()).willReturn(PostStatus.SEARCHING);
 
         participant = mock(ChatRoomParticipant.class);
         given(participant.getChatRoom()).willReturn(room);

--- a/src/test/java/com/fmi/domain/chatroom/converter/ChatRoomConverterSummaryTest.java
+++ b/src/test/java/com/fmi/domain/chatroom/converter/ChatRoomConverterSummaryTest.java
@@ -1,0 +1,150 @@
+package com.fmi.domain.chatroom.converter;
+
+import com.fmi.domain.Enum.Category;
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.chatroom.data.ChatRoom;
+import com.fmi.domain.chatroom.data.ChatRoomParticipant;
+import com.fmi.domain.post.data.Post;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.data.PostType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.ChatRoomSummaryDTO;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class ChatRoomConverterSummaryTest {
+
+    private User contactUser;
+    private ChatRoomParticipant participant;
+
+    @BeforeEach
+    void setUp() {
+        contactUser = User.builder()
+                .id(2L)
+                .nickname("상대방")
+                .email("other@test.com")
+                .build();
+    }
+
+    @Test
+    @DisplayName("toChatRoomSummaryDTO - 게시글 살아있을 때 FK 데이터를 사용한다")
+    void toChatRoomSummaryDTO_postAlive_usesPostData() {
+        Post post = mock(Post.class);
+        given(post.getId()).willReturn(99L);
+        given(post.getTitle()).willReturn("최신 제목");
+        given(post.getPostType()).willReturn(PostType.LOST);
+        given(post.getCategory()).willReturn(Category.WALLET);
+        given(post.getAddress()).willReturn("서울특별시");
+        given(post.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(post.isDeleted()).willReturn(false);
+
+        ChatRoom room = mock(ChatRoom.class);
+        given(room.getId()).willReturn(10L);
+        given(room.isSource_post_deleted()).willReturn(false);
+        given(room.getPost()).willReturn(post);
+
+        participant = mock(ChatRoomParticipant.class);
+        given(participant.getChatRoom()).willReturn(room);
+        given(participant.getLastMessage()).willReturn(null);
+        given(participant.getUnreadCount()).willReturn(0L);
+        given(participant.getLastMessageSentAt()).willReturn(null);
+
+        Map<Long, String> thumbnailMap = Map.of(99L, "https://s3.example.com/live-thumb.jpg");
+
+        ChatRoomSummaryDTO result = ChatRoomConverter.toChatRoomSummaryDTO(participant, contactUser, thumbnailMap);
+
+        assertThat(result.getPostInfo().getTitle()).isEqualTo("최신 제목");
+        assertThat(result.getPostInfo().getThumbnailUrl()).isEqualTo("https://s3.example.com/live-thumb.jpg");
+        assertThat(result.getPostInfo().isDeleted()).isFalse();
+        assertThat(result.getPostInfo().getPostId()).isEqualTo(99L);
+    }
+
+    @Test
+    @DisplayName("toChatRoomSummaryDTO - 게시글 삭제 후 스냅샷 데이터를 사용한다")
+    void toChatRoomSummaryDTO_postDeleted_usesSnapshotData() {
+        ChatRoom room = mock(ChatRoom.class);
+        given(room.getId()).willReturn(10L);
+        given(room.isSource_post_deleted()).willReturn(true);
+        given(room.getSource_post_id()).willReturn(99L);
+        given(room.getSource_title()).willReturn("삭제 전 제목");
+        given(room.getSource_post_type()).willReturn(PostType.LOST);
+        given(room.getSource_category()).willReturn(Category.WALLET);
+        given(room.getSource_address()).willReturn("서울특별시");
+        given(room.getSource_thumbnail_url()).willReturn("https://s3.example.com/snapshot-thumb.jpg");
+        given(room.getPostStatus()).willReturn(PostStatus.SEARCHING);
+
+        participant = mock(ChatRoomParticipant.class);
+        given(participant.getChatRoom()).willReturn(room);
+        given(participant.getLastMessage()).willReturn(null);
+        given(participant.getUnreadCount()).willReturn(0L);
+        given(participant.getLastMessageSentAt()).willReturn(null);
+
+        ChatRoomSummaryDTO result = ChatRoomConverter.toChatRoomSummaryDTO(participant, contactUser, Map.of());
+
+        assertThat(result.getPostInfo().getTitle()).isEqualTo("삭제 전 제목");
+        assertThat(result.getPostInfo().getThumbnailUrl()).isEqualTo("https://s3.example.com/snapshot-thumb.jpg");
+        assertThat(result.getPostInfo().isDeleted()).isTrue();
+        assertThat(result.getPostInfo().getPostId()).isEqualTo(99L);
+    }
+
+    @Test
+    @DisplayName("toChatRoomSummaryDTO - 삭제된 게시글은 thumbnailMap이 비어있어도 NPE가 나지 않는다")
+    void toChatRoomSummaryDTO_postDeleted_emptyThumbnailMapNoNpe() {
+        ChatRoom room = mock(ChatRoom.class);
+        given(room.getId()).willReturn(10L);
+        given(room.isSource_post_deleted()).willReturn(true);
+        given(room.getSource_post_id()).willReturn(99L);
+        given(room.getSource_title()).willReturn("제목");
+        given(room.getSource_post_type()).willReturn(PostType.LOST);
+        given(room.getSource_category()).willReturn(Category.WALLET);
+        given(room.getSource_address()).willReturn("서울");
+        given(room.getSource_thumbnail_url()).willReturn(null);
+        given(room.getPostStatus()).willReturn(PostStatus.SEARCHING);
+
+        participant = mock(ChatRoomParticipant.class);
+        given(participant.getChatRoom()).willReturn(room);
+        given(participant.getLastMessage()).willReturn(null);
+        given(participant.getUnreadCount()).willReturn(0L);
+        given(participant.getLastMessageSentAt()).willReturn(null);
+
+        // NPE 없이 실행되어야 함
+        ChatRoomSummaryDTO result = ChatRoomConverter.toChatRoomSummaryDTO(participant, contactUser, Map.of());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getPostInfo().getThumbnailUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("toChatRoomSummaryDTO - source_*에 stale한 SEARCHING이 있어도 FK로 최신 FOUND를 반환한다")
+    void toChatRoomSummaryDTO_postStatusChanged_usesFkNotCache() {
+        Post post = mock(Post.class);
+        given(post.getId()).willReturn(99L);
+        given(post.getTitle()).willReturn("지갑 찾았어요");
+        given(post.getPostType()).willReturn(PostType.LOST);
+        given(post.getCategory()).willReturn(Category.WALLET);
+        given(post.getAddress()).willReturn("서울");
+        given(post.getPostStatus()).willReturn(PostStatus.FOUND);
+
+        ChatRoom room = mock(ChatRoom.class);
+        given(room.getId()).willReturn(10L);
+        given(room.isSource_post_deleted()).willReturn(false);
+        given(room.getPost()).willReturn(post);
+        given(room.getPostStatus()).willReturn(PostStatus.SEARCHING);
+
+        participant = mock(ChatRoomParticipant.class);
+        given(participant.getChatRoom()).willReturn(room);
+        given(participant.getLastMessage()).willReturn(null);
+        given(participant.getUnreadCount()).willReturn(0L);
+        given(participant.getLastMessageSentAt()).willReturn(null);
+
+        ChatRoomSummaryDTO result = ChatRoomConverter.toChatRoomSummaryDTO(participant, contactUser, Map.of(99L, "thumb.jpg"));
+
+        assertThat(result.getPostInfo().getPostStatus()).isEqualTo(PostStatus.FOUND);
+    }
+}

--- a/src/test/java/com/fmi/domain/chatroom/data/ChatRoomEntityTest.java
+++ b/src/test/java/com/fmi/domain/chatroom/data/ChatRoomEntityTest.java
@@ -1,0 +1,106 @@
+package com.fmi.domain.chatroom.data;
+
+import com.fmi.domain.Enum.Category;
+import com.fmi.domain.post.data.Post;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.data.PostType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class ChatRoomEntityTest {
+
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        post = mock(Post.class);
+        given(post.getId()).willReturn(42L);
+        given(post.getTitle()).willReturn("잃어버린 지갑");
+        given(post.getAddress()).willReturn("서울특별시 강남구");
+        given(post.getPostType()).willReturn(PostType.LOST);
+        given(post.getCategory()).willReturn(Category.WALLET);
+        given(post.getPostStatus()).willReturn(PostStatus.SEARCHING);
+    }
+
+    @Test
+    @DisplayName("initFromPost - source_* 필드가 게시글 값으로 채워진다")
+    void initFromPost_copiesAllFields() {
+        ChatRoom chatRoom = ChatRoom.builder().createdAt(java.time.LocalDateTime.now()).build();
+
+        chatRoom.initFromPost(post);
+
+        assertThat(chatRoom.getSource_post_id()).isEqualTo(42L);
+        assertThat(chatRoom.getSource_title()).isEqualTo("잃어버린 지갑");
+        assertThat(chatRoom.getSource_address()).isEqualTo("서울특별시 강남구");
+        assertThat(chatRoom.getSource_post_type()).isEqualTo(PostType.LOST);
+        assertThat(chatRoom.getSource_category()).isEqualTo(Category.WALLET);
+        assertThat(chatRoom.getPostStatus()).isEqualTo(PostStatus.SEARCHING);
+    }
+
+    @Test
+    @DisplayName("initFromPost - source_post_deleted는 false를 유지한다")
+    void initFromPost_doesNotMarkAsDeleted() {
+        ChatRoom chatRoom = ChatRoom.builder().createdAt(java.time.LocalDateTime.now()).build();
+
+        chatRoom.initFromPost(post);
+
+        assertThat(chatRoom.isSource_post_deleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("initFromPost - source_thumbnail_url은 설정하지 않는다")
+    void initFromPost_doesNotSetThumbnail() {
+        ChatRoom chatRoom = ChatRoom.builder().createdAt(java.time.LocalDateTime.now()).build();
+
+        chatRoom.initFromPost(post);
+
+        assertThat(chatRoom.getSource_thumbnail_url()).isNull();
+    }
+
+    @Test
+    @DisplayName("snapshotFromPost - source_* 필드와 썸네일이 채워지고 deleted=true가 된다")
+    void snapshotFromPost_copiesAllFieldsAndMarksDeleted() {
+        ChatRoom chatRoom = ChatRoom.builder().createdAt(java.time.LocalDateTime.now()).build();
+
+        chatRoom.snapshotFromPost(post, "https://s3.example.com/thumb.jpg");
+
+        assertThat(chatRoom.getSource_post_id()).isEqualTo(42L);
+        assertThat(chatRoom.getSource_title()).isEqualTo("잃어버린 지갑");
+        assertThat(chatRoom.getSource_address()).isEqualTo("서울특별시 강남구");
+        assertThat(chatRoom.getSource_post_type()).isEqualTo(PostType.LOST);
+        assertThat(chatRoom.getSource_category()).isEqualTo(Category.WALLET);
+        assertThat(chatRoom.getPostStatus()).isEqualTo(PostStatus.SEARCHING);
+        assertThat(chatRoom.getSource_thumbnail_url()).isEqualTo("https://s3.example.com/thumb.jpg");
+        assertThat(chatRoom.isSource_post_deleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("snapshotFromPost - 썸네일이 null이어도 정상 동작한다")
+    void snapshotFromPost_nullThumbnail_doesNotThrow() {
+        ChatRoom chatRoom = ChatRoom.builder().createdAt(java.time.LocalDateTime.now()).build();
+
+        chatRoom.snapshotFromPost(post, null);
+
+        assertThat(chatRoom.getSource_thumbnail_url()).isNull();
+        assertThat(chatRoom.isSource_post_deleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("clearPostReference - post FK가 null이 된다")
+    void clearPostReference_setsPostToNull() {
+        Post livePost = mock(Post.class);
+        ChatRoom chatRoom = ChatRoom.builder()
+                .post(livePost)
+                .createdAt(java.time.LocalDateTime.now())
+                .build();
+
+        chatRoom.clearPostReference();
+
+        assertThat(chatRoom.getPost()).isNull();
+    }
+}

--- a/src/test/java/com/fmi/domain/chatroom/data/ChatRoomEntityTest.java
+++ b/src/test/java/com/fmi/domain/chatroom/data/ChatRoomEntityTest.java
@@ -34,12 +34,12 @@ class ChatRoomEntityTest {
 
         chatRoom.initFromPost(post);
 
-        assertThat(chatRoom.getSource_post_id()).isEqualTo(42L);
-        assertThat(chatRoom.getSource_title()).isEqualTo("잃어버린 지갑");
-        assertThat(chatRoom.getSource_address()).isEqualTo("서울특별시 강남구");
-        assertThat(chatRoom.getSource_post_type()).isEqualTo(PostType.LOST);
-        assertThat(chatRoom.getSource_category()).isEqualTo(Category.WALLET);
-        assertThat(chatRoom.getPostStatus()).isEqualTo(PostStatus.SEARCHING);
+        assertThat(chatRoom.getSourcePostId()).isEqualTo(42L);
+        assertThat(chatRoom.getSourceTitle()).isEqualTo("잃어버린 지갑");
+        assertThat(chatRoom.getSourceAddress()).isEqualTo("서울특별시 강남구");
+        assertThat(chatRoom.getSourcePostType()).isEqualTo(PostType.LOST);
+        assertThat(chatRoom.getSourceCategory()).isEqualTo(Category.WALLET);
+        assertThat(chatRoom.getSourcePostStatus()).isEqualTo(PostStatus.SEARCHING);
     }
 
     @Test
@@ -49,7 +49,7 @@ class ChatRoomEntityTest {
 
         chatRoom.initFromPost(post);
 
-        assertThat(chatRoom.isSource_post_deleted()).isFalse();
+        assertThat(chatRoom.isSourcePostDeleted()).isFalse();
     }
 
     @Test
@@ -59,7 +59,7 @@ class ChatRoomEntityTest {
 
         chatRoom.initFromPost(post);
 
-        assertThat(chatRoom.getSource_thumbnail_url()).isNull();
+        assertThat(chatRoom.getSourceThumbnailUrl()).isNull();
     }
 
     @Test
@@ -69,14 +69,14 @@ class ChatRoomEntityTest {
 
         chatRoom.snapshotFromPost(post, "https://s3.example.com/thumb.jpg");
 
-        assertThat(chatRoom.getSource_post_id()).isEqualTo(42L);
-        assertThat(chatRoom.getSource_title()).isEqualTo("잃어버린 지갑");
-        assertThat(chatRoom.getSource_address()).isEqualTo("서울특별시 강남구");
-        assertThat(chatRoom.getSource_post_type()).isEqualTo(PostType.LOST);
-        assertThat(chatRoom.getSource_category()).isEqualTo(Category.WALLET);
-        assertThat(chatRoom.getPostStatus()).isEqualTo(PostStatus.SEARCHING);
-        assertThat(chatRoom.getSource_thumbnail_url()).isEqualTo("https://s3.example.com/thumb.jpg");
-        assertThat(chatRoom.isSource_post_deleted()).isTrue();
+        assertThat(chatRoom.getSourcePostId()).isEqualTo(42L);
+        assertThat(chatRoom.getSourceTitle()).isEqualTo("잃어버린 지갑");
+        assertThat(chatRoom.getSourceAddress()).isEqualTo("서울특별시 강남구");
+        assertThat(chatRoom.getSourcePostType()).isEqualTo(PostType.LOST);
+        assertThat(chatRoom.getSourceCategory()).isEqualTo(Category.WALLET);
+        assertThat(chatRoom.getSourcePostStatus()).isEqualTo(PostStatus.SEARCHING);
+        assertThat(chatRoom.getSourceThumbnailUrl()).isEqualTo("https://s3.example.com/thumb.jpg");
+        assertThat(chatRoom.isSourcePostDeleted()).isTrue();
     }
 
     @Test
@@ -86,8 +86,8 @@ class ChatRoomEntityTest {
 
         chatRoom.snapshotFromPost(post, null);
 
-        assertThat(chatRoom.getSource_thumbnail_url()).isNull();
-        assertThat(chatRoom.isSource_post_deleted()).isTrue();
+        assertThat(chatRoom.getSourceThumbnailUrl()).isNull();
+        assertThat(chatRoom.isSourcePostDeleted()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImplTest.java
+++ b/src/test/java/com/fmi/domain/chatroom/repository/ChatRoomParticipantRepositoryImplTest.java
@@ -1,5 +1,7 @@
 package com.fmi.domain.chatroom.repository;
 
+import com.fmi.domain.chatroom.data.QChatRoom;
+import com.fmi.domain.post.data.QPost;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,9 +30,9 @@ class ChatRoomParticipantRepositoryImplTest {
 
     private BooleanExpression invokeAddressEq(String address) throws Exception {
         Method method = ChatRoomParticipantRepositoryImpl.class
-                .getDeclaredMethod("addressEq", String.class);
+                .getDeclaredMethod("addressEq", String.class, QPost.class, QChatRoom.class);
         method.setAccessible(true);
-        return (BooleanExpression) method.invoke(repository, address);
+        return (BooleanExpression) method.invoke(repository, address, QPost.post, QChatRoom.chatRoom);
     }
 
     @Test

--- a/src/test/java/com/fmi/domain/chatroom/service/ChatRoomServiceDetailTest.java
+++ b/src/test/java/com/fmi/domain/chatroom/service/ChatRoomServiceDetailTest.java
@@ -75,7 +75,7 @@ class ChatRoomServiceDetailTest {
 
         ChatRoom chatRoom = mock(ChatRoom.class);
         given(chatRoom.getId()).willReturn(10L);
-        given(chatRoom.isSource_post_deleted()).willReturn(false);
+        given(chatRoom.isSourcePostDeleted()).willReturn(false);
         given(chatRoom.getPost()).willReturn(post);
         given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
         given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
@@ -96,14 +96,14 @@ class ChatRoomServiceDetailTest {
     void getChatRoomDetail_postSoftDeleted_returnsSnapshotTitle() {
         ChatRoom chatRoom = mock(ChatRoom.class);
         given(chatRoom.getId()).willReturn(10L);
-        given(chatRoom.isSource_post_deleted()).willReturn(true);
-        given(chatRoom.getSource_post_id()).willReturn(99L);
-        given(chatRoom.getSource_title()).willReturn("삭제 전 제목");
-        given(chatRoom.getSource_post_type()).willReturn(PostType.LOST);
-        given(chatRoom.getSource_category()).willReturn(Category.WALLET);
-        given(chatRoom.getSource_address()).willReturn("서울");
-        given(chatRoom.getSource_thumbnail_url()).willReturn("https://s3.example.com/old-thumb.jpg");
-        given(chatRoom.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(chatRoom.isSourcePostDeleted()).willReturn(true);
+        given(chatRoom.getSourcePostId()).willReturn(99L);
+        given(chatRoom.getSourceTitle()).willReturn("삭제 전 제목");
+        given(chatRoom.getSourcePostType()).willReturn(PostType.LOST);
+        given(chatRoom.getSourceCategory()).willReturn(Category.WALLET);
+        given(chatRoom.getSourceAddress()).willReturn("서울");
+        given(chatRoom.getSourceThumbnailUrl()).willReturn("https://s3.example.com/old-thumb.jpg");
+        given(chatRoom.getSourcePostStatus()).willReturn(PostStatus.SEARCHING);
         given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
         given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
 
@@ -122,14 +122,14 @@ class ChatRoomServiceDetailTest {
     void getChatRoomDetail_postSoftDeleted_doesNotQueryPostImageService() {
         ChatRoom chatRoom = mock(ChatRoom.class);
         given(chatRoom.getId()).willReturn(10L);
-        given(chatRoom.isSource_post_deleted()).willReturn(true);
-        given(chatRoom.getSource_post_id()).willReturn(99L);
-        given(chatRoom.getSource_title()).willReturn("삭제 전 제목");
-        given(chatRoom.getSource_post_type()).willReturn(PostType.LOST);
-        given(chatRoom.getSource_category()).willReturn(Category.WALLET);
-        given(chatRoom.getSource_address()).willReturn("서울");
-        given(chatRoom.getSource_thumbnail_url()).willReturn(null);
-        given(chatRoom.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(chatRoom.isSourcePostDeleted()).willReturn(true);
+        given(chatRoom.getSourcePostId()).willReturn(99L);
+        given(chatRoom.getSourceTitle()).willReturn("삭제 전 제목");
+        given(chatRoom.getSourcePostType()).willReturn(PostType.LOST);
+        given(chatRoom.getSourceCategory()).willReturn(Category.WALLET);
+        given(chatRoom.getSourceAddress()).willReturn("서울");
+        given(chatRoom.getSourceThumbnailUrl()).willReturn(null);
+        given(chatRoom.getSourcePostStatus()).willReturn(PostStatus.SEARCHING);
         given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
         given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
 
@@ -156,9 +156,9 @@ class ChatRoomServiceDetailTest {
 
         ChatRoom chatRoom = mock(ChatRoom.class);
         given(chatRoom.getId()).willReturn(10L);
-        given(chatRoom.isSource_post_deleted()).willReturn(false);
+        given(chatRoom.isSourcePostDeleted()).willReturn(false);
         given(chatRoom.getPost()).willReturn(post);
-        given(chatRoom.getPostStatus()).willReturn(PostStatus.SEARCHING); // source_* 초기값
+        given(chatRoom.getSourcePostStatus()).willReturn(PostStatus.SEARCHING); // source_* 초기값
         given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
         given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
 
@@ -176,15 +176,15 @@ class ChatRoomServiceDetailTest {
     void getChatRoomDetail_postHardDeleted_returnsSnapshot() {
         ChatRoom chatRoom = mock(ChatRoom.class);
         given(chatRoom.getId()).willReturn(10L);
-        given(chatRoom.isSource_post_deleted()).willReturn(true); // 소프트딜리트 때 이미 true
+        given(chatRoom.isSourcePostDeleted()).willReturn(true); // 소프트딜리트 때 이미 true
         given(chatRoom.getPost()).willReturn(null); // 하드딜리트 후 null
-        given(chatRoom.getSource_post_id()).willReturn(99L);
-        given(chatRoom.getSource_title()).willReturn("삭제된 게시글");
-        given(chatRoom.getSource_post_type()).willReturn(PostType.LOST);
-        given(chatRoom.getSource_category()).willReturn(Category.WALLET);
-        given(chatRoom.getSource_address()).willReturn("서울");
-        given(chatRoom.getSource_thumbnail_url()).willReturn(null);
-        given(chatRoom.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(chatRoom.getSourcePostId()).willReturn(99L);
+        given(chatRoom.getSourceTitle()).willReturn("삭제된 게시글");
+        given(chatRoom.getSourcePostType()).willReturn(PostType.LOST);
+        given(chatRoom.getSourceCategory()).willReturn(Category.WALLET);
+        given(chatRoom.getSourceAddress()).willReturn("서울");
+        given(chatRoom.getSourceThumbnailUrl()).willReturn(null);
+        given(chatRoom.getSourcePostStatus()).willReturn(PostStatus.SEARCHING);
         given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
         given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
 
@@ -211,7 +211,7 @@ class ChatRoomServiceDetailTest {
 
         ChatRoom chatRoom = mock(ChatRoom.class);
         given(chatRoom.getId()).willReturn(10L);
-        given(chatRoom.isSource_post_deleted()).willReturn(false);
+        given(chatRoom.isSourcePostDeleted()).willReturn(false);
         given(chatRoom.getPost()).willReturn(post);
         given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
         given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant); // unreadCount=3

--- a/src/test/java/com/fmi/domain/chatroom/service/ChatRoomServiceDetailTest.java
+++ b/src/test/java/com/fmi/domain/chatroom/service/ChatRoomServiceDetailTest.java
@@ -1,0 +1,227 @@
+package com.fmi.domain.chatroom.service;
+
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.domain.chatmessage.repository.ChatMessageRepository;
+import com.fmi.domain.chatroom.data.ChatRoom;
+import com.fmi.domain.chatroom.data.ChatRoomParticipant;
+import com.fmi.domain.chatroom.repository.ChatRoomParticipantRepository;
+import com.fmi.domain.chatroom.repository.ChatRoomRepository;
+import com.fmi.domain.chatroom.web.dto.ChatRoomResponseDTO.ChatRoomResultDTO;
+import com.fmi.domain.post.data.Post;
+import com.fmi.domain.post.data.PostStatus;
+import com.fmi.domain.post.data.PostType;
+import com.fmi.domain.post.repository.PostRepository;
+import com.fmi.domain.post.service.PostImageService;
+import com.fmi.domain.userblock.service.BlockService;
+import com.fmi.domain.Enum.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ChatRoomServiceDetailTest {
+
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private PostRepository postRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ChatRoomParticipantRepository chatRoomParticipantRepository;
+    @Mock private ChatMessageRepository chatMessageRepository;
+    @Mock private PostImageService postImageService;
+    @Mock private BlockService blockService;
+
+    @InjectMocks
+    private ChatRoomService chatRoomService;
+
+    private User currentUser;
+    private User opponent;
+    private ChatRoomParticipant participant;
+
+    @BeforeEach
+    void setUp() {
+        currentUser = User.builder().id(1L).email("me@test.com").nickname("나").build();
+        opponent = User.builder().id(2L).email("other@test.com").nickname("상대").build();
+
+        participant = ChatRoomParticipant.builder()
+                .user(currentUser)
+                .unreadCount(3L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("getChatRoomDetail - 게시글 살아있을 때 FK로 최신 제목을 반환한다")
+    void getChatRoomDetail_postAlive_returnsFkTitle() {
+        Post post = mock(Post.class);
+        given(post.getId()).willReturn(99L);
+        given(post.getTitle()).willReturn("최신 제목");
+        given(post.getPostType()).willReturn(PostType.LOST);
+        given(post.getCategory()).willReturn(Category.WALLET);
+        given(post.getAddress()).willReturn("서울");
+        given(post.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(post.isDeleted()).willReturn(false);
+
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(10L);
+        given(chatRoom.isSource_post_deleted()).willReturn(false);
+        given(chatRoom.getPost()).willReturn(post);
+        given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
+        given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
+
+        given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+        given(postImageService.findThumbnailImageUrl(post)).willReturn("https://s3.example.com/new-thumb.jpg");
+        given(blockService.isBlocked(currentUser.getId(), opponent.getId())).willReturn(false);
+
+        ChatRoomResultDTO result = chatRoomService.getChatRoomDetail(10L, currentUser);
+
+        assertThat(result.getPostInfo().getTitle()).isEqualTo("최신 제목");
+        assertThat(result.getPostInfo().getThumbnailUrl()).isEqualTo("https://s3.example.com/new-thumb.jpg");
+        assertThat(result.getPostInfo().isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("getChatRoomDetail - 게시글 소프트딜리트 후 스냅샷 제목을 반환한다")
+    void getChatRoomDetail_postSoftDeleted_returnsSnapshotTitle() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(10L);
+        given(chatRoom.isSource_post_deleted()).willReturn(true);
+        given(chatRoom.getSource_post_id()).willReturn(99L);
+        given(chatRoom.getSource_title()).willReturn("삭제 전 제목");
+        given(chatRoom.getSource_post_type()).willReturn(PostType.LOST);
+        given(chatRoom.getSource_category()).willReturn(Category.WALLET);
+        given(chatRoom.getSource_address()).willReturn("서울");
+        given(chatRoom.getSource_thumbnail_url()).willReturn("https://s3.example.com/old-thumb.jpg");
+        given(chatRoom.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
+        given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
+
+        given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+        given(blockService.isBlocked(currentUser.getId(), opponent.getId())).willReturn(false);
+
+        ChatRoomResultDTO result = chatRoomService.getChatRoomDetail(10L, currentUser);
+
+        assertThat(result.getPostInfo().getTitle()).isEqualTo("삭제 전 제목");
+        assertThat(result.getPostInfo().getThumbnailUrl()).isEqualTo("https://s3.example.com/old-thumb.jpg");
+        assertThat(result.getPostInfo().isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getChatRoomDetail - 게시글 소프트딜리트 후 PostImageService를 호출하지 않는다")
+    void getChatRoomDetail_postSoftDeleted_doesNotQueryPostImageService() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(10L);
+        given(chatRoom.isSource_post_deleted()).willReturn(true);
+        given(chatRoom.getSource_post_id()).willReturn(99L);
+        given(chatRoom.getSource_title()).willReturn("삭제 전 제목");
+        given(chatRoom.getSource_post_type()).willReturn(PostType.LOST);
+        given(chatRoom.getSource_category()).willReturn(Category.WALLET);
+        given(chatRoom.getSource_address()).willReturn("서울");
+        given(chatRoom.getSource_thumbnail_url()).willReturn(null);
+        given(chatRoom.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
+        given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
+
+        given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+        given(blockService.isBlocked(currentUser.getId(), opponent.getId())).willReturn(false);
+
+        chatRoomService.getChatRoomDetail(10L, currentUser);
+
+        org.mockito.Mockito.verify(postImageService, org.mockito.Mockito.never())
+                .findThumbnailImageUrl(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("getChatRoomDetail - source_*에 초기값이 있어도 FK로 최신값을 반환한다")
+    void getChatRoomDetail_postStatusChanged_usesFkNotCache() {
+        Post post = mock(Post.class);
+        given(post.getId()).willReturn(99L);
+        given(post.getTitle()).willReturn("지갑 찾았어요");
+        given(post.getPostType()).willReturn(PostType.LOST);
+        given(post.getCategory()).willReturn(Category.WALLET);
+        given(post.getAddress()).willReturn("서울");
+        given(post.getPostStatus()).willReturn(PostStatus.FOUND); // FK 최신값
+        given(post.isDeleted()).willReturn(false);
+
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(10L);
+        given(chatRoom.isSource_post_deleted()).willReturn(false);
+        given(chatRoom.getPost()).willReturn(post);
+        given(chatRoom.getPostStatus()).willReturn(PostStatus.SEARCHING); // source_* 초기값
+        given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
+        given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
+
+        given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+        given(postImageService.findThumbnailImageUrl(post)).willReturn(null);
+        given(blockService.isBlocked(currentUser.getId(), opponent.getId())).willReturn(false);
+
+        ChatRoomResultDTO result = chatRoomService.getChatRoomDetail(10L, currentUser);
+
+        assertThat(result.getPostInfo().getPostStatus()).isEqualTo(PostStatus.FOUND);
+    }
+
+    @Test
+    @DisplayName("getChatRoomDetail - 하드딜리트 후(post=null) 스냅샷을 반환한다")
+    void getChatRoomDetail_postHardDeleted_returnsSnapshot() {
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(10L);
+        given(chatRoom.isSource_post_deleted()).willReturn(true); // 소프트딜리트 때 이미 true
+        given(chatRoom.getPost()).willReturn(null); // 하드딜리트 후 null
+        given(chatRoom.getSource_post_id()).willReturn(99L);
+        given(chatRoom.getSource_title()).willReturn("삭제된 게시글");
+        given(chatRoom.getSource_post_type()).willReturn(PostType.LOST);
+        given(chatRoom.getSource_category()).willReturn(Category.WALLET);
+        given(chatRoom.getSource_address()).willReturn("서울");
+        given(chatRoom.getSource_thumbnail_url()).willReturn(null);
+        given(chatRoom.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
+        given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant);
+
+        given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+        given(blockService.isBlocked(currentUser.getId(), opponent.getId())).willReturn(false);
+
+        ChatRoomResultDTO result = chatRoomService.getChatRoomDetail(10L, currentUser);
+
+        assertThat(result.getPostInfo().getTitle()).isEqualTo("삭제된 게시글");
+        assertThat(result.getPostInfo().isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getChatRoomDetail - unreadCount가 응답에 포함된다")
+    void getChatRoomDetail_returnsUnreadCount() {
+        Post post = mock(Post.class);
+        given(post.getId()).willReturn(99L);
+        given(post.getTitle()).willReturn("제목");
+        given(post.getPostType()).willReturn(PostType.LOST);
+        given(post.getCategory()).willReturn(Category.WALLET);
+        given(post.getAddress()).willReturn("서울");
+        given(post.getPostStatus()).willReturn(PostStatus.SEARCHING);
+        given(post.isDeleted()).willReturn(false);
+
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(10L);
+        given(chatRoom.isSource_post_deleted()).willReturn(false);
+        given(chatRoom.getPost()).willReturn(post);
+        given(chatRoom.getOtherParticipant(currentUser.getId())).willReturn(opponent);
+        given(chatRoom.getParticipant(currentUser.getId())).willReturn(participant); // unreadCount=3
+
+        given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+        given(postImageService.findThumbnailImageUrl(post)).willReturn(null);
+        given(blockService.isBlocked(currentUser.getId(), opponent.getId())).willReturn(false);
+
+        ChatRoomResultDTO result = chatRoomService.getChatRoomDetail(10L, currentUser);
+
+        assertThat(result.getUnreadCount()).isEqualTo(3L);
+    }
+}

--- a/src/test/java/com/fmi/domain/post/service/PostServiceDeleteTest.java
+++ b/src/test/java/com/fmi/domain/post/service/PostServiceDeleteTest.java
@@ -4,6 +4,7 @@ import com.fmi.domain.chatroom.data.ChatRoom;
 import com.fmi.domain.chatroom.repository.ChatRoomRepository;
 import com.fmi.domain.notification.service.NotificationService;
 import com.fmi.domain.post.data.Post;
+import com.fmi.domain.post.repository.PostRepository;
 import com.fmi.domain.postfavorite.repository.PostFavoriteRepository;
 import com.fmi.service.UserQueryService;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/fmi/domain/post/service/PostServiceDeleteTest.java
+++ b/src/test/java/com/fmi/domain/post/service/PostServiceDeleteTest.java
@@ -49,7 +49,6 @@ class PostServiceDeleteTest {
                 .build();
 
         post = mock(Post.class);
-        given(post.getId()).willReturn(10L);
         given(post.getUser()).willReturn(author);
 
         userDetails = mock(UserDetails.class);

--- a/src/test/java/com/fmi/domain/post/service/PostServiceDeleteTest.java
+++ b/src/test/java/com/fmi/domain/post/service/PostServiceDeleteTest.java
@@ -1,0 +1,115 @@
+package com.fmi.domain.post.service;
+
+import com.fmi.domain.chatroom.data.ChatRoom;
+import com.fmi.domain.chatroom.repository.ChatRoomRepository;
+import com.fmi.domain.notification.service.NotificationService;
+import com.fmi.domain.post.data.Post;
+import com.fmi.domain.postfavorite.repository.PostFavoriteRepository;
+import com.fmi.service.UserQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceDeleteTest {
+
+    @Mock private PostRepository postRepository;
+    @Mock private NotificationService notificationService;
+    @Mock private PostFavoriteRepository postFavoriteRepository;
+    @Mock private UserQueryService userQueryService;
+    @Mock private PostImageService postImageService;
+    @Mock private PostQueryService postQueryService;
+    @Mock private ChatRoomRepository chatRoomRepository;
+
+    @InjectMocks
+    private PostService postService;
+
+    private Post post;
+    private UserDetails userDetails;
+    private com.fmi.domain.auth.data.User author;
+
+    @BeforeEach
+    void setUp() {
+        author = com.fmi.domain.auth.data.User.builder()
+                .id(1L)
+                .email("author@test.com")
+                .nickname("작성자")
+                .build();
+
+        post = mock(Post.class);
+        given(post.getId()).willReturn(10L);
+        given(post.getUser()).willReturn(author);
+
+        userDetails = mock(UserDetails.class);
+        given(userDetails.getUsername()).willReturn("author@test.com");
+    }
+
+    @Test
+    @DisplayName("deletePost - 연관된 모든 채팅방에 snapshotFromPost가 호출된다")
+    void deletePost_snapshotsAllRelatedChatRooms() {
+        ChatRoom room1 = mock(ChatRoom.class);
+        ChatRoom room2 = mock(ChatRoom.class);
+        String thumbnailUrl = "https://s3.example.com/thumb.jpg";
+
+        given(postQueryService.findById(10L)).willReturn(post);
+        given(postImageService.findThumbnailImageUrl(post)).willReturn(thumbnailUrl);
+        given(chatRoomRepository.findAllByPost(post)).willReturn(List.of(room1, room2));
+
+        postService.deletePost(10L, userDetails);
+
+        verify(room1).snapshotFromPost(post, thumbnailUrl);
+        verify(room2).snapshotFromPost(post, thumbnailUrl);
+    }
+
+    @Test
+    @DisplayName("deletePost - 썸네일 URL은 이미지 삭제 전에 먼저 캡처된다")
+    void deletePost_thumbnailCapturedBeforeImageDeletion() {
+        given(postQueryService.findById(10L)).willReturn(post);
+        given(postImageService.findThumbnailImageUrl(post)).willReturn("https://s3.example.com/thumb.jpg");
+        given(chatRoomRepository.findAllByPost(post)).willReturn(List.of());
+
+        postService.deletePost(10L, userDetails);
+
+        InOrder inOrder = inOrder(postImageService);
+        inOrder.verify(postImageService).findThumbnailImageUrl(post);
+        inOrder.verify(postImageService).deleteAllImageByPost(post);
+    }
+
+    @Test
+    @DisplayName("deletePost - 연관 채팅방이 없어도 정상 동작한다")
+    void deletePost_noRelatedChatRooms_noError() {
+        given(postQueryService.findById(10L)).willReturn(post);
+        given(postImageService.findThumbnailImageUrl(post)).willReturn(null);
+        given(chatRoomRepository.findAllByPost(post)).willReturn(List.of());
+
+        postService.deletePost(10L, userDetails);
+
+        verify(post).softDelete();
+        verify(postImageService).deleteAllImageByPost(post);
+    }
+
+    @Test
+    @DisplayName("deletePost - 썸네일이 없는 게시글도 채팅방 스냅샷이 정상 처리된다")
+    void deletePost_noThumbnail_snapshotWithNullUrl() {
+        ChatRoom room = mock(ChatRoom.class);
+
+        given(postQueryService.findById(10L)).willReturn(post);
+        given(postImageService.findThumbnailImageUrl(post)).willReturn(null);
+        given(chatRoomRepository.findAllByPost(post)).willReturn(List.of(room));
+
+        postService.deletePost(10L, userDetails);
+
+        verify(room).snapshotFromPost(post, null);
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close #460 

## 🛠️ 작업 내용
                                                                                                                                                                             
  - 게시글이 소프트 딜리트될 때 채팅방에 게시글 정보를 스냅샷으로 저장하여, 삭제 이후에도 채팅방 목록/상세에서 게시글 정보를 정상 표시될 수 있도록 했습니다. 
  
### 변경사항                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                  
  - ChatRoom에 source_* 스냅샷 필드 추가 (post_id nullable 변경 포함)                                                                                                        
  - 게시글 소프트 딜리트 시 연관 채팅방에 snapshotFromPost 호출
  - 채팅방 목록/상세에서 source_post_deleted 기준으로 FK vs 스냅샷 분기 처리                                                                                                 
  - 채팅방 목록 필터링(type, address)을 Post가 아닌 ChatRoom.source_* 필드 기준으로 변경                                                                                     
  - 소프트 딜리트된 게시글로 채팅방 생성 시도 시 예외 처리 추가                                                                                                                                                                                                                                                                                                                                                
  - V4 Flyway 마이그레이션 추가                                                                                                                                              
   

## 📢 참고 및 특이사항

### 게시글 30일 후 삭제시 참고 사항

#### 채팅방 FK null 처리                                                                                                                                                                     
- findAllByPost(Post post) — ChatRoomRepository에 있는 메서드. post_id 기준으로 연관된 채팅방 전체를 리스트로 반환                                                         
- clearPostReference() — ChatRoom 엔티티에 있는 메서드. this.post = null로 FK를 끊음. JPA dirty checking으로 트랜잭션 종료 시 자동으로 UPDATE 쿼리 나감
                                                                                                                                                                                      
 #### 마이그레이션                                                                                                                                                               
                  
  V4에서 chat_room.post_id를 이미 nullable로 변경해놨으니 별도 마이그레이션 불필요
                                                                                                                                                                             
 #### 전제 조건                                                                                                                                                                  
                  
 - 삭제 대상은 반드시 post.deleted = true인 것만 -> 소프트 딜리트 때 snapshotFromPost가 호출됐어야 채팅방에 스냅샷 데이터가 있음. 
 - 소프트 딜리트 안 된 게시글을 바로 하드 딜리트하면 채팅방에서 source_post_deleted = false인데 post는 null이 되어 NPE 발생                                                                                          
   

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
