### PR TITLE
test: 인증 핵심 회귀 테스트 추가

### DIFF
--- a/src/test/java/com/fmi/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/fmi/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,131 @@
+package com.fmi.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.domain.auth.web.dto.SignupRequest;
+import com.fmi.service.EmailService;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private NicknameValidationService nicknameValidationService;
+
+    @Mock
+    private EmailVerificationService emailVerificationService;
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private final AtomicReference<User> savedUser = new AtomicReference<>();
+
+    @BeforeEach
+    void setUp() {
+        when(userRepository.existsByEmail(anyString())).thenReturn(false);
+        when(userRepository.existsRecentlyDeletedByEmail(anyString(), any())).thenReturn(false);
+        when(emailVerificationService.isEmailVerified(anyString())).thenReturn(true);
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded-password");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            savedUser.set(user);
+            return user;
+        });
+    }
+
+    @Nested
+    @DisplayName("회원 가입")
+    class Signup {
+
+        @Nested
+        @DisplayName("이메일 인증 정보가 있으면")
+        class WithEmailVerificationFlag {
+
+            @Test
+            @DisplayName("인증 정보를 소비한 뒤 이메일 인증 사용자를 저장한다")
+            void 가입은_인증_flag를_소비한_뒤_이메일_인증_사용자를_저장한다() {
+                // given
+                SignupRequest request = signupRequest();
+
+                // when
+                User result = authService.signup(request);
+
+                // then
+                InOrder order = inOrder(emailVerificationService, userRepository);
+                order.verify(emailVerificationService).isEmailVerified(request.getEmail());
+                order.verify(emailVerificationService).consumeEmailVerification(request.getEmail());
+                order.verify(userRepository).save(any(User.class));
+                assertThat(result).isSameAs(savedUser.get());
+                assertThat(savedUser.get())
+                        .extracting(User::getEmail, User::getNickname, User::isEmail_verified)
+                        .containsExactly(request.getEmail(), request.getNickname(), true);
+                verify(emailService)
+                        .sendHtmlEmailAsync(
+                                eq(request.getEmail()), eq("회원가입을 환영합니다"), eq("welcome-email.html"), anyMap());
+            }
+        }
+
+        @Nested
+        @DisplayName("환영 메일 발송에 실패하면")
+        class WithWelcomeMailFailure {
+
+            @Test
+            @DisplayName("가입은 성공한다")
+            void 환영_메일_발송이_실패해도_가입은_성공한다() {
+                // given
+                SignupRequest request = signupRequest();
+                doThrow(new IllegalStateException("mail unavailable"))
+                        .when(emailService)
+                        .sendHtmlEmailAsync(anyString(), anyString(), anyString(), anyMap());
+
+                // when
+                User result = authService.signup(request);
+
+                // then
+                assertThat(result).isSameAs(savedUser.get());
+                verify(userRepository).save(any(User.class));
+            }
+        }
+    }
+
+    private SignupRequest signupRequest() {
+        SignupRequest request = new SignupRequest();
+        request.setEmail("member@finditem.kr");
+        request.setPassword("Password1!");
+        request.setNickname("찾아줘토끼1");
+        request.setPrivacyPolicyAgreed(true);
+        request.setTermsOfServiceAgreed(true);
+        request.setContentPolicyAgreed(false);
+        request.setMarketingConsent(false);
+        return request;
+    }
+}

