### PR TITLE
chore: CI/CD 파일 분리 및 리팩토링

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Github Repository 파일 불러오기
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: gradlew 실행 권한 부여
+        run: chmod +x gradlew
+
+      - name: 빌드하기
+        run: ./gradlew clean build -x test

--- a/.github/workflows/deploy-common.yml
+++ b/.github/workflows/deploy-common.yml
@@ -1,60 +1,28 @@
-name: Build & Deploy to EC2
+name: Common Deploy
 
 on:
-  push:
-    branches:
-      - develop
-  pull_request:
-    branches:
-      - develop
-  workflow_dispatch:  # 수동 실행도 가능
+  workflow_call:
+    inputs:
+      profile:
+        required: true
+        type: string
 
-permissions:
-  contents: read
+      service_name:
+        required: true
+        type: string
 
-concurrency:
-  group: deploy-ec2-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'pull_request' }}
+      image_tag:
+        required: true
+        type: string
 
 jobs:
-  ci:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Github Repository 파일 불러오기
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-
-      - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: gradlew 실행 권한 부여
-        run: chmod +x gradlew
-
-      - name: 빌드하기
-        run: ./gradlew clean build -x test
-
   deploy:
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/develop'
-    needs: ci
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
     steps:
       - name: Github Repository 파일 불러오기
         uses: actions/checkout@v4
-
-      - name: gradlew 실행 권한 부여
-        run: chmod +x gradlew
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
 
       - name: application.yml 생성
         run: |
@@ -63,12 +31,14 @@ jobs:
           EOF
 
       - name: application-dev.yml 생성
+        if: inputs.profile == 'dev'
         run: |
           cat <<'EOF' > src/main/resources/application-dev.yml
           ${{ secrets.APPLICATION_DEV }}
           EOF
 
       - name: application-prod.yml 생성
+        if: inputs.profile == 'prod'
         run: |
           cat <<'EOF' > src/main/resources/application-prod.yml
           ${{ secrets.APPLICATION_PROD }}
@@ -88,15 +58,17 @@ jobs:
       - name: Docker 이미지 빌드 및 ECR 푸시
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: fmi-backend # ECR 레포지토리 이름
-          IMAGE_TAG: ${{ github.sha }}
+          ECR_REPOSITORY: fmi-backend
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          SHA_TAG: ${{ github.sha }}
         run: |
           docker build \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+            .
 
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.3
@@ -105,15 +77,20 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           command_timeout: 25m
+
           script: |
             set -e
+
             cd ~/FMI-BE
 
-            # AWS ECR 로그인 
-            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com
+            aws ecr get-login-password --region ap-northeast-2 \
+              | docker login \
+                --username AWS \
+                --password-stdin \
+                ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-2.amazonaws.com
 
-            # 환경 변수 파일 생성/업데이트
             echo "Setting up environment variables..."
+
             {
               echo "ECR_IMAGE_URL=${{ secrets.ECR_IMAGE_URL }}"
               echo "PROD_DB_URL=${{ secrets.PROD_DB_URL }}"
@@ -152,14 +129,9 @@ jobs:
               echo "SPRING_FLYWAY_BASELINE_VERSION=1"
             } > .env
 
-            # 환경 변수 파일 권한 설정
             chmod 600 .env
 
-            # ECR에서 최신 이미지 가져오기
-            docker compose pull fmi-dev fmi-prod
+            docker compose pull ${{ inputs.service_name }}
+            docker compose up -d --no-deps ${{ inputs.service_name }}
 
-            # 컨테이너 실행 (변경사항 적용)
-            docker compose up -d --no-deps fmi-dev fmi-prod
-
-            # 안 쓰는 옛날 이미지 삭제 
             docker image prune -f

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,28 @@
+name: Deploy DEV
+
+on:
+  push:
+    branches:
+      - develop
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  deploy:
+    needs: ci
+    uses: ./.github/workflows/deploy-common.yml
+    with:
+      profile: dev
+      service_name: fmi-dev
+      image_tag: dev
+    secrets: inherit

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,28 @@
+name: Deploy PROD
+
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  deploy:
+    needs: ci
+    uses: ./.github/workflows/deploy-common.yml
+    with:
+      profile: prod
+      service_name: fmi-prod
+      image_tag: prod
+    secrets: inherit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - redis_data:/data
 
   fmi-prod:
-    image: ${ECR_IMAGE_URL}:latest
+    image: ${ECR_IMAGE_URL}:prod
     ports:
       - "127.0.0.1:8080:8080"
     container_name: fmi-prod
@@ -40,7 +40,7 @@ services:
         max-file: "3"
 
   fmi-dev:
-    image: ${ECR_IMAGE_URL}:latest
+    image: ${ECR_IMAGE_URL}:dev
     ports:
       - "127.0.0.1:8081:8080"
     container_name: fmi-dev


### PR DESCRIPTION
## 🧩 관련 이슈

- close #509 

## 🛠️ 작업 내용

  -  기존 통합 CI/CD 워크플로우(`ci-cd.yml`) 제거
  - CI 전용 워크플로우(`ci.yml`) 추가
  - 공통 배포 워크플로우(`deploy-common.yml`) 추가
  - DEV/PROD 배포 워크플로우 분리
    - `deploy-dev.yml`
    - `deploy-prod.yml`
  - `docker-compose.yml` 이미지 태그를 환경별로 분리
    - DEV: `:dev`
    - PROD: `:prod`

 ### 변경 이유
  - CI와 배포 책임을 분리해 워크플로우 구조를 명확하게 관리하기 위함
  - DEV/PROD 배포 흐름을 분리해 환경별 배포 대상을 명확히 하기 위함
  - 기존 `latest` 단일 태그 사용으로 인한 dev/prod 이미지 충돌 가능성을 줄이기 위함



## 📢 참고 및 특이사항

- 

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
