### PR TITLE
fix: 요청 Origin 기준으로 인증 쿠키 Domain 동적 설정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -146,7 +146,6 @@ jobs:
               echo "VAPID_PRIVATE_KEY=${{ secrets.VAPID_PRIVATE_KEY }}"
               echo "SLACK_WEBHOOK_INQUIRY_URL=${{ secrets.SLACK_WEBHOOK_INQUIRY_URL }}"
               echo "SLACK_WEBHOOK_REPORT_URL=${{ secrets.SLACK_WEBHOOK_REPORT_URL }}"
-              echo "JWT_COOKIE_DOMAIN=${{ secrets.JWT_COOKIE_DOMAIN }}"
               echo "SPRING_FLYWAY_BASELINE_ON_MIGRATE=true"
               echo "SPRING_FLYWAY_BASELINE_VERSION=1"
             } > .env

--- a/src/main/java/com/fmi/domain/auth/web/controller/AuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.fmi.domain.auth.web.dto.LoginRequest;
 import com.fmi.domain.auth.web.dto.SignupRequest;
 import com.fmi.domain.auth.repository.SocialAccountsRepository;
 import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.security.CookieFactory;
 import com.fmi.security.JwtTokenProvider;
 import com.fmi.security.RefreshTokenStore;
 import jakarta.validation.Valid;
@@ -34,17 +35,12 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenStore refreshTokenStore;
     private final SocialAccountsRepository socialAccountsRepository;
+    private final CookieFactory cookieFactory;
 
     @Value("${jwt.cookie.name:refresh_token}")
     private String refreshCookieName;
     @Value("${jwt.cookie.access-token-name:access_token}")
     private String accessCookieName;
-    @Value("${jwt.cookie.secure:false}")
-    private boolean cookieSecure;
-    @Value("${jwt.cookie.same-site:Lax}")
-    private String cookieSameSite;
-    @Value("${jwt.cookie.domain:}")
-    private String cookieDomain;
 
     @PostMapping("/signup")
     @Operation(summary = "회원가입", description = "이메일/비밀번호/닉네임을 입력해 회원을 생성합니다. 비밀번호는 8~16자, 대/소문자·숫자·특수문자를 포함해야 합니다. 가입 성공 시 자동 로그인되어 토큰이 쿠키로 발급됩니다.")
@@ -89,9 +85,10 @@ public class AuthController {
                     )
             )
     })
-    public ResponseEntity<ApiResponse<LoginResponse>> signup(@Valid @RequestBody SignupRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponse>> signup(@Valid @RequestBody SignupRequest request,
+                                                             HttpServletRequest httpRequest) {
         var user = authService.signup(request);
-        return buildTokenResponse(user, false);
+        return buildTokenResponse(httpRequest, user, false);
     }
 
     @PostMapping("/login")
@@ -115,9 +112,10 @@ public class AuthController {
                     )
             )
     })
-    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request,
+                                                            HttpServletRequest httpRequest) {
         var authResult = authService.authenticate(request.getEmail(), request.getPassword());
-        return buildTokenResponse(authResult.getUser(), authResult.isTemporaryPassword());
+        return buildTokenResponse(httpRequest, authResult.getUser(), authResult.isTemporaryPassword());
     }
 
     @GetMapping("/check-nickname")
