### PR TITLE
fix: deploy 시 EC2 ECR 인증 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,17 +75,21 @@ jobs:
 
       - name: EC2 배포
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           command_timeout: 25m
-          envs: TARGET
+          envs: TARGET,ECR_REGISTRY
           script: |
             set -e
             cd ~/FMI-BE
             chmod 600 ".env.$TARGET"
             docker compose --env-file ".env.$TARGET" config --quiet
+            aws ecr get-login-password --region ap-northeast-2 \
+              | docker login --username AWS --password-stdin "$ECR_REGISTRY"
             docker compose --env-file ".env.$TARGET" pull "fmi-$TARGET"
             docker compose --env-file ".env.$TARGET" up -d --no-deps "fmi-$TARGET"
             docker image prune -f


### PR DESCRIPTION
## 🧩 관련 이슈

- close #521

## 🛠️ 작업 내용

- ECR Registry 주소를 EC2 SSH 배포 step에 전달
- Docker image pull 전 EC2에서 ECR 로그인 수행
- ECR 인증 token 만료로 인한 image pull `403` 오류 방지

## 📢 참고 및 특이사항

GitHub Actions Runner의 ECR 로그인 정보는 EC2 Docker에 전달되지 않아서,  EC2에서 배포마다 아래 명령으로 ECR 인증을 갱신하도록 변경했습니다.

```bash
aws ecr get-login-password --region ap-northeast-2 \
  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
```

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수
- [x] 관련 이슈 연결 (`close #521`)
- [x] 불필요한 코드/주석 제거
- [x] YAML syntax 및 diff 검증 완료