### PR TITLE
refactor: 토큰 발급과 OAuth 연동 분리

### DIFF
--- a/src/main/java/com/fmi/domain/auth/service/TokenIssuer.java
+++ b/src/main/java/com/fmi/domain/auth/service/TokenIssuer.java
@@ -1,0 +1,122 @@
+package com.fmi.domain.auth.service;
+
+import com.fmi.domain.Enum.Provider;
+import com.fmi.domain.auth.repository.SocialAccountsRepository;
+import com.fmi.domain.user.data.User;
+import com.fmi.domain.user.repository.UserRepository;
+import com.fmi.security.JwtTokenProvider;
+import com.fmi.security.RefreshTokenStore;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenIssuer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenStore refreshTokenStore;
+    private final UserRepository userRepository;
+    private final SocialAccountsRepository socialAccountsRepository;
+
+    public IssuedTokens issue(User user, boolean isTemporaryPassword, Provider provider) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("userId", user.getId());
+        claims.put("role", user.getRole().name());
+        if (provider != null) {
+            claims.put("provider", provider.name());
+        }
+        claims.put("purpose", "access");
+        if (isTemporaryPassword) {
+            claims.put("isTemporaryPassword", true);
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), claims);
+        String jti = UUID.randomUUID().toString();
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail(), jti);
+        Date accessExpiration = jwtTokenProvider.getExpiration(accessToken);
+        Date refreshExpiration = jwtTokenProvider.getExpiration(refreshToken);
+        refreshTokenStore.issue(jti, user.getEmail(), sha256Hex(refreshToken), refreshExpiration.toInstant());
+
+        return new IssuedTokens(accessToken, accessExpiration, refreshToken, refreshExpiration);
+    }
+
+    public RefreshResult refresh(String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            return RefreshResult.failure(RefreshFailure.INVALID_TOKEN);
+        }
+
+        String email = jwtTokenProvider.getSubject(refreshToken);
+        String jti = jwtTokenProvider.getJti(refreshToken);
+        if (jti == null || jti.isEmpty()) {
+            return RefreshResult.failure(RefreshFailure.MISSING_JTI);
+        }
+
+        if (!refreshTokenStore.validate(jti, sha256Hex(refreshToken), email)) {
+            return RefreshResult.failure(RefreshFailure.HASH_MISMATCH);
+        }
+
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null) {
+            return RefreshResult.failure(RefreshFailure.USER_NOT_FOUND);
+        }
+
+        refreshTokenStore.revoke(jti);
+        Provider provider = socialAccountsRepository
+                .findByUser(user)
+                .map(account -> account.getProvider())
+                .orElse(null);
+        return RefreshResult.success(issue(user, false, provider));
+    }
+
+    public void revokeIfValid(String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            return;
+        }
+
+        String jti = jwtTokenProvider.getJti(refreshToken);
+        if (jti != null && !jti.isEmpty()) {
+            refreshTokenStore.revoke(jti);
+        }
+    }
+
+    private static String sha256Hex(String value) {
+        try {
+            return java.util.HexFormat.of()
+                    .formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 not available", exception);
+        }
+    }
+
+    public record IssuedTokens(
+            String accessToken, Date accessExpiration, String refreshToken, Date refreshExpiration) {}
+
+    public record RefreshResult(IssuedTokens issuedTokens, RefreshFailure failure) {
+
+        private static RefreshResult success(IssuedTokens issuedTokens) {
+            return new RefreshResult(issuedTokens, null);
+        }
+
+        private static RefreshResult failure(RefreshFailure failure) {
+            return new RefreshResult(null, failure);
+        }
+
+        public boolean isSuccess() {
+            return issuedTokens != null;
+        }
+    }
+
+    public enum RefreshFailure {
+        INVALID_TOKEN,
+        MISSING_JTI,
+        HASH_MISMATCH,
+        USER_NOT_FOUND
+    }
+}

--- a/src/main/java/com/fmi/domain/auth/web/controller/AppleAuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/AppleAuthController.java
@@ -1,23 +1,15 @@
 package com.fmi.domain.auth.web.controller;
 
+import com.fmi.domain.Enum.Provider;
 import com.fmi.domain.auth.response.LoginResponse;
-import com.fmi.domain.auth.service.AppleOAuthService;
 import com.fmi.domain.auth.service.SocialLoginService;
+import com.fmi.domain.auth.service.TokenIssuer;
 import com.fmi.domain.auth.web.dto.AppleLoginRequest;
+import com.fmi.external.oauth.apple.AppleOAuthClient;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.security.CookieFactory;
-import com.fmi.security.JwtTokenProvider;
-import com.fmi.security.RefreshTokenStore;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
@@ -32,10 +24,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AppleAuthController {
 
-    private final AppleOAuthService appleOAuthService;
+    private final AppleOAuthClient appleOAuthService;
     private final SocialLoginService socialLoginService;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenStore refreshTokenStore;
+    private final TokenIssuer tokenIssuer;
     private final CookieFactory cookieFactory;
 
     @Value("${jwt.cookie.name:refresh_token}")
@@ -51,42 +42,25 @@ public class AppleAuthController {
         var localUser = socialLoginService.upsertUserFromApple(subject).user();
         boolean termsAgreed = localUser.isPrivacyPolicyAgreed() && localUser.isTermsOfServiceAgreed();
 
-        var claims = new HashMap<String, Object>();
-        claims.put("userId", localUser.getId());
-        claims.put("role", localUser.getRole().name());
-        claims.put("provider", "APPLE");
-        claims.put("purpose", "access");
-        String accessToken = jwtTokenProvider.createAccessToken(localUser.getEmail(), claims);
+        TokenIssuer.IssuedTokens issuedTokens = tokenIssuer.issue(localUser, false, Provider.APPLE);
 
-        String jti = UUID.randomUUID().toString();
-        String refreshToken = jwtTokenProvider.createRefreshToken(localUser.getEmail(), jti);
-        Date refreshExpiration = jwtTokenProvider.getExpiration(refreshToken);
-        refreshTokenStore.issue(jti, localUser.getEmail(), sha256Hex(refreshToken), refreshExpiration.toInstant());
-
-        Date accessExpiration = jwtTokenProvider.getExpiration(accessToken);
         ResponseCookie accessCookie = cookieFactory.build(
                 httpServletRequest,
                 accessCookieName,
-                accessToken,
-                Duration.between(Instant.now(), accessExpiration.toInstant()));
+                issuedTokens.accessToken(),
+                java.time.Duration.between(
+                        java.time.Instant.now(), issuedTokens.accessExpiration().toInstant()));
         ResponseCookie refreshCookie = cookieFactory.build(
                 httpServletRequest,
                 refreshCookieName,
-                refreshToken,
-                Duration.between(Instant.now(), refreshExpiration.toInstant()));
+                issuedTokens.refreshToken(),
+                java.time.Duration.between(
+                        java.time.Instant.now(),
+                        issuedTokens.refreshExpiration().toInstant()));
 
         return ResponseEntity.ok()
                 .header("Set-Cookie", accessCookie.toString())
                 .header("Set-Cookie", refreshCookie.toString())
                 .body(ApiResponse.onSuccess(new LoginResponse(localUser.getId(), false, termsAgreed)));
