### PR TITLE
fix: Docker Compose 배포 환경별로 env 파일 참조 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=prod
     env_file:
-      - .env.prod
+      - .env.${TARGET}
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
       interval: 30s
@@ -51,7 +51,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
     env_file:
-      - .env.dev
+      - .env.${TARGET}
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
       interval: 30s


### PR DESCRIPTION
## 🧩 관련 이슈

- close #519

## 🛠️ 작업 내용

- Docker Compose 서비스 env 파일 참조를 `.env.${TARGET}`으로 변경
- develop/prod 배포 시 대상 환경 env 파일만 필요하도록 수정

## 📢 참고 및 특이사항

- `TARGET=dev`, `TARGET=prod` 기준 `docker compose config --quiet` 검증 완료

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수
- [x] 관련 이슈 연결 (`close #519`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인
