### PR TITLE
feat: 게시글 목록용 썸네일 이미지 생성 및 응답 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 
+    // Image thumbnail
+    implementation 'net.coobird:thumbnailator:0.4.20'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/fmi/domain/map/repository/PostMapCustomImpl.java
+++ b/src/main/java/com/fmi/domain/map/repository/PostMapCustomImpl.java
@@ -7,6 +7,7 @@ import com.fmi.domain.post.data.*;
 import com.fmi.domain.postfavorite.data.QPostFavorite;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
@@ -180,8 +181,10 @@ public class PostMapCustomImpl implements PostMapCustom {
                 .map(Post::getId)
                 .toList();
 
+        // 목록 썸네일 우선, 없으면 원본 URL로 대체
+        Expression<String> listThumbnailUrl = postImage.thumbnailUrl.coalesce(postImage.imgUrl);
         Map<Long, String> thumbnailMap = jpaQueryFactory
-                .select(postImage.post.id, postImage.imgUrl)
+                .select(postImage.post.id, listThumbnailUrl)
                 .from(postImage)
                 .where(
                         postImage.post.id.in(postIdList),
@@ -191,7 +194,7 @@ public class PostMapCustomImpl implements PostMapCustom {
                 .stream()
                 .collect(Collectors.toMap(
                         t -> Objects.requireNonNull(t.get(postImage.post.id)),
-                        t -> Objects.requireNonNull(t.get(postImage.imgUrl)),
+                        t -> Objects.requireNonNull(t.get(listThumbnailUrl)),
                         (a, b) -> a
                 ));
 
@@ -304,7 +307,7 @@ public class PostMapCustomImpl implements PostMapCustom {
                         RecentFoundPostResponse.class,
                         p.id,
                         p.title,
-                        pi.imgUrl,
+                        pi.thumbnailUrl.coalesce(pi.imgUrl),
                         p.createdAt
                 ))
                 .from(p)
@@ -429,8 +432,10 @@ public class PostMapCustomImpl implements PostMapCustom {
                 .map(Post::getId)
                 .toList();
 
+        // 목록 썸네일 우선, 없으면 원본 URL로 대체
+        Expression<String> listThumbnailUrl = postImage.thumbnailUrl.coalesce(postImage.imgUrl);
         Map<Long, String> thumbnailMap = jpaQueryFactory
-                .select(postImage.post.id, postImage.imgUrl)
+                .select(postImage.post.id, listThumbnailUrl)
                 .from(postImage)
                 .where(
                         postImage.post.id.in(postIdList),
@@ -440,7 +445,7 @@ public class PostMapCustomImpl implements PostMapCustom {
                 .stream()
                 .collect(Collectors.toMap(
                         t -> Objects.requireNonNull(t.get(postImage.post.id)),
-                        t -> Objects.requireNonNull(t.get(postImage.imgUrl)),
+                        t -> Objects.requireNonNull(t.get(listThumbnailUrl)),
                         (a, b) -> a
                 ));
 

--- a/src/main/java/com/fmi/domain/post/converter/util/PostImageConverter.java
+++ b/src/main/java/com/fmi/domain/post/converter/util/PostImageConverter.java
@@ -4,13 +4,14 @@ import com.fmi.domain.post.data.ImageType;
 import com.fmi.domain.post.data.Post;
 import com.fmi.domain.post.data.PostImage;
 import com.fmi.domain.post.web.dto.response.image.PostImageResponse;
+import com.fmi.global.dto.UploadedImage;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
 
 public final class PostImageConverter {
-    public static List<PostImage> createPostImageList(List<String> images, Post post) {
+    public static List<PostImage> createPostImageList(List<UploadedImage> images, Post post) {
         if (Objects.isNull(images) || images.isEmpty()) {
             return List.of();
         }
@@ -22,8 +23,8 @@ public final class PostImageConverter {
                 }).toList();
     }
 
-    public static PostImage createPostImage(String url, ImageType imageType, Post post) {
-        return PostImage.create(url, imageType, post);
+    public static PostImage createPostImage(UploadedImage image, ImageType imageType, Post post) {
+        return PostImage.create(image.originalUrl(), image.thumbnailUrl(), imageType, post);
     }
 
     public static List<PostImageResponse> toResponseList(List<PostImage> imageList) {
@@ -36,13 +37,13 @@ public final class PostImageConverter {
         return new PostImageResponse(postImage.getId(), postImage.getImgUrl(), postImage.getImageType());
     }
 
-    public static List<PostImage> createAllNormal(List<String> images, Post post) {
+    public static List<PostImage> createAllNormal(List<UploadedImage> images, Post post) {
         if (Objects.isNull(images) || images.isEmpty()) {
             return List.of();
         }
 
         return images.stream()
-                .map(url -> PostImage.create(url, ImageType.NORMAL, post))
+                .map(image -> PostImage.create(image.originalUrl(), image.thumbnailUrl(), ImageType.NORMAL, post))
                 .toList();
     }
 

--- a/src/main/java/com/fmi/domain/post/data/PostImage.java
+++ b/src/main/java/com/fmi/domain/post/data/PostImage.java
@@ -17,6 +17,9 @@ public class PostImage {
     @Column(name = "img_url", nullable = false)
     private String imgUrl;
 
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "image_type", nullable = false)
     private ImageType imageType;
@@ -25,13 +28,14 @@ public class PostImage {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    private PostImage(String imgUrl, ImageType imageType, Post post) {
+    private PostImage(String imgUrl, String thumbnailUrl, ImageType imageType, Post post) {
         this.imgUrl = imgUrl;
+        this.thumbnailUrl = thumbnailUrl;
         this.imageType = imageType;
         this.post = post;
     }
 
-    public static PostImage create(String imgUrl, ImageType imageType, Post post) {
-        return new PostImage(imgUrl, imageType, post);
+    public static PostImage create(String imgUrl, String thumbnailUrl, ImageType imageType, Post post) {
+        return new PostImage(imgUrl, thumbnailUrl, imageType, post);
     }
 }

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -117,7 +117,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .stream()
                 .collect(Collectors.toMap(
                         t -> Objects.requireNonNull(t.get(postImage.post.id)),
-                        t -> Objects.requireNonNull(t.get(listThumbnailUrl))
+                        t -> Objects.requireNonNull(t.get(listThumbnailUrl)),
+                        (a, b) -> a
                 ));
 
         Map<Long, Long> favoriteCountMap = queryFactory

--- a/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/fmi/domain/post/repository/PostRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.fmi.domain.post.web.dto.response.PostPageResponse;
 import com.fmi.domain.postfavorite.data.QPostFavorite;
 import com.fmi.domain.userblock.repository.BlockedUserRepository;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -103,8 +104,10 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
         List<Long> postIdList = posts.stream().map(Post::getId).toList();
 
+        // 목록 썸네일 우선, 없으면 원본 URL로 대체
+        Expression<String> listThumbnailUrl = postImage.thumbnailUrl.coalesce(postImage.imgUrl);
         Map<Long, String> thumbnailMap = queryFactory
-                .select(postImage.post.id, postImage.id, postImage.imgUrl)
+                .select(postImage.post.id, listThumbnailUrl)
                 .from(postImage)
                 .where(
                         postImage.post.id.in(postIdList),
@@ -114,7 +117,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .stream()
                 .collect(Collectors.toMap(
                         t -> Objects.requireNonNull(t.get(postImage.post.id)),
-                        t -> Objects.requireNonNull(t.get(postImage.imgUrl))
+                        t -> Objects.requireNonNull(t.get(listThumbnailUrl))
                 ));
 
         Map<Long, Long> favoriteCountMap = queryFactory
@@ -345,8 +348,10 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         QPostFavorite postFavorite = QPostFavorite.postFavorite;
         List<Long> postIdList = posts.stream().map(Post::getId).toList();
 
+        // 목록 썸네일 우선, 없으면 원본 URL로 대체
+        Expression<String> listThumbnailUrl = postImage.thumbnailUrl.coalesce(postImage.imgUrl);
         Map<Long, String> thumbnailMap = queryFactory
-                .select(postImage.post.id, postImage.id, postImage.imgUrl)
+                .select(postImage.post.id, listThumbnailUrl)
                 .from(postImage)
                 .where(
                         postImage.post.id.in(postIdList),
@@ -356,7 +361,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .stream()
                 .collect(Collectors.toMap(
                         t -> Objects.requireNonNull(t.get(postImage.post.id)),
-                        t -> Objects.requireNonNull(t.get(postImage.imgUrl)),
+                        t -> Objects.requireNonNull(t.get(listThumbnailUrl)),
                         (a, b) -> a
                 ));
 

--- a/src/main/java/com/fmi/domain/post/service/PostImageService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostImageService.java
@@ -151,7 +151,8 @@ public class PostImageService {
         return thumbnails.stream()
                 .collect(Collectors.toMap(
                         pi -> pi.getPost().getId(),   // key: postId
-                        PostImageService::resolveThumbnailUrl
+                        PostImageService::resolveThumbnailUrl,
+                        (a, b) -> a
                 ));
     }
 
@@ -178,7 +179,8 @@ public class PostImageService {
         return thumbnails.stream()
                 .collect(Collectors.toMap(
                         pi -> pi.getPost().getId(),
-                        PostImageService::resolveThumbnailUrl
+                        PostImageService::resolveThumbnailUrl,
+                        (a, b) -> a
                 ));
     }
 

--- a/src/main/java/com/fmi/domain/post/service/PostImageService.java
+++ b/src/main/java/com/fmi/domain/post/service/PostImageService.java
@@ -16,6 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -76,7 +77,7 @@ public class PostImageService {
     public void createPostImageAtS3AndDB(List<MultipartFile> imageList, Post post) {
         List<PostImage> postImageList = new ArrayList<>();
         if (Objects.nonNull(imageList)) {
-            postImageList = PostImageConverter.createPostImageList(s3Service.upload(imageList), post);
+            postImageList = PostImageConverter.createPostImageList(s3Service.uploadWithThumbnail(imageList), post);
         }
 
         postImageRepository.saveAll(postImageList);
@@ -85,7 +86,7 @@ public class PostImageService {
     public List<PostImage> createPostImageNormalAtS3AndDB(List<MultipartFile> imageList, Post post) {
         List<PostImage> postImageList = new ArrayList<>();
         if (Objects.nonNull(imageList)) {
-            postImageList = PostImageConverter.createAllNormal(s3Service.upload(imageList), post);
+            postImageList = PostImageConverter.createAllNormal(s3Service.uploadWithThumbnail(imageList), post);
         }
 
         return postImageRepository.saveAll(postImageList);
@@ -94,7 +95,7 @@ public class PostImageService {
     public void deleteAllImageByPost(Post post) {
         List<PostImage> postImageList = postImageRepository.findByPost(post);
 
-        List<String> urlList = postImageList.stream().map(PostImage::getImgUrl).toList();
+        List<String> urlList = collectAllUrls(postImageList);
         try {
             s3Service.delete(urlList);
         } catch (Exception e) {
@@ -105,7 +106,7 @@ public class PostImageService {
     }
 
     public void deleteImageAtS3(List<PostImage> imageList) {
-        List<String> imageUrlList = imageList.stream().map(PostImage::getImgUrl).toList();
+        List<String> imageUrlList = collectAllUrls(imageList);
         s3Service.delete(imageUrlList);
     }
 
@@ -126,7 +127,12 @@ public class PostImageService {
     @Transactional(readOnly = true)
     public String findThumbnailImageUrl(Post post) {
         PostImage thumbnail = findThumbnailImage(post);
-        return thumbnail != null ? thumbnail.getImgUrl() : null;
+        return thumbnail != null ? resolveThumbnailUrl(thumbnail) : null;
+    }
+
+    // 목록 썸네일 우선, 없으면 원본 URL로 대체
+    private static String resolveThumbnailUrl(PostImage image) {
+        return image.getThumbnailUrl() != null ? image.getThumbnailUrl() : image.getImgUrl();
     }
 
     @Transactional(readOnly = true)
@@ -145,7 +151,7 @@ public class PostImageService {
         return thumbnails.stream()
                 .collect(Collectors.toMap(
                         pi -> pi.getPost().getId(),   // key: postId
-                        PostImage::getImgUrl
+                        PostImageService::resolveThumbnailUrl
                 ));
     }
 
@@ -172,7 +178,7 @@ public class PostImageService {
         return thumbnails.stream()
                 .collect(Collectors.toMap(
                         pi -> pi.getPost().getId(),
-                        PostImage::getImgUrl
+                        PostImageService::resolveThumbnailUrl
                 ));
     }
 
@@ -205,11 +211,15 @@ public class PostImageService {
     }
 
     private void deleteFromS3(List<PostImage> images) {
-        List<String> urls = images.stream()
-                .map(PostImage::getImgUrl)
-                .toList();
+        s3Service.delete(collectAllUrls(images));
+    }
 
-        s3Service.delete(urls);
+    // 원본 + 썸네일 URL을 모두 모아 S3 삭제 대상으로 반환 (썸네일이 없는 기존 데이터 대비 null 제외)
+    private static List<String> collectAllUrls(List<PostImage> images) {
+        return images.stream()
+                .flatMap(pi -> Stream.of(pi.getImgUrl(), pi.getThumbnailUrl()))
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     private void deleteFromDatabase(List<PostImage> images) {

--- a/src/main/java/com/fmi/global/dto/UploadedImage.java
+++ b/src/main/java/com/fmi/global/dto/UploadedImage.java
@@ -1,0 +1,5 @@
+package com.fmi.global.dto;
+
+// 원본 이미지 URL과 목록용 썸네일 이미지 URL 쌍
+public record UploadedImage(String originalUrl, String thumbnailUrl) {
+}

--- a/src/main/java/com/fmi/global/service/S3Service.java
+++ b/src/main/java/com/fmi/global/service/S3Service.java
@@ -2,8 +2,10 @@ package com.fmi.global.service;
 
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
+import com.fmi.global.dto.UploadedImage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +16,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
@@ -33,12 +36,64 @@ public class S3Service {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
+    // 썸네일 최대 변 길이(px)
+    private static final int THUMBNAIL_SIZE = 180;
+    // 썸네일 JPEG 압축 품질 (0.0 ~ 1.0)
+    private static final double THUMBNAIL_QUALITY = 0.8;
+
     // S3에 저장된 이미지 객체의 public url을 반환
     public List<String> upload(List<MultipartFile> files) {
         // 각 파일을 업로드하고 url을 리스트로 반환
         return files.stream()
                 .map(this::uploadImage)
                 .toList();
+    }
+
+    // 원본 + 목록용 썸네일을 함께 S3에 업로드하고 (원본 url, 썸네일 url) 쌍을 반환
+    public List<UploadedImage> uploadWithThumbnail(List<MultipartFile> files) {
+        return files.stream()
+                .map(this::uploadImageWithThumbnail)
+                .toList();
+    }
+
+    private UploadedImage uploadImageWithThumbnail(MultipartFile file) {
+        validateFile(file.getOriginalFilename());
+        String originalUrl = uploadImageToS3(file);
+        String thumbnailUrl = uploadThumbnailToS3(file);
+        return new UploadedImage(originalUrl, thumbnailUrl);
+    }
+
+    // 원본을 축소한 썸네일을 생성하여 S3에 업로드하고 public url을 반환
+    private String uploadThumbnailToS3(MultipartFile file) {
+        String originalFilename = Objects.requireNonNull(file.getOriginalFilename());
+        String extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+        String format = extension.equals("jpeg") ? "jpg" : extension;
+        String baseName = originalFilename.substring(0, originalFilename.lastIndexOf("."));
+        String s3FileName = "thumb_" + UUID.randomUUID().toString().substring(0, 10) + "_" + baseName + "." + format;
+
+        try (InputStream inputStream = file.getInputStream();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Thumbnails.of(inputStream)
+                    .size(THUMBNAIL_SIZE, THUMBNAIL_SIZE) // 비율 유지하며 최대 변이 THUMBNAIL_SIZE가 되도록 축소
+                    .outputQuality(THUMBNAIL_QUALITY)
+                    .outputFormat(format)
+                    .toOutputStream(outputStream);
+
+            byte[] thumbnailBytes = outputStream.toByteArray();
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3FileName)
+                    .contentType("image/" + format)
+                    .contentLength((long) thumbnailBytes.length)
+                    .build();
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(thumbnailBytes));
+        } catch (Exception exception) {
+            log.error(exception.getMessage(), exception);
+            throw new GeneralException(ErrorStatus._IO_EXCEPTION_UPLOAD_FILE);
+        }
+
+        return s3Client.utilities().getUrl(url -> url.bucket(bucketName).key(s3FileName)).toString();
     }
 
     // validateFile메서드를 호출하여 유효성 검증 후 uploadImageToS3메서드에 데이터를 반환하여 S3에 파일 업로드, public url을 받아 서비스 로직에 반환

--- a/src/main/resources/db/migration/V6__add_post_image_thumbnail_url.sql
+++ b/src/main/resources/db/migration/V6__add_post_image_thumbnail_url.sql
@@ -1,0 +1,2 @@
+ALTER TABLE post_image
+    ADD COLUMN thumbnail_url VARCHAR(255) NULL AFTER img_url;


### PR DESCRIPTION
## 🧩 관련 이슈

- close #491 

## 🛠️ 작업 내용

- 현재는 업로드 이미지를 원본 그대로 저장해 목록/상세에서 동일한 imageUrl을 응답합니다.
  목록 카드 이미지는 약 90x90으로 표시되는데 원본을 그대로 내려받아 전송량 및 렌더링 부담이 큽니다.
  목록 전용 썸네일을 별도로 만들어 이 부담을 줄입니다.
  
  - 이미지 업로드 시 원본과 함께 **목록용 썸네일(긴 변 180px, JPEG 품질 0.8)** 생성
  - 원본/썸네일을 S3에 각각 저장 (썸네일은 `thumb_` prefix)
  - `post_image.thumbnail_url` 컬럼 추가 (Flyway V6)
  - 목록/지도/어드민/채팅방 조회 시 `thumbnail_url` 응답 (없으면 `img_url` fallback)
  - 상세 조회 및 공유(OG)는 기존 원본(imgUrl) 유지
  - 이미지 삭제 시 원본 + 썸네일 모두 S3에서 제거

  ## 📂 주요 변경
  - `S3Service.uploadWithThumbnail()` 추가 (기존 `upload()`는 타 도메인용으로 유지)
  - `global/dto/UploadedImage` (원본/썸네일 URL 쌍) 추가
  - `PostImage`에 `thumbnailUrl` 필드 추가
  - 목록/지도 QueryDSL에 `COALESCE(thumbnail_url, img_url)` 적용

  ## ✅ 비고
  - 기존 이미지는 `thumbnail_url`이 null → 자동으로 원본 fallback 
  - 신규 업로드/수정 시 새로 추가되는 이미지부터 썸네일 생성
 

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