-    }
-
-    private static String sha256Hex(String value) {
-        try {
-            return java.util.HexFormat.of()
-                    .formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
-        } catch (NoSuchAlgorithmException exception) {
-            throw new IllegalStateException("SHA-256 not available", exception);
-        }
     }
 }

--- a/src/main/java/com/fmi/domain/auth/web/controller/AuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/AuthController.java
@@ -1,15 +1,13 @@
 package com.fmi.domain.auth.web.controller;
 
 import com.fmi.domain.auth.converter.AuthConverter;
-import com.fmi.domain.auth.repository.SocialAccountsRepository;
 import com.fmi.domain.auth.response.LoginResponse;
 import com.fmi.domain.auth.service.AuthService;
+import com.fmi.domain.auth.service.TokenIssuer;
 import com.fmi.domain.auth.web.dto.LoginRequest;
 import com.fmi.domain.auth.web.dto.SignupRequest;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.security.CookieFactory;
-import com.fmi.security.JwtTokenProvider;
-import com.fmi.security.RefreshTokenStore;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -32,9 +30,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenStore refreshTokenStore;
-    private final SocialAccountsRepository socialAccountsRepository;
+    private final TokenIssuer tokenIssuer;
     private final CookieFactory cookieFactory;
 
     @Value("${jwt.cookie.name:refresh_token}")
@@ -180,53 +176,19 @@ public class AuthController {
                     .body(ApiResponse.onFailure("AUTH401-INVALID_REFRESH", "리프레시 토큰 없음", null));
         }
 
-        if (!jwtTokenProvider.validateToken(refreshJwt)) {
+        TokenIssuer.RefreshResult refreshResult = tokenIssuer.refresh(refreshJwt);
+        if (!refreshResult.isSuccess()) {
             return ResponseEntity.status(401)
-                    .body(ApiResponse.onFailure("AUTH401-INVALID_REFRESH", "유효하지 않은 리프레시", null));
+                    .body(ApiResponse.onFailure(
+                            "AUTH401-INVALID_REFRESH", refreshFailureMessage(refreshResult.failure()), null));
         }
 
-        String email = jwtTokenProvider.getSubject(refreshJwt);
-        String jti = jwtTokenProvider.getJti(refreshJwt);
-        if (jti == null || jti.isEmpty()) {
-            return ResponseEntity.status(401)
-                    .body(ApiResponse.onFailure("AUTH401-INVALID_REFRESH", "유효하지 않은 리프레시(jti 없음)", null));
-        }
-
-        String hash = sha256Hex(refreshJwt);
-        if (!refreshTokenStore.validate(jti, hash, email)) {
-            return ResponseEntity.status(401)
-                    .body(ApiResponse.onFailure("AUTH401-INVALID_REFRESH", "유효하지 않은 리프레시(대조 실패)", null));
-        }
-
-        var userOpt = authService.findActiveUserByEmail(email);
-        if (userOpt.isEmpty()) {
-            return ResponseEntity.status(401)
-                    .body(ApiResponse.onFailure("AUTH401-INVALID_REFRESH", "유효하지 않은 리프레시(사용자 없음)", null));
-        }
-        var user = userOpt.get();
-
-        // RTR: 기존 리프레시 폐기, 새 토큰 발급
-        refreshTokenStore.revoke(jti);
-
-        var claims = new java.util.HashMap<String, Object>();
-        claims.put("userId", user.getId());
-        claims.put("role", user.getRole().name());
-        claims.put("purpose", "access");
-        socialAccountsRepository
-                .findByUser(user)
-                .ifPresent(
-                        account -> claims.put("provider", account.getProvider().name()));
-        String accessToken = jwtTokenProvider.createAccessToken(email, claims);
-
-        String newJti = java.util.UUID.randomUUID().toString();
-        String newRefresh = jwtTokenProvider.createRefreshToken(email, newJti);
-        String newHash = sha256Hex(newRefresh);
-        java.util.Date refreshExp = jwtTokenProvider.getExpiration(newRefresh);
-        refreshTokenStore.issue(newJti, email, newHash, refreshExp.toInstant());
+        TokenIssuer.IssuedTokens issuedTokens = refreshResult.issuedTokens();
 
         ResponseCookie accessCookie =
-                buildCookie(request, accessCookieName, accessToken, jwtTokenProvider.getExpiration(accessToken));
-        ResponseCookie refreshCookie = buildCookie(request, refreshCookieName, newRefresh, refreshExp);
+                buildCookie(request, accessCookieName, issuedTokens.accessToken(), issuedTokens.accessExpiration());
+        ResponseCookie refreshCookie =
+                buildCookie(request, refreshCookieName, issuedTokens.refreshToken(), issuedTokens.refreshExpiration());
 
         return ResponseEntity.ok()
                 .header("Set-Cookie", accessCookie.toString())
@@ -236,24 +198,12 @@ public class AuthController {
 
     private ResponseEntity<ApiResponse<LoginResponse>> buildTokenResponse(
             HttpServletRequest request, com.fmi.domain.user.data.User user, boolean isTemporaryPassword) {
-        var claims = new java.util.HashMap<String, Object>();
-        claims.put("userId", user.getId());
-        claims.put("role", user.getRole().name());
-        claims.put("purpose", "access");
-        if (isTemporaryPassword) {
-            claims.put("isTemporaryPassword", true);
-        }
-        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), claims);
-        String jti = java.util.UUID.randomUUID().toString();
-        String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail(), jti);
-
-        String refreshHash = sha256Hex(refreshToken);
-        java.util.Date refreshExp = jwtTokenProvider.getExpiration(refreshToken);
-        refreshTokenStore.issue(jti, user.getEmail(), refreshHash, refreshExp.toInstant());
+        TokenIssuer.IssuedTokens issuedTokens = tokenIssuer.issue(user, isTemporaryPassword, null);
 
         ResponseCookie accessCookie =
-                buildCookie(request, accessCookieName, accessToken, jwtTokenProvider.getExpiration(accessToken));
-        ResponseCookie refreshCookie = buildCookie(request, refreshCookieName, refreshToken, refreshExp);
+                buildCookie(request, accessCookieName, issuedTokens.accessToken(), issuedTokens.accessExpiration());
+        ResponseCookie refreshCookie =
+                buildCookie(request, refreshCookieName, issuedTokens.refreshToken(), issuedTokens.refreshExpiration());
 
         return ResponseEntity.ok()
                 .header("Set-Cookie", accessCookie.toString())
@@ -267,28 +217,13 @@ public class AuthController {
                 request, name, value, java.time.Duration.between(java.time.Instant.now(), expiration.toInstant()));
     }
 