@@ -222,8 +220,8 @@ public class AuthController {
         java.util.Date refreshExp = jwtTokenProvider.getExpiration(newRefresh);
         refreshTokenStore.issue(newJti, email, newHash, refreshExp.toInstant());
 
-        ResponseCookie accessCookie = buildCookie(accessCookieName, accessToken, jwtTokenProvider.getExpiration(accessToken));
-        ResponseCookie refreshCookie = buildCookie(refreshCookieName, newRefresh, refreshExp);
+        ResponseCookie accessCookie = buildCookie(request, accessCookieName, accessToken, jwtTokenProvider.getExpiration(accessToken));
+        ResponseCookie refreshCookie = buildCookie(request, refreshCookieName, newRefresh, refreshExp);
 
         return ResponseEntity.ok()
                 .header("Set-Cookie", accessCookie.toString())
@@ -232,7 +230,7 @@ public class AuthController {
     }
 
     private ResponseEntity<ApiResponse<LoginResponse>> buildTokenResponse(
-            com.fmi.domain.auth.data.User user, boolean isTemporaryPassword) {
+            HttpServletRequest request, com.fmi.domain.auth.data.User user, boolean isTemporaryPassword) {
         var claims = new java.util.HashMap<String, Object>();
         claims.put("userId", user.getId());
         claims.put("role", user.getRole().name());
@@ -248,8 +246,8 @@ public class AuthController {
         java.util.Date refreshExp = jwtTokenProvider.getExpiration(refreshToken);
         refreshTokenStore.issue(jti, user.getEmail(), refreshHash, refreshExp.toInstant());
 
-        ResponseCookie accessCookie = buildCookie(accessCookieName, accessToken, jwtTokenProvider.getExpiration(accessToken));
-        ResponseCookie refreshCookie = buildCookie(refreshCookieName, refreshToken, refreshExp);
+        ResponseCookie accessCookie = buildCookie(request, accessCookieName, accessToken, jwtTokenProvider.getExpiration(accessToken));
+        ResponseCookie refreshCookie = buildCookie(request, refreshCookieName, refreshToken, refreshExp);
 
         return ResponseEntity.ok()
                 .header("Set-Cookie", accessCookie.toString())
@@ -257,21 +255,9 @@ public class AuthController {
                 .body(ApiResponse.onSuccess(AuthConverter.toLoginResponse(user.getId(), isTemporaryPassword)));
     }
 
-    private ResponseCookie buildCookie(String name, String value, java.time.Duration maxAge) {
-        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
-                .httpOnly(true)
-                .secure(cookieSecure)
-                .sameSite(cookieSameSite)
-                .path("/")
-                .maxAge(maxAge);
-        if (cookieDomain != null && !cookieDomain.isBlank()) {
-            builder.domain(cookieDomain);
-        }
-        return builder.build();
-    }
-
-    private ResponseCookie buildCookie(String name, String value, java.util.Date expiration) {
-        return buildCookie(name, value, java.time.Duration.between(java.time.Instant.now(), expiration.toInstant()));
+    private ResponseCookie buildCookie(HttpServletRequest request, String name, String value, java.util.Date expiration) {
+        return cookieFactory.build(request, name, value,
+                java.time.Duration.between(java.time.Instant.now(), expiration.toInstant()));
     }
 
     private static String sha256Hex(String value) {
@@ -302,10 +288,10 @@ public class AuthController {
         }
         
         // accessToken 쿠키 제거
-        ResponseCookie removeAccess = buildCookie(accessCookieName, "", java.time.Duration.ZERO);
+        ResponseCookie removeAccess = cookieFactory.expire(request, accessCookieName);
 
         // refreshToken 쿠키 제거
-        ResponseCookie removeRefresh = buildCookie(refreshCookieName, "", java.time.Duration.ZERO);
+        ResponseCookie removeRefresh = cookieFactory.expire(request, refreshCookieName);
         
         return ResponseEntity.ok()
                 .header("Set-Cookie", removeAccess.toString())

--- a/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
@@ -8,6 +8,7 @@ import com.fmi.domain.auth.service.KakaoOAuthService.KakaoUser;
 import com.fmi.domain.auth.service.SocialLoginService;
 import com.fmi.domain.auth.web.dto.KakaoLoginRequest;
 import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.security.CookieFactory;
 import com.fmi.security.JwtTokenProvider;
 import com.fmi.security.RefreshTokenStore;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,17 +38,12 @@ public class KakaoAuthController {
     private final SocialLoginService socialLoginService;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenStore refreshTokenStore;
+    private final CookieFactory cookieFactory;
 
     @Value("${jwt.cookie.name:refresh_token}")
     private String refreshCookieName;
     @Value("${jwt.cookie.access-token-name:access_token}")
     private String accessCookieName;
-    @Value("${jwt.cookie.secure:false}")
-    private boolean cookieSecure;
-    @Value("${jwt.cookie.same-site:Lax}")
-    private String cookieSameSite;
-    @Value("${jwt.cookie.domain:}")
-    private String cookieDomain;
 
     @PostMapping
     @Operation(summary = "카카오 로그인", 
@@ -118,7 +115,8 @@ public class KakaoAuthController {
                     )
             )
     })
-    public ResponseEntity<ApiResponse<LoginResponse>> loginWithKakao(@Valid @RequestBody KakaoLoginRequest req) {
+    public ResponseEntity<ApiResponse<LoginResponse>> loginWithKakao(@Valid @RequestBody KakaoLoginRequest req,
+                                                                     HttpServletRequest request) {
         // environment에 따라 환경 변수에서 자동 선택
         KakaoToken token = kakaoOAuthService.exchangeCodeForToken(req.getCode(), req.getEnvironment());
         String kakaoAccessToken = token.getAccess_token();
@@ -155,11 +153,11 @@ public class KakaoAuthController {
 
         // accessToken 쿠키 설정
         java.util.Date accessExp = jwtTokenProvider.getExpiration(accessToken);
-        ResponseCookie accessCookie = buildCookie(accessCookieName, accessToken,
+        ResponseCookie accessCookie = cookieFactory.build(request, accessCookieName, accessToken,
                 Duration.between(Instant.now(), accessExp.toInstant()));
 
         // refreshToken 쿠키 설정
-        ResponseCookie refreshCookie = buildCookie(refreshCookieName, refreshToken,
+        ResponseCookie refreshCookie = cookieFactory.build(request, refreshCookieName, refreshToken,
                 Duration.between(Instant.now(), refreshExp.toInstant()));
 
         // 응답 생성 및 반환
@@ -169,19 +167,6 @@ public class KakaoAuthController {
                 .header("Set-Cookie", accessCookie.toString())
                 .header("Set-Cookie", refreshCookie.toString())
                 .body(ApiResponse.onSuccess(new LoginResponse(localUser.getId(), false, termsAgreed)));
-    }
-
-    private ResponseCookie buildCookie(String name, String value, Duration maxAge) {
-        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
-                .httpOnly(true)
-                .secure(cookieSecure)
-                .sameSite(cookieSameSite)
-                .path("/")
-                .maxAge(maxAge);
-        if (cookieDomain != null && !cookieDomain.isBlank()) {
-            builder.domain(cookieDomain);
-        }
-        return builder.build();
     }
 
     private static String sha256Hex(String value) {

--- a/src/main/java/com/fmi/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/fmi/domain/user/web/controller/UserController.java
@@ -19,12 +19,14 @@ import com.fmi.domain.user.web.dto.PasswordChangeRequest;
 import com.fmi.domain.user.web.dto.PasswordVerifyRequest;
 import com.fmi.domain.user.web.dto.UserUpdateRequest;
 import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.security.CookieFactory;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,7 +39,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -48,17 +49,12 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final CookieFactory cookieFactory;
 
     @Value("${jwt.cookie.name:refresh_token}")
     private String refreshCookieName;
     @Value("${jwt.cookie.access-token-name:access_token}")
     private String accessCookieName;
-    @Value("${jwt.cookie.secure:false}")
-    private boolean cookieSecure;
-    @Value("${jwt.cookie.same-site:Lax}")
-    private String cookieSameSite;
-    @Value("${jwt.cookie.domain:}")
-    private String cookieDomain;
 
     @PostMapping("/uploads/images")
     @Operation(summary = "이미지 업로드", description = "여러 장의 이미지를 S3에 업로드하고 URL을 반환합니다. (JPEG, PNG 형식만 지원)")
@@ -509,31 +505,19 @@ public class UserController {
     })
     public ResponseEntity<ApiResponse<Void>> deleteAccount(
             @AuthenticationPrincipal UserDetails userDetails,
-            @Valid @RequestBody AccountDeleteRequest request
+            @Valid @RequestBody AccountDeleteRequest request,
+            HttpServletRequest httpRequest
     ) {
         String email = userDetails.getUsername();
         userService.deleteAccount(email, request);
 
-        ResponseCookie removeAccess = buildExpiredCookie(accessCookieName);
-        ResponseCookie removeRefresh = buildExpiredCookie(refreshCookieName);
+        ResponseCookie removeAccess = cookieFactory.expire(httpRequest, accessCookieName);
+        ResponseCookie removeRefresh = cookieFactory.expire(httpRequest, refreshCookieName);
 
         return ResponseEntity.ok()
                 .header("Set-Cookie", removeAccess.toString())
                 .header("Set-Cookie", removeRefresh.toString())
                 .body(ApiResponse.onSuccess(null));
-    }
-
-    private ResponseCookie buildExpiredCookie(String name) {
-        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, "")
-                .httpOnly(true)
-                .secure(cookieSecure)
-                .sameSite(cookieSameSite)
-                .path("/")
-                .maxAge(Duration.ZERO);
-        if (cookieDomain != null && !cookieDomain.isBlank()) {
-            builder.domain(cookieDomain);
-        }
-        return builder.build();
     }
 }
 

--- a/src/main/java/com/fmi/security/CookieFactory.java
+++ b/src/main/java/com/fmi/security/CookieFactory.java
@@ -1,0 +1,76 @@
+package com.fmi.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.time.Duration;
+
+/**
+ * 인증 쿠키를 생성/삭제
+ *     Origin 호스트가 .finditem.kr 에 속하면 → 해당 부모 도메인 부여
+ *     localhost → Domain 미설정(host-only)
+ */
+@Component
+public class CookieFactory {
+
+    @Value("${jwt.cookie.secure:false}")
+    private boolean secure;
+    @Value("${jwt.cookie.same-site:Lax}")
+    private String sameSite;
+    /** 서브도메인 간 공유시킬 부모 도메인(.finditem.kr). 비어 있으면 항상 host-only. */
+    @Value("${jwt.cookie.parent-domain:}")
+    private String parentDomain;
+
+    public ResponseCookie build(HttpServletRequest request, String name, String value, Duration maxAge) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(secure)
+                .sameSite(sameSite)
+                .path("/")
+                .maxAge(maxAge);
+
+        String domain = resolveDomain(request);
+        if (domain != null) {
+            builder.domain(domain);
+        }
+        // domain == null 이면 Domain 미설정 → host-only (로컬 환경)
+        return builder.build();
+    }
+
+    /** 빈 값+MaxAge=0 쿠키를 만들어 정상 삭제 */
+    public ResponseCookie expire(HttpServletRequest request, String name) {
+        return build(request, name, "", Duration.ZERO);
+    }
+
+    private String resolveDomain(HttpServletRequest request) {
+        if (parentDomain == null || parentDomain.isBlank() || request == null) {
+            return null;
+        }
+
+        String host = hostOf(request.getHeader("Origin"));
+        if (host == null) {
+            host = hostOf(request.getHeader("Referer")); // Origin이 없는 엣지케이스 대비
+        }
+        if (host == null) {
+            return null;
+        }
+
+        String bare = parentDomain.startsWith(".") ? parentDomain.substring(1) : parentDomain;
+        boolean belongsToParent = host.equals(bare) || host.endsWith("." + bare);
+        return belongsToParent ? parentDomain : null;
+    }
+
+    private String hostOf(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        try {
+            return URI.create(url).getHost();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/fmi/security/CookieFactoryTest.java
+++ b/src/test/java/com/fmi/security/CookieFactoryTest.java
@@ -1,0 +1,179 @@
+package com.fmi.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CookieFactoryTest {
+
+    private CookieFactory cookieFactory;
+
+    @BeforeEach
+    void setUp() {
+        cookieFactory = new CookieFactory();
+        ReflectionTestUtils.setField(cookieFactory, "secure", true);
+        ReflectionTestUtils.setField(cookieFactory, "sameSite", "None");
+        ReflectionTestUtils.setField(cookieFactory, "parentDomain", ".finditem.kr");
+    }
+
+    private MockHttpServletRequest request() {
+        return new MockHttpServletRequest();
+    }
+
+    @Nested
+    @DisplayName("Origin 기준 Domain 동적 결정")
+    class ResolveDomain {
+
+        @Test
+        @DisplayName("Origin이 localhost면 Domain을 설정하지 않는다 (host-only)")
+        void localhost_isHostOnly() {
+            MockHttpServletRequest req = request();
+            req.addHeader("Origin", "http://localhost:3000");
+
+            ResponseCookie cookie = cookieFactory.build(req, "access_token", "v", Duration.ofMinutes(15));
+
+            assertThat(cookie.getDomain()).isNull();
+        }
+
+        @Test
+        @DisplayName("Origin이 release 서브도메인이면 부모 도메인을 부여한다")
+        void releaseSubdomain_usesParentDomain() {
+            MockHttpServletRequest req = request();
+            req.addHeader("Origin", "https://release.finditem.kr");
+
+            ResponseCookie cookie = cookieFactory.build(req, "access_token", "v", Duration.ofMinutes(15));
+
+            assertThat(cookie.getDomain()).isEqualTo(".finditem.kr");
+        }
+
+        @Test
+        @DisplayName("Origin이 운영 서브도메인이면 부모 도메인을 부여한다")
+        void prodSubdomain_usesParentDomain() {
+            MockHttpServletRequest req = request();
+            req.addHeader("Origin", "https://www.finditem.kr");
+
+            ResponseCookie cookie = cookieFactory.build(req, "access_token", "v", Duration.ofMinutes(15));
+
+            assertThat(cookie.getDomain()).isEqualTo(".finditem.kr");
+        }
+
+        @Test
+        @DisplayName("Origin이 부모 도메인 자체(finditem.kr)여도 부여한다")
+        void bareParentDomain_usesParentDomain() {
+            MockHttpServletRequest req = request();
+            req.addHeader("Origin", "https://finditem.kr");
+
+            ResponseCookie cookie = cookieFactory.build(req, "access_token", "v", Duration.ofMinutes(15));
+
+            assertThat(cookie.getDomain()).isEqualTo(".finditem.kr");
+        }
+
+        @Test
+        @DisplayName("부모 도메인을 가장한 위조 도메인은 부여하지 않는다")
+        void spoofedDomain_isHostOnly() {
+            MockHttpServletRequest req = request();
+            req.addHeader("Origin", "https://finditem.kr.evil.com");
+
+            ResponseCookie cookie = cookieFactory.build(req, "access_token", "v", Duration.ofMinutes(15));
+
+            assertThat(cookie.getDomain()).isNull();
+        }
+
+        @Test
+        @DisplayName("Origin이 없으면 Referer로 판단한다")
+        void fallsBackToReferer() {
+            MockHttpServletRequest req = request();
+            req.addHeader("Referer", "https://release.finditem.kr/login");
+
+            ResponseCookie cookie = cookieFactory.build(req, "access_token", "v", Duration.ofMinutes(15));
+
+            assertThat(cookie.getDomain()).isEqualTo(".finditem.kr");
+        }
+
+        @Test
+        @DisplayName("Origin도 Referer도 없으면 Domain을 설정하지 않는다")
+        void noOriginNoReferer_isHostOnly() {
+            ResponseCookie cookie = cookieFactory.build(request(), "access_token", "v", Duration.ofMinutes(15));
+
+            assertThat(cookie.getDomain()).isNull();
+        }
+
+        @Test
+        @DisplayName("parent-domain 설정이 비어 있으면 finditem.kr Origin이어도 host-only")
+        void blankParentDomain_alwaysHostOnly() {
+            ReflectionTestUtils.setField(cookieFactory, "parentDomain", "");
+            MockHttpServletRequest req = request();
+            req.addHeader("Origin", "https://release.finditem.kr");
+
+            ResponseCookie cookie = cookieFactory.build(req, "access_token", "v", Duration.ofMinutes(15));
+
+            assertThat(cookie.getDomain()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("쿠키 공통 속성")
+    class CommonAttributes {
+
+        @Test
+        @DisplayName("httpOnly/secure/sameSite/path가 설정값대로 적용된다")
+        void appliesBaseAttributes() {
+            MockHttpServletRequest req = request();
+            req.addHeader("Origin", "https://release.finditem.kr");
+
+            ResponseCookie cookie = cookieFactory.build(req, "access_token", "v", Duration.ofMinutes(15));
+
+            assertThat(cookie.isHttpOnly()).isTrue();
+            assertThat(cookie.isSecure()).isTrue();
+            assertThat(cookie.getSameSite()).isEqualTo("None");
+            assertThat(cookie.getPath()).isEqualTo("/");
+            assertThat(cookie.getName()).isEqualTo("access_token");
+            assertThat(cookie.getValue()).isEqualTo("v");
+            assertThat(cookie.getMaxAge()).isEqualTo(Duration.ofMinutes(15));
+        }
+    }
+
+    @Nested
+    @DisplayName("expire - 쿠키 삭제")
+    class Expire {
+
+        @Test
+        @DisplayName("빈 값 + MaxAge 0으로 만든다")
+        void emptyValueZeroMaxAge() {
+            ResponseCookie cookie = cookieFactory.expire(request(), "refresh_token");
+
+            assertThat(cookie.getValue()).isEmpty();
+            assertThat(cookie.getMaxAge()).isEqualTo(Duration.ZERO);
+        }
+
+        @Test
+        @DisplayName("삭제 쿠키도 발급과 동일한 Domain 규칙을 따른다 (release)")
+        void followsSameDomainRule() {
+            MockHttpServletRequest req = request();
+            req.addHeader("Origin", "https://release.finditem.kr");
+
+            ResponseCookie cookie = cookieFactory.expire(req, "refresh_token");
+
+            assertThat(cookie.getDomain()).isEqualTo(".finditem.kr");
+        }
+
+        @Test
+        @DisplayName("삭제 쿠키도 localhost면 host-only로 만든다")
+        void localhostHostOnly() {
+            MockHttpServletRequest req = request();
+            req.addHeader("Origin", "http://localhost:3000");
+
+            ResponseCookie cookie = cookieFactory.expire(req, "refresh_token");
+
+            assertThat(cookie.getDomain()).isNull();
+        }
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- close #495 

## 🛠️ 작업 내용

  하나의 백엔드(dev)가 **로컬/release** 두 프론트 환경을 동시에 상대하는데, 두 환경이
  요구하는 쿠키 `Domain`이 달라 인증 쿠키가 정상 동작하지 않던 문제를 해결합니다.

  - **`CookieFactory` 추가** — 요청 `Origin`(없으면 `Referer`) 호스트가 `parent-domain`에
    속하면 `Domain` 부여, 그 외(localhost 등)는 host-only로 쿠키 발급
  - **컨트롤러 3곳 통합** — `AuthController` / `KakaoAuthController` / `UserController`에
    중복돼 있던 쿠키 생성 로직을 `CookieFactory`로 일원화하고 `HttpServletRequest` 전달
  - **삭제 쿠키 규칙 일치** — 로그아웃/회원탈퇴의 쿠키 삭제도 발급과 동일한 `Domain` 규칙을
    적용해 좀비 쿠키 방지
  - **설정 단순화** — 정적 `domain` → `parent-domain` 기준값으로 변경 
  - **CI 정리** — 더 이상 사용하지 않는 `JWT_COOKIE_DOMAIN` 환경변수 주입 제거
  - **단위 테스트 추가** — `CookieFactoryTest`로 Origin 분기 검증


## 📢 참고 및 특이사항

 **Origin 선택 이유**
  - `Host`는 프록시가 `dev-api.finditem.kr`로 다시 써서 로컬/release 구분 불가
  - `Origin`은 브라우저가 페이지 출처로 설정하고 프록시가 그대로 전달 
  - 쿠키 발급 요청(로그인,카카오,리프레시)은 모두 POST라 Origin이 항상 존재

  **동작 흐름**
  | 요청 Origin | 결과 Domain |
  |---|---|
  | `http://localhost:3000` | 미설정 (host-only) |
  | `https://release.finditem.kr` | `.finditem.kr` |
  | `https://www.finditem.kr` | `.finditem.kr` |

  - 로컬은 프록시 경유라 브라우저 실제 요청 호스트가 `localhost`이므로, `.finditem.kr`을
    붙이면 도메인 불일치로 브라우저가 쿠키를 폐기 → host-only여야 정상 저장
  - release는 웹소켓 등이 `dev-api.finditem.kr`로 직접 나가므로 서브도메인 공유 위해 `.finditem.kr` 필요

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
