### PR TITLE
refactor: 내 정보 조회 api 컬럼 추가, 카카오 회원 탈퇴 api 수정 

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -137,6 +137,7 @@ jobs:
               echo "KAKAO_REST_API_KEY_DEV=${{ secrets.KAKAO_REST_API_KEY_DEV }}"
               echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}"
               echo "KAKAO_REDIRECT_URI_DEV=${{ secrets.KAKAO_REDIRECT_URI_DEV }}"
+              echo "KAKAO_ADMIN_KEY=${{ secrets.KAKAO_ADMIN_KEY }}"
               echo "SLACK_WEBHOOK_INQUIRY_URL=${{ secrets.SLACK_WEBHOOK_INQUIRY_URL }}"
               echo "SLACK_WEBHOOK_REPORT_URL=${{ secrets.SLACK_WEBHOOK_REPORT_URL }}"
               echo "JWT_COOKIE_DOMAIN=${{ secrets.JWT_COOKIE_DOMAIN }}"

--- a/src/main/java/com/fmi/domain/auth/repository/SocialAccountsRepository.java
+++ b/src/main/java/com/fmi/domain/auth/repository/SocialAccountsRepository.java
@@ -15,6 +15,7 @@ public interface SocialAccountsRepository extends JpaRepository<SocialAccounts, 
     Optional<SocialAccounts> findByProviderAndProviderIdWithUser(@Param("provider") Provider provider,
                                                                  @Param("providerId") String providerId);
     Optional<SocialAccounts> findByUser(User user);
+    boolean existsByUser(User user);
 }
 
 

--- a/src/main/java/com/fmi/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/fmi/domain/auth/service/KakaoOAuthService.java
@@ -37,9 +37,12 @@ public class KakaoOAuthService {
     private String redirectUri;
     @Value("${KAKAO_REDIRECT_URI_DEV:}")
     private String redirectUriDev;
+    @Value("${KAKAO_ADMIN_KEY:}")
+    private String adminKey;
 
     private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private static final String USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
 
     public KakaoToken exchangeCodeForToken(String code) {
         return exchangeCodeForToken(code, null);
@@ -147,6 +150,26 @@ public class KakaoOAuthService {
         } catch (RestClientException e) {
             log.error("카카오 사용자 정보 조회 실패: 네트워크 오류", e);
             throw new GeneralException(ErrorStatus._KAKAO_USERINFO_FETCH_FAILED);
+        }
+    }
+
+    public void unlinkUser(String kakaoUserId) {
+        RestTemplate rt = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "KakaoAK " + adminKey);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("target_id_type", "user_id");
+        params.add("target_id", kakaoUserId);
+
+        HttpEntity<MultiValueMap<String, String>> req = new HttpEntity<>(params, headers);
+
+        try {
+            rt.postForEntity(UNLINK_URL, req, String.class);
+            log.info("카카오 연결 끊기 성공: kakaoUserId={}", kakaoUserId);
+        } catch (RestClientException e) {
+            log.warn("카카오 연결 끊기 실패: kakaoUserId={}, error={}", kakaoUserId, e.getMessage());
         }
     }
 