-    private static String sha256Hex(String value) {
-        try {
-            return java.util.HexFormat.of()
-                    .formatHex(java.security.MessageDigest.getInstance("SHA-256")
-                            .digest(value.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
-        } catch (java.security.NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 not available", e);
-        }
-    }
-
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "쿠키의 refresh_token(jti)을 폐기하고 쿠키를 제거합니다.")
     @ApiResponses({@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공")})
     public ResponseEntity<ApiResponse<String>> logout(HttpServletRequest request) {
         String refreshJwt = getCookieValue(request, refreshCookieName);
         if (refreshJwt != null && !refreshJwt.isEmpty()) {
-            if (jwtTokenProvider.validateToken(refreshJwt)) {
-                String jti = jwtTokenProvider.getJti(refreshJwt);
-                if (jti != null && !jti.isEmpty()) {
-                    refreshTokenStore.revoke(jti);
-                }
-            }
+            tokenIssuer.revokeIfValid(refreshJwt);
         }
 
         // accessToken 쿠키 제거
@@ -311,5 +246,14 @@ public class AuthController {
             }
         }
         return null;
+    }
+
+    private static String refreshFailureMessage(TokenIssuer.RefreshFailure failure) {
+        return switch (failure) {
+            case INVALID_TOKEN -> "유효하지 않은 리프레시";
+            case MISSING_JTI -> "유효하지 않은 리프레시(jti 없음)";
+            case HASH_MISMATCH -> "유효하지 않은 리프레시(대조 실패)";
+            case USER_NOT_FOUND -> "유효하지 않은 리프레시(사용자 없음)";
+        };
     }
 }

--- a/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
+++ b/src/main/java/com/fmi/domain/auth/web/controller/KakaoAuthController.java
@@ -1,15 +1,15 @@
 package com.fmi.domain.auth.web.controller;
 
+import com.fmi.domain.Enum.Provider;
 import com.fmi.domain.auth.response.LoginResponse;
-import com.fmi.domain.auth.service.KakaoOAuthService;
-import com.fmi.domain.auth.service.KakaoOAuthService.KakaoToken;
-import com.fmi.domain.auth.service.KakaoOAuthService.KakaoUser;
 import com.fmi.domain.auth.service.SocialLoginService;
+import com.fmi.domain.auth.service.TokenIssuer;
 import com.fmi.domain.auth.web.dto.KakaoLoginRequest;
+import com.fmi.external.oauth.kakao.KakaoOAuthClient;
+import com.fmi.external.oauth.kakao.KakaoOAuthClient.KakaoToken;
+import com.fmi.external.oauth.kakao.KakaoOAuthClient.KakaoUser;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.security.CookieFactory;
-import com.fmi.security.JwtTokenProvider;
-import com.fmi.security.RefreshTokenStore;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -17,9 +17,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
@@ -32,10 +29,9 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Auth")
 public class KakaoAuthController {
 
-    private final KakaoOAuthService kakaoOAuthService;
+    private final KakaoOAuthClient kakaoOAuthService;
     private final SocialLoginService socialLoginService;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenStore refreshTokenStore;
+    private final TokenIssuer tokenIssuer;
     private final CookieFactory cookieFactory;
 
     @Value("${jwt.cookie.name:refresh_token}")
@@ -135,27 +131,24 @@ public class KakaoAuthController {
         var localUser = result.user();
         boolean termsAgreed = localUser.isPrivacyPolicyAgreed() && localUser.isTermsOfServiceAgreed();
 
-        var claims = new java.util.HashMap<String, Object>();
-        claims.put("userId", localUser.getId());
-        claims.put("role", localUser.getRole().name());
-        claims.put("provider", "KAKAO");
-        claims.put("purpose", "access");
-        String accessToken = jwtTokenProvider.createAccessToken(localUser.getEmail(), claims);
-
-        String jti = UUID.randomUUID().toString();
-        String refreshToken = jwtTokenProvider.createRefreshToken(localUser.getEmail(), jti);
-        String refreshHash = sha256Hex(refreshToken);
-        java.util.Date refreshExp = jwtTokenProvider.getExpiration(refreshToken);
-        refreshTokenStore.issue(jti, localUser.getEmail(), refreshHash, refreshExp.toInstant());
+        TokenIssuer.IssuedTokens issuedTokens = tokenIssuer.issue(localUser, false, Provider.KAKAO);
 
         // accessToken 쿠키 설정
-        java.util.Date accessExp = jwtTokenProvider.getExpiration(accessToken);
         ResponseCookie accessCookie = cookieFactory.build(
-                request, accessCookieName, accessToken, Duration.between(Instant.now(), accessExp.toInstant()));
+                request,
+                accessCookieName,
+                issuedTokens.accessToken(),
+                java.time.Duration.between(
+                        java.time.Instant.now(), issuedTokens.accessExpiration().toInstant()));
 
         // refreshToken 쿠키 설정
         ResponseCookie refreshCookie = cookieFactory.build(
-                request, refreshCookieName, refreshToken, Duration.between(Instant.now(), refreshExp.toInstant()));
+                request,
+                refreshCookieName,
+                issuedTokens.refreshToken(),
+                java.time.Duration.between(
+                        java.time.Instant.now(),
+                        issuedTokens.refreshExpiration().toInstant()));
 
         // 응답 생성 및 반환
         // accessToken과 refreshToken은 쿠키로 전송되므로 응답 body에는 포함하지 않습니다.
@@ -164,15 +157,5 @@ public class KakaoAuthController {
                 .header("Set-Cookie", accessCookie.toString())
                 .header("Set-Cookie", refreshCookie.toString())
                 .body(ApiResponse.onSuccess(new LoginResponse(localUser.getId(), false, termsAgreed)));
-    }
-
-    private static String sha256Hex(String value) {
-        try {
-            return java.util.HexFormat.of()
-                    .formatHex(java.security.MessageDigest.getInstance("SHA-256")
-                            .digest(value.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
-        } catch (java.security.NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 not available", e);
-        }
     }
 }

--- a/src/main/java/com/fmi/domain/user/service/UserService.java
+++ b/src/main/java/com/fmi/domain/user/service/UserService.java
@@ -6,7 +6,6 @@ import com.fmi.domain.Enum.Provider;
 import com.fmi.domain.Enum.SortType;
 import com.fmi.domain.Enum.UserOtherPageType;
 import com.fmi.domain.auth.repository.SocialAccountsRepository;
-import com.fmi.domain.auth.service.KakaoOAuthService;
 import com.fmi.domain.comment.data.Comment;
 import com.fmi.domain.comment.repository.CommentRepository;
 import com.fmi.domain.comment.service.CommentImageService;
@@ -45,6 +44,7 @@ import com.fmi.domain.user.web.dto.PasswordChangeRequest;
 import com.fmi.domain.user.web.dto.PasswordVerifyRequest;
 import com.fmi.domain.user.web.dto.UserUpdateRequest;
 import com.fmi.domain.userblock.repository.BlockedUserRepository;
+import com.fmi.external.oauth.kakao.KakaoOAuthClient;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import com.fmi.global.service.S3Service;
@@ -89,7 +89,7 @@ public class UserService {
     private final PostService postService;
     private final InquiryCommentRepository inquiryCommentRepository;
     private final SocialAccountsRepository socialAccountsRepository;
-    private final KakaoOAuthService kakaoOAuthService;
+    private final KakaoOAuthClient kakaoOAuthService;
 
     /**
      * 내 정보 조회

--- a/src/main/java/com/fmi/external/oauth/apple/AppleClientSecretGenerator.java
+++ b/src/main/java/com/fmi/external/oauth/apple/AppleClientSecretGenerator.java
@@ -1,4 +1,4 @@
-package com.fmi.domain.auth.service.apple;
+package com.fmi.external.oauth.apple;
 
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;

--- a/src/main/java/com/fmi/external/oauth/apple/AppleIdTokenVerifier.java
+++ b/src/main/java/com/fmi/external/oauth/apple/AppleIdTokenVerifier.java
@@ -1,4 +1,4 @@
-package com.fmi.domain.auth.service.apple;
+package com.fmi.external.oauth.apple;
 
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;

--- a/src/main/java/com/fmi/external/oauth/apple/AppleOAuthClient.java
+++ b/src/main/java/com/fmi/external/oauth/apple/AppleOAuthClient.java
@@ -1,8 +1,6 @@
-package com.fmi.domain.auth.service;
+package com.fmi.external.oauth.apple;
 
 import com.fmi.config.AppleOAuthProperties;
-import com.fmi.domain.auth.service.apple.AppleClientSecretGenerator;
-import com.fmi.domain.auth.service.apple.AppleIdTokenVerifier;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
 import com.fmi.global.apiPayload.exception.GeneralException;
 import java.util.Map;
@@ -22,7 +20,7 @@ import org.springframework.web.client.RestClientException;
 
 @Slf4j
 @Service
-public class AppleOAuthService {
+public class AppleOAuthClient {
 
     private static final String APPLE_TOKEN_URL = "https://appleid.apple.com/auth/token";
     private static final String APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys";
@@ -31,7 +29,7 @@ public class AppleOAuthService {
 
     private final AppleOAuthProperties oauthProperties;
 
-    public AppleOAuthService(RestClient.Builder restClientBuilder, AppleOAuthProperties oauthProperties) {
+    public AppleOAuthClient(RestClient.Builder restClientBuilder, AppleOAuthProperties oauthProperties) {
         this.restClient = restClientBuilder.build();
         this.oauthProperties = oauthProperties;
     }

--- a/src/main/java/com/fmi/external/oauth/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/fmi/external/oauth/kakao/KakaoOAuthClient.java
@@ -1,4 +1,4 @@
-package com.fmi.domain.auth.service;
+package com.fmi.external.oauth.kakao;
 
 import com.fmi.config.KakaoOAuthProperties;
 import com.fmi.global.apiPayload.code.status.ErrorStatus;
@@ -23,7 +23,7 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class KakaoOAuthService {
+public class KakaoOAuthClient {
 
     private final KakaoOAuthProperties oauthProperties;
 

--- a/src/test/java/com/fmi/domain/auth/service/TokenIssuerTest.java
+++ b/src/test/java/com/fmi/domain/auth/service/TokenIssuerTest.java
@@ -1,0 +1,240 @@
+package com.fmi.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fmi.domain.Enum.Provider;
+import com.fmi.domain.Enum.Role;
+import com.fmi.domain.auth.data.SocialAccounts;
+import com.fmi.domain.auth.repository.SocialAccountsRepository;
+import com.fmi.domain.user.data.User;
+import com.fmi.domain.user.repository.UserRepository;
+import com.fmi.security.JwtTokenProvider;
+import com.fmi.security.RefreshTokenStore;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TokenIssuerTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenStore refreshTokenStore;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SocialAccountsRepository socialAccountsRepository;
+
+    @Captor
+    private ArgumentCaptor<Map<String, Object>> claimsCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> refreshHashCaptor;
+
+    @InjectMocks
+    private TokenIssuer tokenIssuer;
+
+    @Nested
+    @DisplayName("토큰 발급")
+    class Issue {
+
+        @Nested
+        @DisplayName("카카오 로그인 사용자이면")
+        class WithKakaoUser {
+
+            @Test
+            @DisplayName("제공자 claim과 refresh hash를 저장한다")
+            void issuesTokensAndStoresRefreshHash() {
+                // given
+                User user = User.builder()
+                        .id(1L)
+                        .email("member@finditem.kr")
+                        .role(Role.USER)
+                        .build();
+                Date accessExpiration = Date.from(Instant.now().plusSeconds(900));
+                Date refreshExpiration = Date.from(Instant.now().plusSeconds(1_200));
+                when(jwtTokenProvider.createAccessToken(eq(user.getEmail()), claimsCaptor.capture()))
+                        .thenReturn("access-token");
+                when(jwtTokenProvider.createRefreshToken(eq(user.getEmail()), anyString()))
+                        .thenReturn("refresh-token");
+                when(jwtTokenProvider.getExpiration("access-token")).thenReturn(accessExpiration);
+                when(jwtTokenProvider.getExpiration("refresh-token")).thenReturn(refreshExpiration);
+
+                // when
+                TokenIssuer.IssuedTokens issuedTokens = tokenIssuer.issue(user, false, Provider.KAKAO);
+
+                // then
+                verify(refreshTokenStore)
+                        .issue(
+                                anyString(),
+                                eq(user.getEmail()),
+                                refreshHashCaptor.capture(),
+                                eq(refreshExpiration.toInstant()));
+                assertThat(issuedTokens.accessToken()).isEqualTo("access-token");
+                assertThat(issuedTokens.accessExpiration()).isEqualTo(accessExpiration);
+                assertThat(issuedTokens.refreshToken()).isEqualTo("refresh-token");
+                assertThat(issuedTokens.refreshExpiration()).isEqualTo(refreshExpiration);
+                assertThat(claimsCaptor.getValue())
+                        .containsEntry("userId", 1L)
+                        .containsEntry("role", "USER")
+                        .containsEntry("provider", "KAKAO")
+                        .containsEntry("purpose", "access");
+                assertThat(refreshHashCaptor.getValue()).isEqualTo(sha256Hex("refresh-token"));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 갱신")
+    class Refresh {
+
+        @Nested
+        @DisplayName("refresh token 검증에 실패하면")
+        class WithInvalidRefreshToken {
+
+            @ParameterizedTest
+            @EnumSource(TokenIssuer.RefreshFailure.class)
+            @DisplayName("Redis 상태를 변경하지 않고 실패 원인을 반환한다")
+            void returnsFailureWithoutChangingRedis(TokenIssuer.RefreshFailure expectedFailure) {
+                // given
+                String refreshToken = "refresh-token";
+                String email = "member@finditem.kr";
+                when(jwtTokenProvider.validateToken(refreshToken))
+                        .thenReturn(expectedFailure != TokenIssuer.RefreshFailure.INVALID_TOKEN);
+                if (expectedFailure != TokenIssuer.RefreshFailure.INVALID_TOKEN) {
+                    when(jwtTokenProvider.getSubject(refreshToken)).thenReturn(email);
+                }
+                if (expectedFailure == TokenIssuer.RefreshFailure.HASH_MISMATCH
+                        || expectedFailure == TokenIssuer.RefreshFailure.USER_NOT_FOUND) {
+                    when(jwtTokenProvider.getJti(refreshToken)).thenReturn("refresh-jti");
+                }
+                if (expectedFailure == TokenIssuer.RefreshFailure.HASH_MISMATCH) {
+                    when(refreshTokenStore.validate(eq("refresh-jti"), anyString(), eq(email)))
+                            .thenReturn(false);
+                }
+                if (expectedFailure == TokenIssuer.RefreshFailure.USER_NOT_FOUND) {
+                    when(refreshTokenStore.validate(eq("refresh-jti"), anyString(), eq(email)))
+                            .thenReturn(true);
+                    when(userRepository.findByEmail(email)).thenReturn(java.util.Optional.empty());
+                }
+
+                // when
+                TokenIssuer.RefreshResult refreshResult = tokenIssuer.refresh(refreshToken);
+
+                // then
+                assertThat(refreshResult.issuedTokens()).isNull();
+                assertThat(refreshResult.failure()).isEqualTo(expectedFailure);
+                verify(refreshTokenStore, never()).revoke(anyString());
+                verify(refreshTokenStore, never()).issue(anyString(), anyString(), anyString(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("유효한 refresh token과 활성 사용자가 있으면")
+        class WithValidRefreshToken {
+
+            @Test
+            @DisplayName("기존 JTI를 폐기한 뒤 제공자 claim을 포함한 새 토큰을 발급한다")
+            void rotatesTokensAfterRevokingOldJti() {
+                // given
+                String oldRefreshToken = "old-refresh-token";
+                String oldJti = "old-jti";
+                User user = User.builder()
+                        .id(1L)
+                        .email("member@finditem.kr")
+                        .role(Role.USER)
+                        .build();
+                SocialAccounts socialAccount = SocialAccounts.builder()
+                        .user(user)
+                        .provider(Provider.KAKAO)
+                        .build();
+                Date accessExpiration = Date.from(Instant.now().plusSeconds(900));
+                Date refreshExpiration = Date.from(Instant.now().plusSeconds(1_200));
+                when(jwtTokenProvider.validateToken(oldRefreshToken)).thenReturn(true);
+                when(jwtTokenProvider.getSubject(oldRefreshToken)).thenReturn(user.getEmail());
+                when(jwtTokenProvider.getJti(oldRefreshToken)).thenReturn(oldJti);
+                when(refreshTokenStore.validate(eq(oldJti), anyString(), eq(user.getEmail())))
+                        .thenReturn(true);
+                when(userRepository.findByEmail(user.getEmail())).thenReturn(java.util.Optional.of(user));
+                when(socialAccountsRepository.findByUser(user)).thenReturn(java.util.Optional.of(socialAccount));
+                when(jwtTokenProvider.createAccessToken(eq(user.getEmail()), claimsCaptor.capture()))
+                        .thenReturn("access-token");
+                when(jwtTokenProvider.createRefreshToken(eq(user.getEmail()), anyString()))
+                        .thenReturn("refresh-token");
+                when(jwtTokenProvider.getExpiration("access-token")).thenReturn(accessExpiration);
+                when(jwtTokenProvider.getExpiration("refresh-token")).thenReturn(refreshExpiration);
+
+                // when
+                TokenIssuer.RefreshResult refreshResult = tokenIssuer.refresh(oldRefreshToken);
+
+                // then
+                InOrder refreshStoreOrder = org.mockito.Mockito.inOrder(refreshTokenStore);
+                refreshStoreOrder.verify(refreshTokenStore).validate(eq(oldJti), anyString(), eq(user.getEmail()));
+                refreshStoreOrder.verify(refreshTokenStore).revoke(oldJti);
+                refreshStoreOrder
+                        .verify(refreshTokenStore)
+                        .issue(anyString(), eq(user.getEmail()), anyString(), eq(refreshExpiration.toInstant()));
+                assertThat(refreshResult.issuedTokens()).isNotNull();
+                assertThat(refreshResult.failure()).isNull();
+                assertThat(claimsCaptor.getValue()).containsEntry("provider", "KAKAO");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 폐기")
+    class Revoke {
+
+        @Nested
+        @DisplayName("유효한 refresh token에 JTI가 있으면")
+        class WithValidRefreshToken {
+
+            @Test
+            @DisplayName("해당 JTI를 폐기한다")
+            void revokesJti() {
+                // given
+                String refreshToken = "refresh-token";
+                when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+                when(jwtTokenProvider.getJti(refreshToken)).thenReturn("refresh-jti");
+
+                // when
+                tokenIssuer.revokeIfValid(refreshToken);
+
+                // then
+                verify(refreshTokenStore).revoke("refresh-jti");
+            }
+        }
+    }
+
+    private static String sha256Hex(String value) {
+        try {
+            return java.util.HexFormat.of()
+                    .formatHex(java.security.MessageDigest.getInstance("SHA-256")
+                            .digest(value.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        } catch (java.security.NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+}

--- a/src/test/java/com/fmi/domain/auth/web/controller/AppleAuthControllerTest.java
+++ b/src/test/java/com/fmi/domain/auth/web/controller/AppleAuthControllerTest.java
@@ -1,27 +1,25 @@
 package com.fmi.domain.auth.web.controller;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fmi.domain.Enum.Provider;
 import com.fmi.domain.Enum.Role;
 import com.fmi.domain.auth.response.LoginResponse;
-import com.fmi.domain.auth.service.AppleOAuthService;
 import com.fmi.domain.auth.service.SocialLoginService;
+import com.fmi.domain.auth.service.TokenIssuer;
 import com.fmi.domain.auth.web.dto.AppleLoginRequest;
 import com.fmi.domain.user.data.User;
+import com.fmi.external.oauth.apple.AppleOAuthClient;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.security.CookieFactory;
-import com.fmi.security.JwtTokenProvider;
-import com.fmi.security.RefreshTokenStore;
 import java.time.Instant;
 import java.util.Date;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,16 +32,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 class AppleAuthControllerTest {
 
     @Mock
-    private AppleOAuthService appleOAuthService;
+    private AppleOAuthClient appleOAuthService;
 
     @Mock
     private SocialLoginService socialLoginService;
 
     @Mock
-    private JwtTokenProvider jwtTokenProvider;
-
-    @Mock
-    private RefreshTokenStore refreshTokenStore;
+    private TokenIssuer tokenIssuer;
 
     @Mock
     private CookieFactory cookieFactory;
@@ -66,13 +61,12 @@ class AppleAuthControllerTest {
         when(appleOAuthService.exchangeCodeForSubject("apple-code", "dev")).thenReturn("apple-subject");
         when(socialLoginService.upsertUserFromApple("apple-subject"))
                 .thenReturn(new SocialLoginService.AppleLoginResult(user));
-        when(jwtTokenProvider.createAccessToken(eq(user.getEmail()), any())).thenReturn("access-token");
-        when(jwtTokenProvider.createRefreshToken(eq(user.getEmail()), anyString()))
-                .thenReturn("refresh-token");
-        when(jwtTokenProvider.getExpiration("access-token"))
-                .thenReturn(Date.from(Instant.now().plusSeconds(900)));
-        when(jwtTokenProvider.getExpiration("refresh-token"))
-                .thenReturn(Date.from(Instant.now().plusSeconds(1_200)));
+        when(tokenIssuer.issue(user, false, Provider.APPLE))
+                .thenReturn(new TokenIssuer.IssuedTokens(
+                        "access-token",
+                        Date.from(Instant.now().plusSeconds(900)),
+                        "refresh-token",
+                        Date.from(Instant.now().plusSeconds(1_200))));
         when(cookieFactory.build(eq(httpRequest), eq("access_token"), eq("access-token"), any()))
                 .thenReturn(ResponseCookie.from("access_token", "access-token").build());
         when(cookieFactory.build(eq(httpRequest), eq("refresh_token"), eq("refresh-token"), any()))
@@ -83,8 +77,7 @@ class AppleAuthControllerTest {
         ResponseEntity<ApiResponse<LoginResponse>> response = appleAuthController.loginWithApple(request, httpRequest);
 
         // then
-        ArgumentCaptor<String> refreshJtiCaptor = ArgumentCaptor.forClass(String.class);
-        verify(refreshTokenStore).issue(refreshJtiCaptor.capture(), eq(user.getEmail()), anyString(), any());
+        verify(tokenIssuer).issue(user, false, Provider.APPLE);
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(response.getStatusCode().value()).isEqualTo(200);
             softly.assertThat(response.getHeaders().get("Set-Cookie"))
@@ -93,7 +86,6 @@ class AppleAuthControllerTest {
             softly.assertThat(response.getBody().getResult().isTemporaryPassword())
                     .isFalse();
             softly.assertThat(response.getBody().getResult().isTermsAgreed()).isFalse();
-            softly.assertThat(refreshJtiCaptor.getValue()).isNotBlank();
         });
     }
 }

--- a/src/test/java/com/fmi/domain/auth/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/fmi/domain/auth/web/controller/AuthControllerTest.java
@@ -2,37 +2,29 @@ package com.fmi.domain.auth.web.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.fmi.domain.Enum.Provider;
 import com.fmi.domain.Enum.Role;
-import com.fmi.domain.auth.data.SocialAccounts;
-import com.fmi.domain.auth.repository.SocialAccountsRepository;
 import com.fmi.domain.auth.response.LoginResponse;
 import com.fmi.domain.auth.service.AuthService;
+import com.fmi.domain.auth.service.TokenIssuer;
 import com.fmi.domain.auth.web.dto.LoginRequest;
 import com.fmi.domain.user.data.User;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.security.CookieFactory;
-import com.fmi.security.JwtTokenProvider;
-import com.fmi.security.RefreshTokenStore;
 import jakarta.servlet.http.Cookie;
 import java.time.Instant;
 import java.util.Date;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,19 +40,10 @@ class AuthControllerTest {
     private AuthService authService;
 
     @Mock
-    private JwtTokenProvider jwtTokenProvider;
-
-    @Mock
-    private RefreshTokenStore refreshTokenStore;
-
-    @Mock
-    private SocialAccountsRepository socialAccountsRepository;
+    private TokenIssuer tokenIssuer;
 
     @Mock
     private CookieFactory cookieFactory;
-
-    @Captor
-    private ArgumentCaptor<Map<String, Object>> claimsCaptor;
 
     @InjectMocks
     private AuthController authController;
@@ -76,6 +59,29 @@ class AuthControllerTest {
     class Refresh {
 
         @Nested
+        @DisplayName("TokenIssuer가 갱신에 실패하면")
+        class WithRefreshFailure {
+
+            @ParameterizedTest
+            @EnumSource(TokenIssuer.RefreshFailure.class)
+            @DisplayName("기존 오류 메시지로 401 응답을 반환한다")
+            void returnsExistingFailureMessage(TokenIssuer.RefreshFailure failure) {
+                // given
+                String refreshToken = "refresh-token";
+                MockHttpServletRequest request = new MockHttpServletRequest();
+                request.setCookies(new Cookie("refresh_token", refreshToken));
+                when(tokenIssuer.refresh(refreshToken)).thenReturn(new TokenIssuer.RefreshResult(null, failure));
+
+                // when
+                ResponseEntity<ApiResponse<LoginResponse>> response = authController.refresh(request);
+
+                // then
+                assertThat(response.getStatusCode().value()).isEqualTo(401);
+                assertThat(response.getBody().getMessage()).isEqualTo(refreshFailureMessage(failure));
+            }
+        }
+
+        @Nested
         @DisplayName("유효한 갱신 토큰 쿠키가 있으면")
         class WithValidRefreshCookie {
 
@@ -83,31 +89,19 @@ class AuthControllerTest {
             @DisplayName("기존 JTI를 폐기한 뒤 제공자 클레임과 두 쿠키를 발급한다")
             void 유효한_refresh는_기존_JTI를_폐기한_뒤_provider_claim과_두_쿠키를_발급한다() {
                 // given
-                String email = "member@finditem.kr";
                 String oldRefreshToken = "old-refresh-token";
-                String oldJti = "old-jti";
                 String newAccessToken = "new-access-token";
                 String newRefreshToken = "new-refresh-token";
-                User user = User.builder().id(1L).email(email).role(Role.USER).build();
-                SocialAccounts socialAccount =
-                        SocialAccounts.builder().provider(Provider.KAKAO).build();
                 MockHttpServletRequest request = new MockHttpServletRequest();
                 request.setCookies(new Cookie("refresh_token", oldRefreshToken));
                 Date accessExpiration = Date.from(Instant.now().plusSeconds(900));
                 Date refreshExpiration = Date.from(Instant.now().plusSeconds(1_200));
 
-                when(jwtTokenProvider.validateToken(oldRefreshToken)).thenReturn(true);
-                when(jwtTokenProvider.getSubject(oldRefreshToken)).thenReturn(email);
-                when(jwtTokenProvider.getJti(oldRefreshToken)).thenReturn(oldJti);
-                when(refreshTokenStore.validate(eq(oldJti), anyString(), eq(email)))
-                        .thenReturn(true);
-                when(authService.findActiveUserByEmail(email)).thenReturn(Optional.of(user));
-                when(socialAccountsRepository.findByUser(user)).thenReturn(Optional.of(socialAccount));
-                when(jwtTokenProvider.createAccessToken(eq(email), any())).thenReturn(newAccessToken);
-                when(jwtTokenProvider.createRefreshToken(eq(email), anyString()))
-                        .thenReturn(newRefreshToken);
-                when(jwtTokenProvider.getExpiration(newAccessToken)).thenReturn(accessExpiration);
-                when(jwtTokenProvider.getExpiration(newRefreshToken)).thenReturn(refreshExpiration);
+                when(tokenIssuer.refresh(oldRefreshToken))
+                        .thenReturn(new TokenIssuer.RefreshResult(
+                                new TokenIssuer.IssuedTokens(
+                                        newAccessToken, accessExpiration, newRefreshToken, refreshExpiration),
+                                null));
                 when(cookieFactory.build(eq(request), eq("access_token"), eq(newAccessToken), any()))
                         .thenReturn(ResponseCookie.from("access_token", newAccessToken)
                                 .build());
@@ -119,23 +113,11 @@ class AuthControllerTest {
                 ResponseEntity<ApiResponse<LoginResponse>> response = authController.refresh(request);
 
                 // then
-                InOrder refreshStoreOrder = inOrder(refreshTokenStore);
-                refreshStoreOrder.verify(refreshTokenStore).validate(eq(oldJti), anyString(), eq(email));
-                refreshStoreOrder.verify(refreshTokenStore).revoke(oldJti);
-                refreshStoreOrder
-                        .verify(refreshTokenStore)
-                        .issue(anyString(), eq(email), anyString(), eq(refreshExpiration.toInstant()));
-
-                org.mockito.Mockito.verify(jwtTokenProvider).createAccessToken(eq(email), claimsCaptor.capture());
+                verify(tokenIssuer).refresh(oldRefreshToken);
                 assertThat(response.getStatusCode().value()).isEqualTo(200);
                 assertThat(response.getHeaders().get("Set-Cookie"))
                         .containsExactly("access_token=" + newAccessToken, "refresh_token=" + newRefreshToken);
                 assertThat(response.getBody().getResult()).isEqualTo(new LoginResponse(null, false, true));
-                assertThat(claimsCaptor.getValue())
-                        .containsEntry("userId", 1L)
-                        .containsEntry("role", "USER")
-                        .containsEntry("purpose", "access")
-                        .containsEntry("provider", "KAKAO");
             }
         }
     }
@@ -172,7 +154,7 @@ class AuthControllerTest {
                                 "access_token=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
                                 "refresh_token=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT");
                 assertThat(response.getBody().getResult()).isEqualTo("OK");
-                verifyNoInteractions(jwtTokenProvider, refreshTokenStore);
+                verifyNoInteractions(tokenIssuer);
             }
         }
     }
@@ -202,11 +184,9 @@ class AuthControllerTest {
 
                 when(authService.authenticate(email, "temporary-password"))
                         .thenReturn(new AuthService.AuthenticateResult(user, true));
-                when(jwtTokenProvider.createAccessToken(eq(email), any())).thenReturn(accessToken);
-                when(jwtTokenProvider.createRefreshToken(eq(email), anyString()))
-                        .thenReturn(refreshToken);
-                when(jwtTokenProvider.getExpiration(accessToken)).thenReturn(accessExpiration);
-                when(jwtTokenProvider.getExpiration(refreshToken)).thenReturn(refreshExpiration);
+                when(tokenIssuer.issue(user, true, null))
+                        .thenReturn(new TokenIssuer.IssuedTokens(
+                                accessToken, accessExpiration, refreshToken, refreshExpiration));
                 when(cookieFactory.build(eq(httpRequest), eq("access_token"), eq(accessToken), any()))
                         .thenReturn(
                                 ResponseCookie.from("access_token", accessToken).build());
@@ -218,18 +198,21 @@ class AuthControllerTest {
                 ResponseEntity<ApiResponse<LoginResponse>> response = authController.login(request, httpRequest);
 
                 // then
-                org.mockito.Mockito.verify(jwtTokenProvider).createAccessToken(eq(email), claimsCaptor.capture());
+                verify(tokenIssuer).issue(user, true, null);
                 assertThat(response.getStatusCode().value()).isEqualTo(200);
                 assertThat(response.getHeaders().get("Set-Cookie"))
                         .containsExactly("access_token=" + accessToken, "refresh_token=" + refreshToken);
                 assertThat(response.getBody().getResult()).isEqualTo(new LoginResponse(1L, true, true));
-                assertThat(claimsCaptor.getValue())
-                        .containsEntry("userId", 1L)
-                        .containsEntry("role", "USER")
-                        .containsEntry("purpose", "access")
-                        .containsEntry("isTemporaryPassword", true)
-                        .doesNotContainKey("provider");
             }
         }
+    }
+
+    private static String refreshFailureMessage(TokenIssuer.RefreshFailure failure) {
+        return switch (failure) {
+            case INVALID_TOKEN -> "유효하지 않은 리프레시";
+            case MISSING_JTI -> "유효하지 않은 리프레시(jti 없음)";
+            case HASH_MISMATCH -> "유효하지 않은 리프레시(대조 실패)";
+            case USER_NOT_FOUND -> "유효하지 않은 리프레시(사용자 없음)";
+        };
     }
 }

--- a/src/test/java/com/fmi/domain/auth/web/controller/KakaoAuthControllerTest.java
+++ b/src/test/java/com/fmi/domain/auth/web/controller/KakaoAuthControllerTest.java
@@ -2,33 +2,29 @@ package com.fmi.domain.auth.web.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fmi.domain.Enum.Provider;
 import com.fmi.domain.Enum.Role;
 import com.fmi.domain.auth.response.LoginResponse;
-import com.fmi.domain.auth.service.KakaoOAuthService;
-import com.fmi.domain.auth.service.KakaoOAuthService.KakaoToken;
-import com.fmi.domain.auth.service.KakaoOAuthService.KakaoUser;
 import com.fmi.domain.auth.service.SocialLoginService;
+import com.fmi.domain.auth.service.TokenIssuer;
 import com.fmi.domain.auth.web.dto.KakaoLoginRequest;
 import com.fmi.domain.user.data.User;
+import com.fmi.external.oauth.kakao.KakaoOAuthClient;
+import com.fmi.external.oauth.kakao.KakaoOAuthClient.KakaoToken;
+import com.fmi.external.oauth.kakao.KakaoOAuthClient.KakaoUser;
 import com.fmi.global.apiPayload.ApiResponse;
 import com.fmi.security.CookieFactory;
-import com.fmi.security.JwtTokenProvider;
-import com.fmi.security.RefreshTokenStore;
 import java.time.Instant;
 import java.util.Date;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -41,22 +37,16 @@ import org.springframework.test.util.ReflectionTestUtils;
 class KakaoAuthControllerTest {
 
     @Mock
-    private KakaoOAuthService kakaoOAuthService;
+    private KakaoOAuthClient kakaoOAuthService;
 
     @Mock
     private SocialLoginService socialLoginService;
 
     @Mock
-    private JwtTokenProvider jwtTokenProvider;
-
-    @Mock
-    private RefreshTokenStore refreshTokenStore;
+    private TokenIssuer tokenIssuer;
 
     @Mock
     private CookieFactory cookieFactory;
-
-    @Captor
-    private ArgumentCaptor<Map<String, Object>> claimsCaptor;
 
     @InjectMocks
     private KakaoAuthController kakaoAuthController;
@@ -103,11 +93,9 @@ class KakaoAuthControllerTest {
                 when(kakaoOAuthService.getUserInfo("kakao-access-token")).thenReturn(kakaoUser);
                 when(socialLoginService.upsertUserFromKakao(100L, email, "카카오토끼", "https://example.com/profile.png"))
                         .thenReturn(new SocialLoginService.KakaoLoginResult(localUser));
-                when(jwtTokenProvider.createAccessToken(eq(email), any())).thenReturn("access-token");
-                when(jwtTokenProvider.createRefreshToken(eq(email), anyString()))
-                        .thenReturn("refresh-token");
-                when(jwtTokenProvider.getExpiration("access-token")).thenReturn(accessExpiration);
-                when(jwtTokenProvider.getExpiration("refresh-token")).thenReturn(refreshExpiration);
+                when(tokenIssuer.issue(localUser, false, Provider.KAKAO))
+                        .thenReturn(new TokenIssuer.IssuedTokens(
+                                "access-token", accessExpiration, "refresh-token", refreshExpiration));
                 when(cookieFactory.build(eq(httpRequest), eq("access_token"), eq("access-token"), any()))
                         .thenReturn(ResponseCookie.from("access_token", "access-token")
                                 .build());
@@ -120,17 +108,11 @@ class KakaoAuthControllerTest {
                         kakaoAuthController.loginWithKakao(request, httpRequest);
 
                 // then
-                verify(jwtTokenProvider).createAccessToken(eq(email), claimsCaptor.capture());
-                verify(refreshTokenStore).issue(anyString(), eq(email), anyString(), eq(refreshExpiration.toInstant()));
+                verify(tokenIssuer).issue(localUser, false, Provider.KAKAO);
                 assertThat(response.getStatusCode().value()).isEqualTo(200);
                 assertThat(response.getHeaders().get("Set-Cookie"))
                         .containsExactly("access_token=access-token", "refresh_token=refresh-token");
                 assertThat(response.getBody().getResult()).isEqualTo(new LoginResponse(1L, false, true));
-                assertThat(claimsCaptor.getValue())
-                        .containsEntry("userId", 1L)
-                        .containsEntry("role", "USER")
-                        .containsEntry("provider", "KAKAO")
-                        .containsEntry("purpose", "access");
             }
         }
     }

--- a/src/test/java/com/fmi/domain/user/service/UserServiceAuthTest.java
+++ b/src/test/java/com/fmi/domain/user/service/UserServiceAuthTest.java
@@ -11,13 +11,13 @@ import com.fmi.domain.Enum.Provider;
 import com.fmi.domain.Enum.WithdrawalReason;
 import com.fmi.domain.auth.data.SocialAccounts;
 import com.fmi.domain.auth.repository.SocialAccountsRepository;
-import com.fmi.domain.auth.service.KakaoOAuthService;
 import com.fmi.domain.post.service.PostService;
 import com.fmi.domain.user.data.User;
 import com.fmi.domain.user.repository.UserRepository;
 import com.fmi.domain.user.web.dto.AccountDeleteRequest;
 import com.fmi.domain.user.web.dto.PasswordChangeRequest;
 import com.fmi.domain.user.web.dto.TermsAgreeRequest;
+import com.fmi.external.oauth.kakao.KakaoOAuthClient;
 import com.fmi.global.service.S3Service;
 import com.fmi.security.RefreshTokenStore;
 import com.fmi.service.EmailService;
@@ -59,7 +59,7 @@ class UserServiceAuthTest {
     private SocialAccountsRepository socialAccountsRepository;
 
     @Mock
-    private KakaoOAuthService kakaoOAuthService;
+    private KakaoOAuthClient kakaoOAuthService;
 
     @InjectMocks
     private UserService userService;

--- a/src/test/java/com/fmi/external/oauth/apple/AppleClientSecretGeneratorTest.java
+++ b/src/test/java/com/fmi/external/oauth/apple/AppleClientSecretGeneratorTest.java
@@ -1,4 +1,4 @@
-package com.fmi.domain.auth.service.apple;
+package com.fmi.external.oauth.apple;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/com/fmi/external/oauth/apple/AppleIdTokenVerifierTest.java
+++ b/src/test/java/com/fmi/external/oauth/apple/AppleIdTokenVerifierTest.java
@@ -1,4 +1,4 @@
-package com.fmi.domain.auth.service.apple;
+package com.fmi.external.oauth.apple;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;

--- a/src/test/java/com/fmi/external/oauth/apple/AppleOAuthClientTest.java
+++ b/src/test/java/com/fmi/external/oauth/apple/AppleOAuthClientTest.java
@@ -1,4 +1,4 @@
-package com.fmi.domain.auth.service;
+package com.fmi.external.oauth.apple;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -26,7 +26,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
 @ExtendWith(MockitoExtension.class)
-class AppleOAuthServiceTest {
+class AppleOAuthClientTest {
 
     @Mock
     private RestClient.Builder restClientBuilder;
@@ -43,7 +43,7 @@ class AppleOAuthServiceTest {
     @Mock
     private RestClient.ResponseSpec responseSpec;
 
-    private AppleOAuthService appleOAuthService;
+    private AppleOAuthClient appleOAuthService;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -60,7 +60,7 @@ class AppleOAuthServiceTest {
                 Map.of(
                         "dev", "https://dev.finditem.kr/auth/apple/callback",
                         "release", "https://release.finditem.kr/auth/apple/callback"));
-        appleOAuthService = new AppleOAuthService(restClientBuilder, properties);
+        appleOAuthService = new AppleOAuthClient(restClientBuilder, properties);
     }
 
     @Test
@@ -112,7 +112,7 @@ class AppleOAuthServiceTest {
                 .thenReturn(requestBodyUriSpec);
         when(requestBodyUriSpec.body(any(MultiValueMap.class))).thenReturn(requestBodySpec);
         when(requestBodySpec.retrieve()).thenReturn(responseSpec);
-        when(responseSpec.body(AppleOAuthService.AppleToken.class))
+        when(responseSpec.body(AppleOAuthClient.AppleToken.class))
                 .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
     }
 }


### PR DESCRIPTION
## 🧩 관련 이슈

- #535 

## 🛠️ 작업 내용

- `TokenIssuer`가 JWT 발급, refresh token 검증·회전·폐기를 맡습니다.
- 인증 Controller는 `TokenIssuer` 결과로 쿠키만 만듭니다.
- Kakao·Apple OAuth client를 `external/oauth`로 옮깁니다.
- 세션과 Controller 회귀 테스트를 추가·갱신합니다.

## 📢 참고 및 특이사항

- 이 PR은 인증 리팩터링 stack의 세 번째 PR입니다.
- #530 → #531 → 이 PR 순서로 병합합니다.
- API, JWT claim, Redis 명령 순서, 쿠키 동작은 변경하지 않습니다.
- OAuth client는 구현체를 직접 주입합니다.

## ✅ 체크리스트

- [x] Merge 대상 브랜치가 **develop** 인지 확인
- [x] PR 제목 형식 준수 (예: `feat: 로그인 기능 구현`)
- [x] 관련 이슈 연결 (`close #이슈번호`)
- [x] 불필요한 코드/주석 제거
- [x] 기능 정상 작동 확인