### PR TITLE
feat: 메인 주소 검색시 부분 검색 기능 추가

### DIFF
--- a/src/main/java/com/fmi/domain/map/repository/PostMapCustom.java
+++ b/src/main/java/com/fmi/domain/map/repository/PostMapCustom.java
@@ -44,6 +44,7 @@ public interface PostMapCustom {
                                                          PostType postType,
                                                          PostStatus postStatus,
                                                          Category category,
+                                                         String keyword,
                                                          Long userId,
                                                          Set<Long> excludedUserIds,
                                                          Set<Long> hotPostIds,

--- a/src/main/java/com/fmi/domain/map/repository/PostMapCustomImpl.java
+++ b/src/main/java/com/fmi/domain/map/repository/PostMapCustomImpl.java
@@ -325,6 +325,7 @@ public class PostMapCustomImpl implements PostMapCustom {
                                                                 PostType postType,
                                                                 PostStatus postStatus,
                                                                 Category category,
+                                                                String keyword,
                                                                 Long userId,
                                                                 Set<Long> excludedUserIds,
                                                                 Set<Long> hotPostIds,
@@ -355,13 +356,23 @@ public class PostMapCustomImpl implements PostMapCustom {
                 lng, lat
         );
 
+        BooleanBuilder geoOrKeyword = new BooleanBuilder();
+
+        geoOrKeyword.or(
+                post.latitude.isNotNull()
+                        .and(post.longitude.isNotNull())
+                        .and(post.latitude.between(minLat, maxLat))
+                        .and(post.longitude.between(minLng, maxLng))
+        );
+
+        if(keyword != null && !keyword.isBlank()) {
+            geoOrKeyword.or(post.address.containsIgnoreCase(keyword));
+        }
+
         BooleanBuilder where = new BooleanBuilder();
+        where.and(geoOrKeyword);
         where.and(post.deleted.isFalse());
         where.and(post.temporarySave.isFalse());
-        where.and(post.latitude.isNotNull());
-        where.and(post.longitude.isNotNull());
-        where.and(post.latitude.between(minLat, maxLat));
-        where.and(post.longitude.between(minLng, maxLng));
 
         if (postType != null) {
             where.and(post.postType.eq(postType));

--- a/src/main/java/com/fmi/domain/map/repository/PostMapCustomImpl.java
+++ b/src/main/java/com/fmi/domain/map/repository/PostMapCustomImpl.java
@@ -359,18 +359,18 @@ public class PostMapCustomImpl implements PostMapCustom {
         BooleanBuilder geoOrKeyword = new BooleanBuilder();
 
         geoOrKeyword.or(
-                post.latitude.isNotNull()
-                        .and(post.longitude.isNotNull())
-                        .and(post.latitude.between(minLat, maxLat))
+                post.latitude.between(minLat, maxLat)
                         .and(post.longitude.between(minLng, maxLng))
         );
 
-        if(keyword != null && !keyword.isBlank()) {
+        if (keyword != null && !keyword.isBlank()) {
             geoOrKeyword.or(post.address.containsIgnoreCase(keyword));
         }
 
         BooleanBuilder where = new BooleanBuilder();
         where.and(geoOrKeyword);
+        where.and(post.latitude.isNotNull());
+        where.and(post.longitude.isNotNull());
         where.and(post.deleted.isFalse());
         where.and(post.temporarySave.isFalse());
 

--- a/src/main/java/com/fmi/domain/map/service/PostMapService.java
+++ b/src/main/java/com/fmi/domain/map/service/PostMapService.java
@@ -129,6 +129,7 @@ public class PostMapService {
                 request.postType(),
                 request.postStatus(),
                 request.category(),
+                request.keyword(),
                 Objects.nonNull(user) ? user.getId() : null,
                 excludedUserIds,
                 hotPostIds,

--- a/src/main/java/com/fmi/domain/map/web/controller/MapController.java
+++ b/src/main/java/com/fmi/domain/map/web/controller/MapController.java
@@ -242,10 +242,11 @@ public class MapController {
                     - 로그인 사용자인 경우 차단 유저의 게시글은 제외됩니다.
                     - 첫 요청은 lastDistance, lastPostId 없이 호출합니다.
                     - 이후 응답의 nextDistance, nextPostId를 다음 요청에 전달합니다.
+                    - keyword가 있으면, 반경 밖이더라도 address에 keyword가 포함된 게시글을 함게 반환합니다. (예: "강남구"로 검색 시 좌표 반경 밖이라도 address에 "강남구"가 들어간 글은 결과에 포함)
                     
                     예)
                     - 첫 요청:
-                      /main/posts/search-location?latitude=37.5665&longitude=126.9780&level=5
+                      /main/posts/search-location?latitude=37.5665&longitude=126.9780&level=5&keyword=강남구
                     - 다음 요청:
                       /main/posts/search-location?latitude=37.5665&longitude=126.9780&level=5&lastDistance=152.4&lastPostId=12
                     """

--- a/src/main/java/com/fmi/domain/map/web/dto/request/LocationMapPostRequest.java
+++ b/src/main/java/com/fmi/domain/map/web/dto/request/LocationMapPostRequest.java
@@ -29,6 +29,9 @@ public record LocationMapPostRequest(
         PostStatus postStatus,
 
         @Schema(description = "카테고리 필터", example = "WALLET")
-        Category category
+        Category category,
+
+        @Schema(description = "검색 키워드", example = "강남구")
+        String keyword
         ) {
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- close #488 

## 🛠️ 작업 내용
- /main/posts/search-location API에 keyword 쿼리 파라미터를 추가하여,                                                                               
  행정구역/도로명 검색 시 반경 밖의 게시글까지 매칭되도록 부분 검색이 가능하게 개선했습니다.
                                                                                                                                                        
## 📢 참고 및 특이사항
- address LIKE %keyword%는 B-Tree 인덱스 활용 불가 → 추후 Full-Text Index 도입 검토  

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