--- a/src/main/java/com/fmi/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/fmi/domain/user/converter/UserConverter.java
@@ -21,13 +21,14 @@ public class UserConverter {
      * User Entity → UserProfileResponse 변환
      * 닉네임, 이메일, 프로필 이미지만 반환
      */
-    public static UserProfileResponse toUserProfileResponse(User user) {
+    public static UserProfileResponse toUserProfileResponse(User user, boolean isSocialUser) {
         return UserProfileResponse.builder()
                 .userId(user.getId())
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .profileImg(user.getProfile_img())
                 .role(user.getRole())
+                .isSocialUser(isSocialUser)
                 .build();
     }
 

--- a/src/main/java/com/fmi/domain/user/response/UserProfileResponse.java
+++ b/src/main/java/com/fmi/domain/user/response/UserProfileResponse.java
@@ -14,5 +14,6 @@ public class UserProfileResponse {
     private String email;             // 이메일 (조회만)
     private String profileImg;        // 프로필 이미지 URL (수정 가능)
     private Role role;                // 유저 권한 (USER, ADMIN)
+    private boolean isSocialUser;     // 소셜 로그인 회원 여부 (true: 카카오 등 소셜, false: 일반)
 }
 

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -110,6 +110,21 @@ public class UserService {
     }
 
     /**
+     * 약관 동의 처리
+     */
+    @Transactional
+    public void agreeTerms(String email, com.fmi.domain.user.web.dto.TermsAgreeRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
+
+        user.setPrivacyPolicyAgreed(request.isPrivacyPolicyAgreed());
+        user.setTermsOfServiceAgreed(request.isTermsOfServiceAgreed());
+        user.setContentPolicyAgreed(request.isContentPolicyAgreed());
+        user.setMarketingConsent(request.isMarketingConsent());
+        userRepository.save(user);
+    }
+
+    /**
      * 유저 메타데이터 조회 (OG 태그용)
      */
     @Transactional(readOnly = true)

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -101,7 +101,7 @@ public class UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        boolean isSocialUser = socialAccountsRepository.findByUser(user).isPresent();
+        boolean isSocialUser = socialAccountsRepository.existsByUser(user);
         return UserConverter.toUserProfileResponse(user, isSocialUser);
     }
 

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -40,7 +40,10 @@ import com.fmi.domain.user.web.dto.AccountDeleteRequest;
 import com.fmi.domain.user.web.dto.PasswordChangeRequest;
 import com.fmi.domain.user.web.dto.PasswordVerifyRequest;
 import com.fmi.domain.user.web.dto.UserUpdateRequest;
+import com.fmi.domain.Enum.Provider;
+import com.fmi.domain.auth.data.SocialAccounts;
 import com.fmi.domain.auth.repository.SocialAccountsRepository;
+import com.fmi.domain.auth.service.KakaoOAuthService;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import com.fmi.global.service.S3Service;
@@ -91,6 +94,7 @@ public class UserService {
     private final CommentImageService commentImageService;
     private final InquiryCommentRepository inquiryCommentRepository;
     private final SocialAccountsRepository socialAccountsRepository;
+    private final KakaoOAuthService kakaoOAuthService;
 
 
     /**
@@ -578,6 +582,11 @@ public class UserService {
         if (request.getReasons().contains(com.fmi.domain.Enum.WithdrawalReason.OTHER)) {
             user.setWithdrawalOtherReason(request.getOtherReason());
         }
+
+        // 카카오 회원이면 카카오 연결 끊기
+        socialAccountsRepository.findByUser(user)
+                .filter(sa -> sa.getProvider() == Provider.KAKAO)
+                .ifPresent(sa -> kakaoOAuthService.unlinkUser(sa.getProviderId()));
 
         // Soft Delete (deletedAt 설정)
         user.setDeletedAt(LocalDateTime.now());

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -40,6 +40,7 @@ import com.fmi.domain.user.web.dto.AccountDeleteRequest;
 import com.fmi.domain.user.web.dto.PasswordChangeRequest;
 import com.fmi.domain.user.web.dto.PasswordVerifyRequest;
 import com.fmi.domain.user.web.dto.UserUpdateRequest;
+import com.fmi.domain.auth.repository.SocialAccountsRepository;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import com.fmi.global.service.S3Service;
@@ -89,6 +90,7 @@ public class UserService {
     private final CommentLikeService commentLikeService;
     private final CommentImageService commentImageService;
     private final InquiryCommentRepository inquiryCommentRepository;
+    private final SocialAccountsRepository socialAccountsRepository;
 
 
     /**
@@ -99,7 +101,8 @@ public class UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
 
-        return UserConverter.toUserProfileResponse(user);
+        boolean isSocialUser = socialAccountsRepository.findByUser(user).isPresent();
+        return UserConverter.toUserProfileResponse(user, isSocialUser);
     }
 
     /**
@@ -457,7 +460,8 @@ public class UserService {
 
         user.setUpdatedAt(LocalDateTime.now());
         User updatedUser = userRepository.save(user);
-        return UserConverter.toUserProfileResponse(updatedUser);
+        boolean isSocialUser = socialAccountsRepository.findByUser(updatedUser).isPresent();
+        return UserConverter.toUserProfileResponse(updatedUser, isSocialUser);
     }
 
     /**

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -125,6 +125,30 @@ public class UserController {
         return ApiResponse.onSuccess(response);
     }
 
+    @PatchMapping("/me/terms")
+    @Operation(summary = "약관 동의", description = "카카오 회원가입 후 약관 동의를 처리합니다. 개인정보 처리방침과 이용약관은 필수입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "약관 동의 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "USER404-NOT_FOUND: 존재하지 않는 회원입니다",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\"isSuccess\": false, \"code\": \"USER404-NOT_FOUND\", \"message\": \"존재하지 않는 회원입니다.\"}"
+                            )
+                    )
+            )
+    })
+    public ApiResponse<Void> agreeTerms(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody com.fmi.domain.user.web.dto.TermsAgreeRequest request
+    ) {
+        String email = userDetails.getUsername();
+        userService.agreeTerms(email, request);
+        return ApiResponse.onSuccess(null);
+    }
+
     @GetMapping("/me/comments")
     @Operation(summary = "내가 쓴 댓글 목록", description = """
             현재 로그인한 사용자가 작성한 댓글 목록을 커서 기반으로 조회합니다. 삭제된 댓글은 제외됩니다.

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -103,7 +103,7 @@ public class UserController {
     }
 
     @GetMapping("/me")
-    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 기본 프로필 정보를 조회합니다. (닉네임, 이메일, 프로필 이미지)")
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 사용자의 기본 프로필 정보를 조회합니다. (닉네임, 이메일, 프로필 이미지, 소셜 로그인 여부)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 정보 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/fmi/domain/user/web/dto/TermsAgreeRequest.java
+++ b/src/main/java/com/fmi/domain/user/web/dto/TermsAgreeRequest.java
@@ -1,0 +1,22 @@
+package com.fmi.domain.user.web.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TermsAgreeRequest {
+
+    @AssertTrue(message = "개인정보 처리방침에 동의해주세요")
+    private boolean privacyPolicyAgreed;
+
+    @AssertTrue(message = "이용약관에 동의해주세요")
+    private boolean termsOfServiceAgreed;
+
+    private boolean contentPolicyAgreed;
+
+    private boolean marketingConsent;
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close #468

## 🛠️ 작업 내용

- 내 정보 조회 응답에 소셜 로그인 회원 여부 필드 추가
- 카카오 회원 탈퇴 api 수정 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
