### PR TITLE
feat: 댓글 목록/답글 조회 API 비회원 접근 허용

### DIFF
--- a/src/main/java/com/fmi/config/SecurityConfig.java
+++ b/src/main/java/com/fmi/config/SecurityConfig.java
@@ -57,6 +57,8 @@ public class SecurityConfig {
                         .requestMatchers("/users/{userId}/page").permitAll()
                         .requestMatchers(HttpMethod.GET, "/users/{userId}/meta").permitAll()
                         .requestMatchers(HttpMethod.GET, "/posts/search/**", "/posts/*", "/posts/*/similar", "/posts/*/share").permitAll()
+                        // 댓글 목록/답글 조회 - 비회원도 조회 가능
+                        .requestMatchers(HttpMethod.GET, "/comments/posts/*", "/comments/*/replies").permitAll()
                         .requestMatchers(HttpMethod.GET, "/main/posts/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/push/vapid-key").permitAll()
                         // 관리자 전용 API 보호


### PR DESCRIPTION
## 🧩 관련 이슈

- close #506

## 🛠️ 작업 내용


  - 댓글 목록 조회 API를 비회원도 접근 가능하도록 `permitAll()` 처리
  - 답글 조회 API를 비회원도 접근 가능하도록 `permitAll()` 처리
  - 댓글 작성/수정/삭제 API는 기존처럼 인증 필요 상태 유지

  ## 📢 참고 및 특이사항

  - 비회원 조회 시 `isLike`, `canEdit`, `canDelete`는 기본값으로 응답됩니다.
  - 회원이 유효한 토큰으로 조회하는 경우 기존처럼 좋아요 여부, 수정/삭제 가능 여부 등 개인화 정보가 반영됩니다.
  - 공개 처리된 API:
    - `GET /comments/posts/{postId}`
    - `GET /comments/{commentId}/replies`

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
