### PR TITLE
feat: 베타 도메인 CORS 허용 및 yml 설정 분리

### DIFF
--- a/src/main/java/com/fmi/FmiApplication.java
+++ b/src/main/java/com/fmi/FmiApplication.java
@@ -3,6 +3,7 @@ package com.fmi;
 import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -15,6 +16,7 @@ import java.util.TimeZone;
 @EnableScheduling
 @EnableCaching
 @EnableAsync
+@ConfigurationPropertiesScan
 public class FmiApplication {
 
 	@PostConstruct

--- a/src/main/java/com/fmi/config/CorsProperties.java
+++ b/src/main/java/com/fmi/config/CorsProperties.java
@@ -1,0 +1,17 @@
+package com.fmi.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@ConfigurationProperties(prefix = "cors")
+@Getter
+@Setter
+public class CorsProperties {
+    private List<String> allowedOriginPatterns = new ArrayList<>();
+}

--- a/src/main/java/com/fmi/config/CorsProperties.java
+++ b/src/main/java/com/fmi/config/CorsProperties.java
@@ -1,17 +1,18 @@
 package com.fmi.config;
 
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-import java.util.ArrayList;
 import java.util.List;
 
-@Configuration
+
 @ConfigurationProperties(prefix = "cors")
 @Getter
-@Setter
 public class CorsProperties {
-    private List<String> allowedOriginPatterns = new ArrayList<>();
+    private final List<String> allowedOriginPatterns;
+
+    public CorsProperties(List<String> allowedOriginPatterns) {
+        this.allowedOriginPatterns =
+                allowedOriginPatterns != null ? allowedOriginPatterns : List.of();
+    }
 }

--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -28,12 +28,17 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import lombok.RequiredArgsConstructor;
+
 import java.io.IOException;
 import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CorsProperties corsProperties;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, JwtTokenProvider tokenProvider, CustomUserDetailsService userDetailsService) throws Exception {
@@ -98,15 +103,7 @@ public class SecurityConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowCredentials(true);
-        // localhost의 모든 포트 허용 (개발 환경)
-        config.setAllowedOriginPatterns(Arrays.asList(
-                "http://localhost:*",
-                "http://127.0.0.1:*",
-                "https://finditem.kr",
-                "https://www.finditem.kr",
-                "https://finditem-release.vercel.app",
-                "https://release.finditem.kr"
-                ));
+        config.setAllowedOriginPatterns(corsProperties.getAllowedOriginPatterns());
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
         config.setMaxAge(3600L);


### PR DESCRIPTION
## 🧩 관련 이슈

- close #502 

## 🛠️ 작업 내용

  - CORS 허용 Origin 목록을 `SecurityConfig` 하드코딩 방식에서 yml 설정 기반으로 분리했습니다.
  - `CorsProperties`를 추가하여 `cors.allowed-origin-patterns` 설정값을 바인딩하도록 구성했습니다.
  - 베타 프론트 도메인을 CORS 허용 Origin에 포함할 수 있도록 설정 관리 구조를 개선했습니다.

## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