--- a/src/test/java/com/fmi/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/fmi/domain/auth/service/EmailVerificationServiceTest.java
@@ -1,0 +1,121 @@
+package com.fmi.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.service.EmailBounceHandler;
+import com.fmi.service.EmailService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationServiceTest {
+
+    private static final String EMAIL = "member@finditem.kr";
+
+    @Mock
+    private StringRedisTemplate redis;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EmailBounceHandler emailBounceHandler;
+
+    @Captor
+    private ArgumentCaptor<String> redisValueCaptor;
+
+    @InjectMocks
+    private EmailVerificationService emailVerificationService;
+
+    @BeforeEach
+    void setUp() {
+        when(redis.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Nested
+    @DisplayName("인증 코드 발송")
+    class SendCode {
+
+        @Nested
+        @DisplayName("가입 가능한 이메일이면")
+        class WithAvailableEmail {
+
+            @Test
+            @DisplayName("기존 코드를 삭제한 뒤 5분 TTL로 저장하고 메일 발송을 요청한다")
+            void 이메일_인증_코드_발송은_기존_코드를_삭제한_뒤_5분_TTL로_저장하고_메일을_요청한다() {
+                // given
+                when(userRepository.existsByEmail(EMAIL)).thenReturn(false);
+                when(emailBounceHandler.hasBounced(EMAIL)).thenReturn(false);
+
+                // when
+                emailVerificationService.sendCode(EMAIL);
+
+                // then
+                verify(redis).delete("email:verify:" + EMAIL);
+                verify(valueOperations)
+                        .set(eq("email:verify:" + EMAIL), redisValueCaptor.capture(), eq(Duration.ofMinutes(5)));
+                verify(emailService).sendHtmlEmailAsync(eq(EMAIL), eq("이메일 인증 코드"), eq("verify-code.html"), anyMap());
+                String[] codeAndExpiry = redisValueCaptor.getValue().split(":");
+                assertThat(codeAndExpiry).hasSize(2);
+                assertThat(codeAndExpiry[0]).matches("\\d{6}");
+                assertThat(Long.parseLong(codeAndExpiry[1]))
+                        .isGreaterThan(Instant.now().getEpochSecond());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("인증 코드 검증")
+    class Verify {
+
+        @Nested
+        @DisplayName("유효한 인증 코드가 있으면")
+        class WithValidCode {
+
+            @Test
+            @DisplayName("기존 코드를 삭제하고 24시간 인증 정보를 저장한다")
+            void 유효한_이메일_인증_코드는_기존_코드를_삭제하고_24시간_인증_flag를_저장한다() {
+                // given
+                User user = User.builder().email(EMAIL).email_verified(false).build();
+                String verifiedKey = "email:verified:" + EMAIL;
+                when(valueOperations.get("email:verify:" + EMAIL))
+                        .thenReturn("123456:"
+                                + Instant.now().plus(Duration.ofMinutes(1)).getEpochSecond());
+                when(userRepository.findByEmail(EMAIL)).thenReturn(Optional.of(user));
+
+                // when
+                emailVerificationService.verify(EMAIL, "123456");
+
+                // then
+                verify(redis).delete("email:verify:" + EMAIL);
+                verify(valueOperations).set(verifiedKey, "true", Duration.ofHours(24));
+                assertThat(user.isEmail_verified()).isTrue();
+            }
+        }
+    }
+}

--- a/src/test/java/com/fmi/domain/auth/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/fmi/domain/auth/service/PasswordResetServiceTest.java
@@ -1,0 +1,145 @@
+package com.fmi.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.SocialAccountsRepository;
+import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.service.EmailService;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SocialAccountsRepository socialAccountsRepository;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private PasswordResetService passwordResetService;
+
+    @Nested
+    @DisplayName("임시 비밀번호 발급")
+    class IssueTemporaryPassword {
+
+        @Nested
+        @DisplayName("일반 계정이면")
+        class WithLocalAccount {
+
+            @Test
+            @DisplayName("저장한 뒤 동기 메일을 발송한다")
+            void sendsMailAfterSaving() {
+                // given
+                String email = "member@finditem.kr";
+                User user = User.builder()
+                        .email(email)
+                        .password("original-password-hash")
+                        .build();
+                when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+                when(socialAccountsRepository.findByUser(user)).thenReturn(Optional.empty());
+                when(passwordEncoder.encode(anyString()))
+                        .thenReturn("temporary-password-hash", "current-password-hash");
+
+                // when
+                passwordResetService.issueTemporaryPassword(email);
+
+                // then
+                InOrder order = inOrder(userRepository, emailService);
+                order.verify(userRepository).save(user);
+                order.verify(emailService)
+                        .sendHtmlEmail(eq(email), eq("임시 비밀번호 발급"), eq("password-reset-email.html"), anyMap());
+                assertThat(user.getOriginalPassword()).isEqualTo("original-password-hash");
+                assertThat(user.getTemporaryPassword()).isEqualTo("temporary-password-hash");
+                assertThat(user.getPassword()).isEqualTo("current-password-hash");
+                assertThat(user.getTemporaryPasswordExpiresAt())
+                        .isAfter(LocalDateTime.now().plusMinutes(59));
+                assertThat(user.getTemporaryPasswordExpiresAt())
+                        .isBefore(LocalDateTime.now().plusMinutes(61));
+            }
+        }
+
+        @Nested
+        @DisplayName("소셜 계정이면")
+        class WithSocialAccount {
+
+            @Test
+            @DisplayName("저장과 메일 발송 없이 실패한다")
+            void failsWithoutSavingOrSendingMail() {
+                // given
+                String email = "member@finditem.kr";
+                User user = User.builder().email(email).build();
+                when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+                when(socialAccountsRepository.findByUser(user)).thenReturn(Optional.of(mockSocialAccount()));
+
+                // when & then
+                assertThatThrownBy(() -> passwordResetService.issueTemporaryPassword(email))
+                        .isInstanceOf(RuntimeException.class);
+                verify(userRepository, never()).save(any(User.class));
+                verify(emailService, never()).sendHtmlEmail(anyString(), anyString(), anyString(), anyMap());
+            }
+        }
+
+        @Nested
+        @DisplayName("메일 발송에 실패하면")
+        class WithMailFailure {
+
+            @Test
+            @DisplayName("저장 이후 예외를 호출자에게 전파한다")
+            void propagatesExceptionAfterSaving() {
+                // given
+                String email = "member@finditem.kr";
+                User user = User.builder()
+                        .email(email)
+                        .password("original-password-hash")
+                        .build();
+                when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+                when(socialAccountsRepository.findByUser(user)).thenReturn(Optional.empty());
+                when(passwordEncoder.encode(anyString()))
+                        .thenReturn("temporary-password-hash", "current-password-hash");
+                doThrow(new IllegalStateException("mail unavailable"))
+                        .when(emailService)
+                        .sendHtmlEmail(anyString(), anyString(), anyString(), anyMap());
+
+                // when & then
+                assertThatThrownBy(() -> passwordResetService.issueTemporaryPassword(email))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessage("mail unavailable");
+                InOrder order = inOrder(userRepository, emailService);
+                order.verify(userRepository).save(user);
+                order.verify(emailService).sendHtmlEmail(anyString(), anyString(), anyString(), anyMap());
+            }
+        }
+    }
+
+    private com.fmi.domain.auth.data.SocialAccounts mockSocialAccount() {
+        return org.mockito.Mockito.mock(com.fmi.domain.auth.data.SocialAccounts.class);
+    }
+}

--- a/src/test/java/com/fmi/domain/auth/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/fmi/domain/auth/web/controller/AuthControllerTest.java
@@ -1,0 +1,235 @@
+package com.fmi.domain.auth.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fmi.domain.Enum.Provider;
+import com.fmi.domain.Enum.Role;
+import com.fmi.domain.auth.data.SocialAccounts;
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.SocialAccountsRepository;
+import com.fmi.domain.auth.response.LoginResponse;
+import com.fmi.domain.auth.service.AuthService;
+import com.fmi.domain.auth.web.dto.LoginRequest;
+import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.security.CookieFactory;
+import com.fmi.security.JwtTokenProvider;
+import com.fmi.security.RefreshTokenStore;
+import jakarta.servlet.http.Cookie;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenStore refreshTokenStore;
+
+    @Mock
+    private SocialAccountsRepository socialAccountsRepository;
+
+    @Mock
+    private CookieFactory cookieFactory;
+
+    @Captor
+    private ArgumentCaptor<Map<String, Object>> claimsCaptor;
+
+    @InjectMocks
+    private AuthController authController;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(authController, "accessCookieName", "access_token");
+        ReflectionTestUtils.setField(authController, "refreshCookieName", "refresh_token");
+    }
+
+    @Nested
+    @DisplayName("토큰 갱신")
+    class Refresh {
+
+        @Nested
+        @DisplayName("유효한 갱신 토큰 쿠키가 있으면")
+        class WithValidRefreshCookie {
+
+            @Test
+            @DisplayName("기존 JTI를 폐기한 뒤 제공자 클레임과 두 쿠키를 발급한다")
+            void 유효한_refresh는_기존_JTI를_폐기한_뒤_provider_claim과_두_쿠키를_발급한다() {
+                // given
+                String email = "member@finditem.kr";
+                String oldRefreshToken = "old-refresh-token";
+                String oldJti = "old-jti";
+                String newAccessToken = "new-access-token";
+                String newRefreshToken = "new-refresh-token";
+                User user = User.builder().id(1L).email(email).role(Role.USER).build();
+                SocialAccounts socialAccount =
+                        SocialAccounts.builder().provider(Provider.KAKAO).build();
+                MockHttpServletRequest request = new MockHttpServletRequest();
+                request.setCookies(new Cookie("refresh_token", oldRefreshToken));
+                Date accessExpiration = Date.from(Instant.now().plusSeconds(900));
+                Date refreshExpiration = Date.from(Instant.now().plusSeconds(1_200));
+
+                when(jwtTokenProvider.validateToken(oldRefreshToken)).thenReturn(true);
+                when(jwtTokenProvider.getSubject(oldRefreshToken)).thenReturn(email);
+                when(jwtTokenProvider.getJti(oldRefreshToken)).thenReturn(oldJti);
+                when(refreshTokenStore.validate(eq(oldJti), anyString(), eq(email)))
+                        .thenReturn(true);
+                when(authService.findActiveUserByEmail(email)).thenReturn(Optional.of(user));
+                when(socialAccountsRepository.findByUser(user)).thenReturn(Optional.of(socialAccount));
+                when(jwtTokenProvider.createAccessToken(eq(email), any())).thenReturn(newAccessToken);
+                when(jwtTokenProvider.createRefreshToken(eq(email), anyString()))
+                        .thenReturn(newRefreshToken);
+                when(jwtTokenProvider.getExpiration(newAccessToken)).thenReturn(accessExpiration);
+                when(jwtTokenProvider.getExpiration(newRefreshToken)).thenReturn(refreshExpiration);
+                when(cookieFactory.build(eq(request), eq("access_token"), eq(newAccessToken), any()))
+                        .thenReturn(ResponseCookie.from("access_token", newAccessToken)
+                                .build());
+                when(cookieFactory.build(eq(request), eq("refresh_token"), eq(newRefreshToken), any()))
+                        .thenReturn(ResponseCookie.from("refresh_token", newRefreshToken)
+                                .build());
+
+                // when
+                ResponseEntity<ApiResponse<LoginResponse>> response = authController.refresh(request);
+
+                // then
+                InOrder refreshStoreOrder = inOrder(refreshTokenStore);
+                refreshStoreOrder.verify(refreshTokenStore).validate(eq(oldJti), anyString(), eq(email));
+                refreshStoreOrder.verify(refreshTokenStore).revoke(oldJti);
+                refreshStoreOrder
+                        .verify(refreshTokenStore)
+                        .issue(anyString(), eq(email), anyString(), eq(refreshExpiration.toInstant()));
+
+                org.mockito.Mockito.verify(jwtTokenProvider).createAccessToken(eq(email), claimsCaptor.capture());
+                assertThat(response.getStatusCode().value()).isEqualTo(200);
+                assertThat(response.getHeaders().get("Set-Cookie"))
+                        .containsExactly("access_token=" + newAccessToken, "refresh_token=" + newRefreshToken);
+                assertThat(response.getBody().getResult()).isEqualTo(new LoginResponse(null, false, true));
+                assertThat(claimsCaptor.getValue())
+                        .containsEntry("userId", 1L)
+                        .containsEntry("role", "USER")
+                        .containsEntry("purpose", "access")
+                        .containsEntry("provider", "KAKAO");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃")
+    class Logout {
+
+        @Nested
+        @DisplayName("갱신 토큰 쿠키가 없으면")
+        class WithoutRefreshCookie {
+
+            @Test
+            @DisplayName("성공 응답과 두 만료 쿠키를 반환한다")
+            void refresh_쿠키가_없어도_logout은_성공하고_두_쿠키를_만료한다() {
+                // given
+                MockHttpServletRequest request = new MockHttpServletRequest();
+                when(cookieFactory.expire(request, "access_token"))
+                        .thenReturn(ResponseCookie.from("access_token", "")
+                                .maxAge(0)
+                                .build());
+                when(cookieFactory.expire(request, "refresh_token"))
+                        .thenReturn(ResponseCookie.from("refresh_token", "")
+                                .maxAge(0)
+                                .build());
+
+                // when
+                ResponseEntity<ApiResponse<String>> response = authController.logout(request);
+
+                // then
+                assertThat(response.getStatusCode().value()).isEqualTo(200);
+                assertThat(response.getHeaders().get("Set-Cookie"))
+                        .containsExactly(
+                                "access_token=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+                                "refresh_token=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT");
+                assertThat(response.getBody().getResult()).isEqualTo("OK");
+                verifyNoInteractions(jwtTokenProvider, refreshTokenStore);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인")
+    class Login {
+
+        @Nested
+        @DisplayName("임시 비밀번호 인증 결과면")
+        class WithTemporaryPassword {
+
+            @Test
+            @DisplayName("임시 클레임과 두 쿠키를 발급한다")
+            void 임시_비밀번호_로그인은_임시_claim과_두_쿠키를_발급한다() {
+                // given
+                String email = "member@finditem.kr";
+                String accessToken = "access-token";
+                String refreshToken = "refresh-token";
+                User user = User.builder().id(1L).email(email).role(Role.USER).build();
+                LoginRequest request = new LoginRequest();
+                request.setEmail(email);
+                request.setPassword("temporary-password");
+                MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+                Date accessExpiration = Date.from(Instant.now().plusSeconds(900));
+                Date refreshExpiration = Date.from(Instant.now().plusSeconds(1_200));
+
+                when(authService.authenticate(email, "temporary-password"))
+                        .thenReturn(new AuthService.AuthenticateResult(user, true));
+                when(jwtTokenProvider.createAccessToken(eq(email), any())).thenReturn(accessToken);
+                when(jwtTokenProvider.createRefreshToken(eq(email), anyString()))
+                        .thenReturn(refreshToken);
+                when(jwtTokenProvider.getExpiration(accessToken)).thenReturn(accessExpiration);
+                when(jwtTokenProvider.getExpiration(refreshToken)).thenReturn(refreshExpiration);
+                when(cookieFactory.build(eq(httpRequest), eq("access_token"), eq(accessToken), any()))
+                        .thenReturn(
+                                ResponseCookie.from("access_token", accessToken).build());
+                when(cookieFactory.build(eq(httpRequest), eq("refresh_token"), eq(refreshToken), any()))
+                        .thenReturn(ResponseCookie.from("refresh_token", refreshToken)
+                                .build());
+
+                // when
+                ResponseEntity<ApiResponse<LoginResponse>> response = authController.login(request, httpRequest);
+
+                // then
+                org.mockito.Mockito.verify(jwtTokenProvider).createAccessToken(eq(email), claimsCaptor.capture());
+                assertThat(response.getStatusCode().value()).isEqualTo(200);
+                assertThat(response.getHeaders().get("Set-Cookie"))
+                        .containsExactly("access_token=" + accessToken, "refresh_token=" + refreshToken);
+                assertThat(response.getBody().getResult()).isEqualTo(new LoginResponse(1L, true, true));
+                assertThat(claimsCaptor.getValue())
+                        .containsEntry("userId", 1L)
+                        .containsEntry("role", "USER")
+                        .containsEntry("purpose", "access")
+                        .containsEntry("isTemporaryPassword", true)
+                        .doesNotContainKey("provider");
+            }
+        }
+    }
+}

--- a/src/test/java/com/fmi/domain/auth/web/controller/KakaoAuthControllerTest.java
+++ b/src/test/java/com/fmi/domain/auth/web/controller/KakaoAuthControllerTest.java
@@ -1,0 +1,137 @@
+package com.fmi.domain.auth.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fmi.domain.Enum.Role;
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.response.LoginResponse;
+import com.fmi.domain.auth.service.KakaoOAuthService;
+import com.fmi.domain.auth.service.KakaoOAuthService.KakaoToken;
+import com.fmi.domain.auth.service.KakaoOAuthService.KakaoUser;
+import com.fmi.domain.auth.service.SocialLoginService;
+import com.fmi.domain.auth.web.dto.KakaoLoginRequest;
+import com.fmi.global.apiPayload.ApiResponse;
+import com.fmi.security.CookieFactory;
+import com.fmi.security.JwtTokenProvider;
+import com.fmi.security.RefreshTokenStore;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoAuthControllerTest {
+
+    @Mock
+    private KakaoOAuthService kakaoOAuthService;
+
+    @Mock
+    private SocialLoginService socialLoginService;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenStore refreshTokenStore;
+
+    @Mock
+    private CookieFactory cookieFactory;
+
+    @Captor
+    private ArgumentCaptor<Map<String, Object>> claimsCaptor;
+
+    @InjectMocks
+    private KakaoAuthController kakaoAuthController;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(kakaoAuthController, "accessCookieName", "access_token");
+        ReflectionTestUtils.setField(kakaoAuthController, "refreshCookieName", "refresh_token");
+    }
+
+    @Nested
+    @DisplayName("카카오 로그인")
+    class LoginWithKakao {
+
+        @Nested
+        @DisplayName("카카오 OAuth 연동이 성공하면")
+        class WithSuccessfulKakaoOAuth {
+
+            @Test
+            @DisplayName("KAKAO 제공자 클레임과 두 쿠키를 반환한다")
+            void returnsProviderClaimAndCookies() {
+                // given
+                String email = "member@finditem.kr";
+                User localUser = User.builder()
+                        .id(1L)
+                        .email(email)
+                        .role(Role.USER)
+                        .privacyPolicyAgreed(true)
+                        .termsOfServiceAgreed(true)
+                        .build();
+                KakaoLoginRequest request = new KakaoLoginRequest("authorization-code", "dev");
+                MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+                Date accessExpiration = Date.from(Instant.now().plusSeconds(900));
+                Date refreshExpiration = Date.from(Instant.now().plusSeconds(1_200));
+                KakaoToken kakaoToken = new KakaoToken("bearer", "kakao-access-token", 300, null, null, null);
+                KakaoUser kakaoUser = new KakaoUser(
+                        100L,
+                        new KakaoUser.KakaoAccount(
+                                email, new KakaoUser.KakaoAccount.Profile("카카오토끼", "https://example.com/profile.png")),
+                        null);
+
+                when(kakaoOAuthService.exchangeCodeForToken("authorization-code", "dev"))
+                        .thenReturn(kakaoToken);
+                when(kakaoOAuthService.getUserInfo("kakao-access-token")).thenReturn(kakaoUser);
+                when(socialLoginService.upsertUserFromKakao(100L, email, "카카오토끼", "https://example.com/profile.png"))
+                        .thenReturn(new SocialLoginService.KakaoLoginResult(localUser));
+                when(jwtTokenProvider.createAccessToken(eq(email), any())).thenReturn("access-token");
+                when(jwtTokenProvider.createRefreshToken(eq(email), anyString()))
+                        .thenReturn("refresh-token");
+                when(jwtTokenProvider.getExpiration("access-token")).thenReturn(accessExpiration);
+                when(jwtTokenProvider.getExpiration("refresh-token")).thenReturn(refreshExpiration);
+                when(cookieFactory.build(eq(httpRequest), eq("access_token"), eq("access-token"), any()))
+                        .thenReturn(ResponseCookie.from("access_token", "access-token")
+                                .build());
+                when(cookieFactory.build(eq(httpRequest), eq("refresh_token"), eq("refresh-token"), any()))
+                        .thenReturn(ResponseCookie.from("refresh_token", "refresh-token")
+                                .build());
+
+                // when
+                ResponseEntity<ApiResponse<LoginResponse>> response =
+                        kakaoAuthController.loginWithKakao(request, httpRequest);
+
+                // then
+                verify(jwtTokenProvider).createAccessToken(eq(email), claimsCaptor.capture());
+                verify(refreshTokenStore).issue(anyString(), eq(email), anyString(), eq(refreshExpiration.toInstant()));
+                assertThat(response.getStatusCode().value()).isEqualTo(200);
+                assertThat(response.getHeaders().get("Set-Cookie"))
+                        .containsExactly("access_token=access-token", "refresh_token=refresh-token");
+                assertThat(response.getBody().getResult()).isEqualTo(new LoginResponse(1L, false, true));
+                assertThat(claimsCaptor.getValue())
+                        .containsEntry("userId", 1L)
+                        .containsEntry("role", "USER")
+                        .containsEntry("provider", "KAKAO")
+                        .containsEntry("purpose", "access");
+            }
+        }
+    }
+}

--- a/src/test/java/com/fmi/domain/user/service/UserServiceAuthTest.java
+++ b/src/test/java/com/fmi/domain/user/service/UserServiceAuthTest.java
@@ -1,0 +1,191 @@
+package com.fmi.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fmi.domain.Enum.Provider;
+import com.fmi.domain.Enum.WithdrawalReason;
+import com.fmi.domain.auth.data.SocialAccounts;
+import com.fmi.domain.auth.data.User;
+import com.fmi.domain.auth.repository.SocialAccountsRepository;
+import com.fmi.domain.auth.repository.UserRepository;
+import com.fmi.domain.auth.service.KakaoOAuthService;
+import com.fmi.domain.post.service.PostService;
+import com.fmi.domain.user.web.dto.AccountDeleteRequest;
+import com.fmi.domain.user.web.dto.PasswordChangeRequest;
+import com.fmi.domain.user.web.dto.TermsAgreeRequest;
+import com.fmi.global.service.S3Service;
+import com.fmi.security.RefreshTokenStore;
+import com.fmi.service.EmailService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceAuthTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private RefreshTokenStore refreshTokenStore;
+
+    @Mock
+    private PostService postService;
+
+    @Mock
+    private SocialAccountsRepository socialAccountsRepository;
+
+    @Mock
+    private KakaoOAuthService kakaoOAuthService;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Nested
+    @DisplayName("비밀번호 변경")
+    class ChangePassword {
+
+        @Nested
+        @DisplayName("임시 비밀번호 상태의 사용자이면")
+        class WithTemporaryPassword {
+
+            @Test
+            @DisplayName("별도 검증 이력 없이 임시 상태를 지우고 모든 세션을 폐기한다")
+            void clearsTemporaryStateAndRevokesAllSessions() {
+                // given
+                String email = "member@finditem.kr";
+                User user = User.builder()
+                        .email(email)
+                        .password("temporary-password-hash")
+                        .originalPassword("original-password-hash")
+                        .temporaryPassword("temporary-password-hash")
+                        .temporaryPasswordExpiresAt(LocalDateTime.now().plusHours(1))
+                        .build();
+                PasswordChangeRequest request = new PasswordChangeRequest();
+                request.setNewPassword("NewPassword1!");
+                request.setNewPasswordConfirm("NewPassword1!");
+                when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+                when(passwordEncoder.encode("NewPassword1!")).thenReturn("new-password-hash");
+
+                // when
+                userService.changePassword(email, request);
+
+                // then
+                InOrder order = inOrder(userRepository, refreshTokenStore);
+                order.verify(userRepository).save(user);
+                order.verify(refreshTokenStore).revokeAllForUser(email);
+                assertThat(user.getPassword()).isEqualTo("new-password-hash");
+                assertThat(user.getOriginalPassword()).isNull();
+                assertThat(user.getTemporaryPassword()).isNull();
+                assertThat(user.getTemporaryPasswordExpiresAt()).isNull();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("약관 동의")
+    class AgreeTerms {
+
+        @Nested
+        @DisplayName("사용자가 약관 동의를 요청하면")
+        class WithTermsAgreementRequest {
+
+            @Test
+            @DisplayName("네 가지 동의 값을 사용자에게 저장한다")
+            void storesAllFourAgreementValues() {
+                // given
+                String email = "member@finditem.kr";
+                User user = User.builder().email(email).build();
+                TermsAgreeRequest request = new TermsAgreeRequest();
+                request.setPrivacyPolicyAgreed(true);
+                request.setTermsOfServiceAgreed(true);
+                request.setContentPolicyAgreed(true);
+                request.setMarketingConsent(false);
+                when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+                // when
+                userService.agreeTerms(email, request);
+
+                // then
+                verify(userRepository).save(user);
+                assertThat(user.isPrivacyPolicyAgreed()).isTrue();
+                assertThat(user.isTermsOfServiceAgreed()).isTrue();
+                assertThat(user.isContentPolicyAgreed()).isTrue();
+                assertThat(user.isMarketingConsent()).isFalse();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("계정 탈퇴")
+    class DeleteAccount {
+
+        @Nested
+        @DisplayName("카카오 연동 계정이 탈퇴하면")
+        class WithKakaoAccount {
+
+            @Test
+            @DisplayName("S3, 카카오, 저장, 세션, 게시글, 메일 순서로 처리한다")
+            void processesAccountDeletionInOrder() {
+                // given
+                String email = "member@finditem.kr";
+                String profileImage = "https://bucket.example.com/profile.png";
+                User user = User.builder()
+                        .id(1L)
+                        .email(email)
+                        .nickname("찾아줘토끼")
+                        .profile_img(profileImage)
+                        .build();
+                SocialAccounts kakaoAccount = SocialAccounts.builder()
+                        .provider(Provider.KAKAO)
+                        .providerId("kakao-user-id")
+                        .user(user)
+                        .build();
+                AccountDeleteRequest request = new AccountDeleteRequest();
+                request.setReasons(List.of(WithdrawalReason.NOT_USING));
+                when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+                when(s3Service.isValidS3Url(profileImage)).thenReturn(true);
+                when(socialAccountsRepository.findByUser(user)).thenReturn(Optional.of(kakaoAccount));
+
+                // when
+                userService.deleteAccount(email, request);
+
+                // then
+                InOrder order = inOrder(
+                        s3Service, kakaoOAuthService, userRepository, refreshTokenStore, postService, emailService);
+                order.verify(s3Service).delete(List.of(profileImage));
+                order.verify(kakaoOAuthService).unlinkUser("kakao-user-id");
+                order.verify(userRepository).save(user);
+                order.verify(refreshTokenStore).revokeAllForUser(email);
+                order.verify(postService).softDeleteAllByUser(user);
+                order.verify(emailService)
+                        .sendHtmlEmailAsync(eq(email), eq("계정이 삭제되었습니다"), eq("account-deletion-email.html"), anyMap());
+                assertThat(user.getDeletedAt()).isNotNull();
+                assertThat(user.getWithdrawalReason()).isEqualTo("NOT_USING");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🧩 관련 이슈

- #535 

## 🛠️ 작업 내용

- 인증 컨트롤러 테스트가 토큰 갱신, 로그아웃, 임시 비밀번호 로그인을 검증합니다.
- 인증 서비스 테스트가 회원가입, 이메일 인증, 임시 비밀번호 발급을 검증합니다.
- 카카오 로그인과 사용자 비밀번호 변경, 약관 동의, 계정 탈퇴 테스트를 추가합니다.
- OAuth, S3, 메일 연동은 mock으로 대체합니다.

## 📢 참고 및 특이사항

- API, JWT claim, 쿠키, 데이터베이스 스키마는 변경하지 않습니다.
- 로컬 MySQL `8.4.8`, Redis에서 테스트합니다.
- Testcontainers는 포함하지 않습니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인